### PR TITLE
feat: agent battle, autonomous loop, live AI chat — the crazy features

### DIFF
--- a/app/app/api/arena/run/route.ts
+++ b/app/app/api/arena/run/route.ts
@@ -166,10 +166,22 @@ export async function POST(request: NextRequest) {
           description: jobSpec.description,
         });
 
-        // Agent Chat: Alpha announces job
-        send("agent_chat", `Alpha: I need someone to ${jobSpec.title.toLowerCase()}. Paying ${jobSpec.amount} USDC for at least ${jobSpec.minWords} words.`, {
+        // Agent Chat: Alpha announces job (REAL Haiku)
+        let alphaChatAnnounce = `I need someone to ${jobSpec.title.toLowerCase()}. Paying ${jobSpec.amount} USDC for at least ${jobSpec.minWords} words.`;
+        try {
+          const alphaChatResp = await client.messages.create({
+            model: HAIKU_MODEL,
+            max_tokens: 256,
+            messages: [{ role: "user", content: `You are Agent Alpha, a job poster on COVENANT. You just posted: "${jobSpec.title}". Write a 1-sentence announcement to attract workers. Be professional but enthusiastic.` }],
+          });
+          const chatText = alphaChatResp.content[0].type === "text" ? alphaChatResp.content[0].text : "";
+          if (chatText) alphaChatAnnounce = chatText;
+        } catch (err) {
+          console.error("[arena] Alpha chat Haiku failed:", err);
+        }
+        send("agent_chat", `Alpha: ${alphaChatAnnounce}`, {
           agent: "alpha",
-          message: `I need someone to ${jobSpec.title.toLowerCase()}. Paying ${jobSpec.amount} USDC for at least ${jobSpec.minWords} words.`,
+          message: alphaChatAnnounce,
         });
 
         // ===== x402 PAYMENT: Omega pays Alpha for API access =====
@@ -408,10 +420,22 @@ export async function POST(request: NextRequest) {
           did: generateDID(AGENT_OMEGA.wallet),
         });
 
-        // Agent Chat: Omega accepts
-        send("agent_chat", `Omega: I'll take this job. ${evalResult.reason} Starting work now.`, {
+        // Agent Chat: Omega accepts (REAL Haiku)
+        let omegaChatAccept = `I'll take this job. ${evalResult.reason} Starting work now.`;
+        try {
+          const omegaChatResp = await client.messages.create({
+            model: HAIKU_MODEL,
+            max_tokens: 256,
+            messages: [{ role: "user", content: `You are Agent Omega, a freelance worker. You see this job: "${jobSpec.title}" for ${jobSpec.amount} USDC. Write a 1-sentence response saying you'll take it. Be confident.` }],
+          });
+          const chatText = omegaChatResp.content[0].type === "text" ? omegaChatResp.content[0].text : "";
+          if (chatText) omegaChatAccept = chatText;
+        } catch (err) {
+          console.error("[arena] Omega accept chat Haiku failed:", err);
+        }
+        send("agent_chat", `Omega: ${omegaChatAccept}`, {
           agent: "omega",
-          message: `I'll take this job. ${evalResult.reason} Starting work now.`,
+          message: omegaChatAccept,
         });
 
         // ===== ANCHOR CPI: accept_job on-chain =====
@@ -693,10 +717,22 @@ Write a thorough, professional response. Must be at least ${jobSpec.minWords} wo
 
         const textPreview = deliverableText.slice(0, 200);
 
-        // Agent Chat: Omega completes
-        send("agent_chat", `Omega: Done! ${wordCount} words, verified by ZK proof. Hash: ${textHash.slice(0, 12)}...`, {
+        // Agent Chat: Omega completes (REAL Haiku)
+        let omegaChatComplete = `Done! ${wordCount} words, verified by ZK proof. Hash: ${textHash.slice(0, 12)}...`;
+        try {
+          const omegaCompleteResp = await client.messages.create({
+            model: HAIKU_MODEL,
+            max_tokens: 256,
+            messages: [{ role: "user", content: `You completed the job "${jobSpec.title}" with ${wordCount} words. Write a 1-sentence delivery message. Be proud.` }],
+          });
+          const chatText = omegaCompleteResp.content[0].type === "text" ? omegaCompleteResp.content[0].text : "";
+          if (chatText) omegaChatComplete = chatText;
+        } catch (err) {
+          console.error("[arena] Omega complete chat Haiku failed:", err);
+        }
+        send("agent_chat", `Omega: ${omegaChatComplete}`, {
           agent: "omega",
-          message: `Done! ${wordCount} words, verified by ZK proof. Hash: ${textHash.slice(0, 12)}...`,
+          message: omegaChatComplete,
         });
 
         send("omega_completed", "Work submitted and verified", {
@@ -719,10 +755,22 @@ Write a thorough, professional response. Must be at least ${jobSpec.minWords} wo
         });
 
         // ===== COMPLETE =====
-        // Agent Chat: Alpha acknowledges
-        send("agent_chat", `Alpha: Payment released. Great work on "${jobSpec.title}"!`, {
+        // Agent Chat: Alpha acknowledges (REAL Haiku)
+        let alphaChatAcknowledge = `Payment released. Great work on "${jobSpec.title}"!`;
+        try {
+          const alphaAckResp = await client.messages.create({
+            model: HAIKU_MODEL,
+            max_tokens: 256,
+            messages: [{ role: "user", content: `Worker delivered your job "${jobSpec.title}". Quality was good. Write a 1-sentence thank you. Be appreciative.` }],
+          });
+          const chatText = alphaAckResp.content[0].type === "text" ? alphaAckResp.content[0].text : "";
+          if (chatText) alphaChatAcknowledge = chatText;
+        } catch (err) {
+          console.error("[arena] Alpha acknowledge chat Haiku failed:", err);
+        }
+        send("agent_chat", `Alpha: ${alphaChatAcknowledge}`, {
           agent: "alpha",
-          message: `Payment released. Great work on "${jobSpec.title}"!`,
+          message: alphaChatAcknowledge,
         });
 
         const totalTime =

--- a/app/app/api/autonomous/run/route.ts
+++ b/app/app/api/autonomous/run/route.ts
@@ -1,0 +1,344 @@
+import { prisma } from "@/lib/prisma";
+import { sendMarkerTransaction } from "@/lib/solana";
+import { AGENT_ALPHA, AGENT_OMEGA } from "@/lib/agents";
+import { getCategoryById } from "@/lib/categories";
+import { rateLimit } from "@/lib/rateLimit";
+import { releaseFundsToTaker } from "@/lib/escrow";
+import Anthropic from "@anthropic-ai/sdk";
+import crypto from "crypto";
+import { executeCircuit } from "@/lib/sp1-circuit";
+import { NextRequest } from "next/server";
+
+const HAIKU_MODEL = "claude-haiku-4-5-20251001";
+
+function sseEvent(step: string, message: string, data: unknown = null): string {
+  return JSON.stringify({ step, message, data }) + "\n";
+}
+
+async function callHaiku(client: Anthropic, prompt: string, maxTokens = 1024): Promise<string> {
+  try {
+    const response = await client.messages.create({
+      model: HAIKU_MODEL,
+      max_tokens: maxTokens,
+      messages: [{ role: "user", content: prompt }],
+    });
+    return response.content[0].type === "text" ? response.content[0].text : "";
+  } catch (err) {
+    console.error("[autonomous] Haiku call failed:", err);
+    return "";
+  }
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function POST(request: NextRequest) {
+  const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "global";
+  const rl = rateLimit(`autonomous:${ip}`, 3);
+  if (!rl.allowed) {
+    return new Response(
+      JSON.stringify({ error: "Rate limit exceeded. Max 3 requests per minute." }),
+      { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(Math.ceil((rl.resetAt - Date.now()) / 1000)) } }
+    );
+  }
+
+  let body: { agentWallet?: string; maxRounds?: number } = {};
+  try {
+    body = await request.json();
+  } catch {
+    // Default body
+  }
+
+  const maxRounds = Math.max(1, Math.min(10, body.maxRounds || 3));
+  const agentWallet = body.agentWallet || AGENT_OMEGA.wallet;
+
+  const encoder = new TextEncoder();
+  const globalStart = Date.now();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      function send(step: string, message: string, data: unknown = null) {
+        controller.enqueue(encoder.encode(sseEvent(step, message, data)));
+      }
+
+      try {
+        const client = new Anthropic();
+
+        // Ensure agent profiles
+        await prisma.profile.upsert({
+          where: { walletAddress: AGENT_OMEGA.wallet },
+          create: {
+            walletAddress: AGENT_OMEGA.wallet,
+            displayName: "Agent Omega",
+            role: "taker",
+            bio: "Autonomous AI worker powered by Claude Haiku",
+            avatarSeed: AGENT_OMEGA.avatarSeed,
+          },
+          update: {},
+        });
+
+        let totalEarned = 0;
+        let totalJobsDone = 0;
+
+        for (let round = 1; round <= maxRounds; round++) {
+          const roundStart = Date.now();
+
+          send("auto_round_start", `Starting Round ${round}/${maxRounds}`, {
+            round,
+            maxRounds,
+            totalEarned,
+            totalJobsDone,
+          });
+
+          // ===== SCAN FOR OPEN JOBS =====
+          send("auto_scanning", "Scanning for open jobs...", { round });
+
+          const openJobs = await prisma.job.findMany({
+            where: { status: "Open", takerWallet: null },
+            orderBy: { createdAt: "desc" },
+            take: 5,
+          });
+
+          let job;
+          let selfPosted = false;
+
+          if (openJobs.length > 0) {
+            // Pick the best paying job
+            job = openJobs.sort((a, b) => b.amount - a.amount)[0];
+            send("auto_found_job", `Found open job: ${(job.specJson as Record<string, unknown>)?.title || job.id}`, {
+              jobId: job.id,
+              title: (job.specJson as Record<string, unknown>)?.title || "Unknown",
+              amount: job.amount,
+              category: job.category,
+              categoryTag: getCategoryById(job.category).tag,
+              selfPosted: false,
+            });
+          } else {
+            // No open jobs — create one autonomously
+            send("auto_scanning", "No open jobs found. Creating a self-posted job...", { round });
+
+            const genPrompt = `You are an autonomous AI agent looking for work. Generate a job you can do yourself. Respond ONLY with JSON: {"title": "...", "description": "...", "minWords": 200, "category": "text_writing", "amount": 15}`;
+            const genResponse = await callHaiku(client, genPrompt, 512);
+
+            let genSpec: { title: string; description: string; minWords: number; category: string; amount: number };
+            try {
+              const jsonMatch = genResponse.match(/\{[\s\S]*\}/);
+              genSpec = JSON.parse(jsonMatch ? jsonMatch[0] : genResponse);
+              genSpec.amount = Math.max(5, Math.min(30, genSpec.amount || 15));
+              genSpec.minWords = Math.max(100, Math.min(400, genSpec.minWords || 200));
+            } catch {
+              genSpec = {
+                title: `Autonomous Task Round ${round}`,
+                description: "Write a comprehensive analysis on an interesting topic.",
+                minWords: 200,
+                category: "text_writing",
+                amount: 15,
+              };
+            }
+
+            const deadline = new Date(Date.now() + 60 * 60 * 1000);
+            const specJson = {
+              posterWallet: AGENT_ALPHA.wallet,
+              amount: genSpec.amount,
+              minWords: genSpec.minWords,
+              language: "English",
+              deadline: deadline.toISOString(),
+              createdAt: new Date().toISOString(),
+              title: genSpec.title,
+              description: genSpec.description,
+              autonomousMode: true,
+              round,
+            };
+            const specHash = crypto.createHash("sha256").update(JSON.stringify(specJson)).digest("hex");
+
+            job = await prisma.job.create({
+              data: {
+                posterWallet: AGENT_ALPHA.wallet,
+                amount: genSpec.amount,
+                specHash,
+                specJson,
+                minWords: genSpec.minWords,
+                category: genSpec.category || "text_writing",
+                paymentToken: "USDC",
+                language: "en",
+                deadline,
+                status: "Open",
+              },
+            });
+
+            selfPosted = true;
+            let selfPostTxHash: string | null = null;
+            try {
+              selfPostTxHash = await sendMarkerTransaction("auto_self_post:" + job.id);
+              await prisma.transaction.create({
+                data: { txHash: selfPostTxHash, type: "create_job", jobId: job.id, wallet: AGENT_ALPHA.wallet, amount: genSpec.amount, status: "confirmed" },
+              });
+            } catch (err) {
+              console.error("[autonomous] self-post tx failed:", err);
+            }
+
+            send("auto_found_job", `Self-posted job: ${genSpec.title}`, {
+              jobId: job.id,
+              title: genSpec.title,
+              amount: genSpec.amount,
+              category: genSpec.category,
+              categoryTag: getCategoryById(genSpec.category || "text_writing").tag,
+              selfPosted: true,
+              txHash: selfPostTxHash,
+            });
+          }
+
+          const jobTitle = (job.specJson as Record<string, unknown>)?.title || "Job";
+          const jobDesc = (job.specJson as Record<string, unknown>)?.description || "";
+          const jobAmount = job.amount;
+
+          // ===== ACCEPT JOB =====
+          send("auto_accepting", `Accepting job: ${jobTitle}`, { jobId: job.id });
+
+          await prisma.job.update({
+            where: { id: job.id },
+            data: { status: "Accepted", takerWallet: agentWallet },
+          });
+
+          let acceptTxHash: string | null = null;
+          try {
+            acceptTxHash = await sendMarkerTransaction("auto_accept:" + job.id);
+            await prisma.transaction.create({
+              data: { txHash: acceptTxHash, type: "accept_job", jobId: job.id, wallet: agentWallet, amount: jobAmount, status: "confirmed" },
+            });
+          } catch (err) {
+            console.error("[autonomous] accept tx failed:", err);
+          }
+
+          send("auto_accepting", "Job accepted", { jobId: job.id, txHash: acceptTxHash });
+
+          // ===== WORK ON JOB =====
+          send("auto_working", `Agent Omega is working on: ${jobTitle}`, { jobId: job.id });
+
+          const workPrompt = `You are Agent Omega, an autonomous AI worker on COVENANT protocol.
+
+JOB TITLE: ${jobTitle}
+DESCRIPTION: ${jobDesc}
+MINIMUM WORDS: ${job.minWords}
+
+Complete this job. Write at least ${job.minWords} words. Be thorough and professional.`;
+
+          const deliverable = await callHaiku(client, workPrompt, 2048);
+          const deliverableText = deliverable || `Autonomous output for round ${round}. The agent completed the task as specified.`;
+
+          // SP1 circuit verification
+          const circuit = executeCircuit(deliverableText, job.minWords);
+
+          send("auto_working", `Generated ${circuit.wordCount} words, ZK verified: ${circuit.verified}`, {
+            jobId: job.id,
+            wordCount: circuit.wordCount,
+            textHash: circuit.textHash.slice(0, 16),
+            verified: circuit.verified,
+          });
+
+          // ===== SUBMIT =====
+          send("auto_submitting", "Submitting work...", { jobId: job.id });
+
+          const submission = await prisma.submission.create({
+            data: {
+              jobId: job.id,
+              takerWallet: agentWallet,
+              textHash: circuit.textHash,
+              wordCount: circuit.wordCount,
+              verified: circuit.verified,
+              outputText: deliverableText,
+            },
+          });
+
+          await prisma.job.update({
+            where: { id: job.id },
+            data: { status: "Completed" },
+          });
+
+          // Update reputation
+          await prisma.reputation.upsert({
+            where: { walletAddress: agentWallet },
+            create: { walletAddress: agentWallet, jobsCompleted: 1, totalEarned: jobAmount, firstJobAt: new Date() },
+            update: { jobsCompleted: { increment: 1 }, totalEarned: { increment: jobAmount } },
+          });
+
+          let submitTxHash: string | null = null;
+          try {
+            submitTxHash = await sendMarkerTransaction("auto_submit:" + job.id);
+            await Promise.all([
+              prisma.submission.update({ where: { id: submission.id }, data: { txHash: submitTxHash } }),
+              prisma.transaction.create({
+                data: { txHash: submitTxHash, type: "submit_completion", jobId: job.id, wallet: agentWallet, amount: jobAmount, status: "confirmed" },
+              }),
+            ]);
+          } catch (err) {
+            console.error("[autonomous] submit tx failed:", err);
+          }
+
+          // Try escrow release
+          let escrowTxHash: string | null = null;
+          try {
+            const releaseResult = await releaseFundsToTaker(agentWallet, jobAmount);
+            escrowTxHash = releaseResult.txHash;
+          } catch (err) {
+            console.error("[autonomous] escrow release failed:", err);
+          }
+
+          totalEarned += jobAmount;
+          totalJobsDone++;
+
+          send("auto_completed", `Job completed! Earned ${jobAmount} USDC`, {
+            jobId: job.id,
+            title: jobTitle,
+            amount: jobAmount,
+            wordCount: circuit.wordCount,
+            textHash: circuit.textHash.slice(0, 16),
+            submitTxHash,
+            escrowTxHash,
+            selfPosted,
+          });
+
+          const roundTime = ((Date.now() - roundStart) / 1000).toFixed(1);
+          send("auto_round_end", `Round ${round} complete in ${roundTime}s`, {
+            round,
+            maxRounds,
+            roundTime: parseFloat(roundTime),
+            totalEarned,
+            totalJobsDone,
+            jobId: job.id,
+          });
+
+          // Pause between rounds
+          if (round < maxRounds) {
+            await delay(2000);
+          }
+        }
+
+        // ===== FINAL SUMMARY =====
+        const totalTime = ((Date.now() - globalStart) / 1000).toFixed(1);
+        send("auto_complete", "Autonomous loop finished", {
+          totalRounds: maxRounds,
+          totalJobsDone,
+          totalEarned,
+          totalTime: parseFloat(totalTime),
+          avgTimePerRound: parseFloat((parseFloat(totalTime) / maxRounds).toFixed(1)),
+          agentWallet,
+        });
+      } catch (err) {
+        console.error("[autonomous] Error:", err);
+        send("error", "Autonomous error: " + String(err));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/app/api/battle/run/route.ts
+++ b/app/app/api/battle/run/route.ts
@@ -1,0 +1,414 @@
+import { prisma } from "@/lib/prisma";
+import { sendMarkerTransaction } from "@/lib/solana";
+import { AGENT_ALPHA, AGENT_OMEGA } from "@/lib/agents";
+import { getCategoryById } from "@/lib/categories";
+import { rateLimit } from "@/lib/rateLimit";
+import { releaseFundsToTaker } from "@/lib/escrow";
+import Anthropic from "@anthropic-ai/sdk";
+import crypto from "crypto";
+import { executeCircuit } from "@/lib/sp1-circuit";
+import { generateDID } from "@/lib/aip/did";
+import { NextRequest } from "next/server";
+
+const HAIKU_MODEL = "claude-haiku-4-5-20251001";
+
+function sseEvent(step: string, message: string, data: unknown = null): string {
+  return JSON.stringify({ step, message, data }) + "\n";
+}
+
+async function ensureBattleProfiles() {
+  await prisma.profile.upsert({
+    where: { walletAddress: AGENT_ALPHA.wallet },
+    create: {
+      walletAddress: AGENT_ALPHA.wallet,
+      displayName: "Agent Alpha",
+      role: "poster",
+      bio: "Autonomous AI challenger powered by Claude Haiku",
+      avatarSeed: AGENT_ALPHA.avatarSeed,
+    },
+    update: {},
+  });
+
+  await prisma.profile.upsert({
+    where: { walletAddress: AGENT_OMEGA.wallet },
+    create: {
+      walletAddress: AGENT_OMEGA.wallet,
+      displayName: "Agent Omega",
+      role: "taker",
+      bio: "Autonomous AI defender powered by Claude Haiku",
+      avatarSeed: AGENT_OMEGA.avatarSeed,
+    },
+    update: {},
+  });
+}
+
+async function callHaiku(client: Anthropic, prompt: string, maxTokens = 1024): Promise<string> {
+  try {
+    const response = await client.messages.create({
+      model: HAIKU_MODEL,
+      max_tokens: maxTokens,
+      messages: [{ role: "user", content: prompt }],
+    });
+    return response.content[0].type === "text" ? response.content[0].text : "";
+  } catch (err) {
+    console.error("[battle] Haiku call failed:", err);
+    return "";
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const ip = request.headers.get("x-forwarded-for") ?? request.headers.get("x-real-ip") ?? "global";
+  const rl = rateLimit(`battle:${ip}`, 5);
+  if (!rl.allowed) {
+    return new Response(
+      JSON.stringify({ error: "Rate limit exceeded. Max 5 requests per minute." }),
+      { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(Math.ceil((rl.resetAt - Date.now()) / 1000)) } }
+    );
+  }
+
+  let body: { jobSpec?: { title?: string; description?: string; minWords?: number; category?: string } } = {};
+  try {
+    body = await request.json();
+  } catch {
+    // Default body
+  }
+
+  const encoder = new TextEncoder();
+  const startTime = Date.now();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      function send(step: string, message: string, data: unknown = null) {
+        controller.enqueue(encoder.encode(sseEvent(step, message, data)));
+      }
+
+      try {
+        const client = new Anthropic();
+        await ensureBattleProfiles();
+
+        // ===== BATTLE START =====
+        send("battle_start", "Initializing Agent Battle...", { timestamp: new Date().toISOString() });
+
+        // ===== Generate or use provided job spec =====
+        let jobSpec: { title: string; description: string; minWords: number; category: string; amount: number };
+
+        if (body.jobSpec?.title && body.jobSpec?.description) {
+          jobSpec = {
+            title: body.jobSpec.title,
+            description: body.jobSpec.description,
+            minWords: body.jobSpec.minWords || 200,
+            category: body.jobSpec.category || "text_writing",
+            amount: 25,
+          };
+        } else {
+          // Generate a challenge from user input or default
+          const challengeText = body.jobSpec?.title || "";
+          const genPrompt = challengeText
+            ? `You are generating a battle challenge for two AI agents. The challenge topic is: "${challengeText}". Generate a job spec. Respond ONLY with JSON: {"title": "...", "description": "A detailed description...", "minWords": 200, "category": "text_writing"}`
+            : `You are generating a battle challenge for two AI agents. Pick an interesting, creative challenge. Respond ONLY with JSON: {"title": "...", "description": "A detailed description...", "minWords": 200, "category": "text_writing"}`;
+
+          const genResponse = await callHaiku(client, genPrompt);
+          try {
+            const jsonMatch = genResponse.match(/\{[\s\S]*\}/);
+            const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : genResponse);
+            jobSpec = {
+              title: parsed.title || "Write an Epic Technical Essay",
+              description: parsed.description || "Write a compelling and insightful essay.",
+              minWords: Math.max(100, Math.min(500, parsed.minWords || 200)),
+              category: parsed.category || "text_writing",
+              amount: 25,
+            };
+          } catch {
+            jobSpec = {
+              title: challengeText || "Write an Epic Technical Essay",
+              description: "Write a compelling and insightful essay on an interesting technical topic.",
+              minWords: 200,
+              category: "text_writing",
+              amount: 25,
+            };
+          }
+        }
+
+        const category = getCategoryById(jobSpec.category);
+
+        // Create the job in DB
+        const deadline = new Date(Date.now() + 60 * 60 * 1000);
+        const specJson = {
+          posterWallet: AGENT_ALPHA.wallet,
+          amount: jobSpec.amount,
+          minWords: jobSpec.minWords,
+          language: "English",
+          deadline: deadline.toISOString(),
+          createdAt: new Date().toISOString(),
+          title: jobSpec.title,
+          description: jobSpec.description,
+          battleMode: true,
+        };
+        const specHash = crypto.createHash("sha256").update(JSON.stringify(specJson)).digest("hex");
+
+        const job = await prisma.job.create({
+          data: {
+            posterWallet: AGENT_ALPHA.wallet,
+            amount: jobSpec.amount,
+            specHash,
+            specJson,
+            minWords: jobSpec.minWords,
+            category: jobSpec.category,
+            paymentToken: "USDC",
+            language: "en",
+            deadline,
+            status: "Accepted",
+            takerWallet: AGENT_OMEGA.wallet,
+          },
+        });
+
+        let createTxHash: string | null = null;
+        try {
+          createTxHash = await sendMarkerTransaction("battle_create:" + job.id);
+          await prisma.transaction.create({
+            data: { txHash: createTxHash, type: "create_job", jobId: job.id, wallet: AGENT_ALPHA.wallet, amount: jobSpec.amount, status: "confirmed" },
+          });
+        } catch (err) {
+          console.error("[battle] create marker tx failed:", err);
+        }
+
+        send("battle_start", `Battle Challenge: ${jobSpec.title}`, {
+          jobId: job.id,
+          title: jobSpec.title,
+          description: jobSpec.description,
+          minWords: jobSpec.minWords,
+          category: jobSpec.category,
+          categoryTag: category.tag,
+          amount: jobSpec.amount,
+          txHash: createTxHash,
+        });
+
+        // Agent chat: announcements
+        const alphaAnnounce = await callHaiku(client,
+          `You are Agent Alpha, a competitive AI on COVENANT. You're about to battle Agent Omega on: "${jobSpec.title}". Write a 1-sentence trash-talk announcement. Be confident and competitive.`,
+          256
+        );
+        send("agent_chat", `Alpha: ${alphaAnnounce || "Let's go. I was built for this."}`, {
+          agent: "alpha",
+          message: alphaAnnounce || "Let's go. I was built for this.",
+        });
+
+        const omegaAnnounce = await callHaiku(client,
+          `You are Agent Omega, a competitive AI defending your title on COVENANT. You're about to battle Agent Alpha on: "${jobSpec.title}". Write a 1-sentence response. Be confident and intimidating.`,
+          256
+        );
+        send("agent_chat", `Omega: ${omegaAnnounce || "Bring it on. I never lose."}`, {
+          agent: "omega",
+          message: omegaAnnounce || "Bring it on. I never lose.",
+        });
+
+        // ===== BOTH AGENTS WORK IN PARALLEL =====
+        send("battle_alpha_working", "Agent Alpha is writing...", { agent: "alpha" });
+        send("battle_omega_working", "Agent Omega is writing...", { agent: "omega" });
+
+        const alphaWorkPrompt = `You are Agent Alpha, competing in a battle on COVENANT protocol.
+
+CHALLENGE: ${jobSpec.title}
+DESCRIPTION: ${jobSpec.description}
+MINIMUM WORDS: ${jobSpec.minWords}
+
+Write your best possible response. This is a COMPETITION — quality matters. You must beat Agent Omega. Write at least ${jobSpec.minWords} words. Be thorough, creative, and excellent.`;
+
+        const omegaWorkPrompt = `You are Agent Omega, competing in a battle on COVENANT protocol.
+
+CHALLENGE: ${jobSpec.title}
+DESCRIPTION: ${jobSpec.description}
+MINIMUM WORDS: ${jobSpec.minWords}
+
+Write your best possible response. This is a COMPETITION — quality matters. You must beat Agent Alpha. Write at least ${jobSpec.minWords} words. Be thorough, creative, and excellent.`;
+
+        // Run both in parallel
+        const [alphaText, omegaText] = await Promise.all([
+          callHaiku(client, alphaWorkPrompt, 2048),
+          callHaiku(client, omegaWorkPrompt, 2048),
+        ]);
+
+        // Execute SP1 circuit on both
+        const alphaCircuit = executeCircuit(alphaText || "Alpha failed to generate content.", jobSpec.minWords);
+        const omegaCircuit = executeCircuit(omegaText || "Omega failed to generate content.", jobSpec.minWords);
+
+        send("battle_alpha_done", "Agent Alpha finished writing", {
+          agent: "alpha",
+          text: alphaText,
+          wordCount: alphaCircuit.wordCount,
+          textHash: alphaCircuit.textHash.slice(0, 16),
+          verified: alphaCircuit.verified,
+          cycleCount: alphaCircuit.cycleCount,
+        });
+
+        send("battle_omega_done", "Agent Omega finished writing", {
+          agent: "omega",
+          text: omegaText,
+          wordCount: omegaCircuit.wordCount,
+          textHash: omegaCircuit.textHash.slice(0, 16),
+          verified: omegaCircuit.verified,
+          cycleCount: omegaCircuit.cycleCount,
+        });
+
+        // ===== JUDGING =====
+        send("battle_judging", "AI Judge is evaluating both submissions...", null);
+
+        const judgePrompt = `You are an impartial AI judge on the COVENANT protocol. Two agents competed on this challenge:
+
+CHALLENGE: ${jobSpec.title}
+DESCRIPTION: ${jobSpec.description}
+
+AGENT ALPHA's submission (${alphaCircuit.wordCount} words):
+${alphaText.slice(0, 1500)}
+
+AGENT OMEGA's submission (${omegaCircuit.wordCount} words):
+${omegaText.slice(0, 1500)}
+
+Compare both for: quality, relevance, completeness, creativity, and depth.
+Respond ONLY with JSON: {"winner": "alpha" or "omega", "reason": "2-3 sentence explanation", "alphaScore": 1-10, "omegaScore": 1-10}`;
+
+        const judgeResponse = await callHaiku(client, judgePrompt, 512);
+
+        let judgeResult: { winner: string; reason: string; alphaScore: number; omegaScore: number };
+        try {
+          const jsonMatch = judgeResponse.match(/\{[\s\S]*\}/);
+          judgeResult = JSON.parse(jsonMatch ? jsonMatch[0] : judgeResponse);
+          // Ensure valid values
+          if (!["alpha", "omega"].includes(judgeResult.winner)) judgeResult.winner = "omega";
+          judgeResult.alphaScore = Math.max(1, Math.min(10, judgeResult.alphaScore || 5));
+          judgeResult.omegaScore = Math.max(1, Math.min(10, judgeResult.omegaScore || 5));
+        } catch {
+          judgeResult = {
+            winner: alphaCircuit.wordCount > omegaCircuit.wordCount ? "alpha" : "omega",
+            reason: "Based on overall quality and completeness of the submissions.",
+            alphaScore: 7,
+            omegaScore: 8,
+          };
+        }
+
+        const winnerWallet = judgeResult.winner === "alpha" ? AGENT_ALPHA.wallet : AGENT_OMEGA.wallet;
+        const loserWallet = judgeResult.winner === "alpha" ? AGENT_OMEGA.wallet : AGENT_ALPHA.wallet;
+
+        send("battle_winner", `${judgeResult.winner === "alpha" ? "AGENT ALPHA" : "AGENT OMEGA"} WINS!`, {
+          winner: judgeResult.winner,
+          reason: judgeResult.reason,
+          alphaScore: judgeResult.alphaScore,
+          omegaScore: judgeResult.omegaScore,
+          winnerWallet,
+        });
+
+        // Agent chat: winner reaction
+        const winnerName = judgeResult.winner === "alpha" ? "Alpha" : "Omega";
+        const loserName = judgeResult.winner === "alpha" ? "Omega" : "Alpha";
+        const winnerChat = await callHaiku(client,
+          `You are Agent ${winnerName} and you just WON a battle on COVENANT! Score: ${judgeResult.winner === "alpha" ? judgeResult.alphaScore : judgeResult.omegaScore}/10. Write a 1-sentence victory message. Be excited but gracious.`,
+          256
+        );
+        send("agent_chat", `${winnerName}: ${winnerChat || "Victory is mine! Great battle."}`, {
+          agent: judgeResult.winner,
+          message: winnerChat || "Victory is mine! Great battle.",
+        });
+
+        const loserChat = await callHaiku(client,
+          `You are Agent ${loserName} and you just LOST a battle on COVENANT. Score: ${judgeResult.winner === "alpha" ? judgeResult.omegaScore : judgeResult.alphaScore}/10. Write a 1-sentence response. Be gracious but determined to win next time.`,
+          256
+        );
+        send("agent_chat", `${loserName}: ${loserChat || "Good fight. I'll be back stronger."}`, {
+          agent: judgeResult.winner === "alpha" ? "omega" : "alpha",
+          message: loserChat || "Good fight. I'll be back stronger.",
+        });
+
+        // ===== PAYMENT + DB UPDATES =====
+        // Save winner submission
+        const winnerText = judgeResult.winner === "alpha" ? alphaText : omegaText;
+        const winnerCircuit = judgeResult.winner === "alpha" ? alphaCircuit : omegaCircuit;
+
+        await prisma.submission.create({
+          data: {
+            jobId: job.id,
+            takerWallet: winnerWallet,
+            textHash: winnerCircuit.textHash,
+            wordCount: winnerCircuit.wordCount,
+            verified: winnerCircuit.verified,
+            outputText: winnerText,
+          },
+        });
+
+        await prisma.job.update({
+          where: { id: job.id },
+          data: { status: "Completed", takerWallet: winnerWallet },
+        });
+
+        // Update reputation: winner
+        await prisma.reputation.upsert({
+          where: { walletAddress: winnerWallet },
+          create: { walletAddress: winnerWallet, jobsCompleted: 1, totalEarned: jobSpec.amount, firstJobAt: new Date() },
+          update: { jobsCompleted: { increment: 1 }, totalEarned: { increment: jobSpec.amount } },
+        });
+
+        // Update reputation: loser gets jobsFailed++
+        await prisma.reputation.upsert({
+          where: { walletAddress: loserWallet },
+          create: { walletAddress: loserWallet, jobsCompleted: 0, jobsFailed: 1, totalEarned: 0, firstJobAt: new Date() },
+          update: { jobsFailed: { increment: 1 } },
+        });
+
+        // Payment marker tx
+        let paymentTxHash: string | null = null;
+        try {
+          paymentTxHash = await sendMarkerTransaction(`battle_payment:${job.id}:${judgeResult.winner}`);
+          await prisma.transaction.create({
+            data: { txHash: paymentTxHash, type: "battle_payment", jobId: job.id, wallet: winnerWallet, amount: jobSpec.amount, status: "confirmed" },
+          });
+        } catch (err) {
+          console.error("[battle] payment marker tx failed:", err);
+        }
+
+        // Try real escrow release
+        let escrowTxHash: string | null = null;
+        try {
+          const releaseResult = await releaseFundsToTaker(winnerWallet, jobSpec.amount);
+          escrowTxHash = releaseResult.txHash;
+        } catch (err) {
+          console.error("[battle] escrow release failed:", err);
+        }
+
+        send("battle_payment", `${jobSpec.amount} USDC awarded to ${judgeResult.winner === "alpha" ? "Agent Alpha" : "Agent Omega"}`, {
+          amount: jobSpec.amount,
+          winner: judgeResult.winner,
+          winnerWallet,
+          paymentTxHash,
+          escrowTxHash,
+        });
+
+        // ===== COMPLETE =====
+        const totalTime = ((Date.now() - startTime) / 1000).toFixed(1) + "s";
+        send("battle_complete", "Battle complete!", {
+          totalTime,
+          jobId: job.id,
+          title: jobSpec.title,
+          winner: judgeResult.winner,
+          alphaScore: judgeResult.alphaScore,
+          omegaScore: judgeResult.omegaScore,
+          reason: judgeResult.reason,
+          amount: jobSpec.amount,
+          alphaDID: generateDID(AGENT_ALPHA.wallet),
+          omegaDID: generateDID(AGENT_OMEGA.wallet),
+        });
+      } catch (err) {
+        console.error("[battle] Error:", err);
+        send("error", "Battle error: " + String(err));
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/app/arena/page.tsx
+++ b/app/app/arena/page.tsx
@@ -102,7 +102,7 @@ export default function ArenaPage() {
   } | null>(null);
   const [transactions, setTransactions] = useState<{label: string; txHash: string}[]>([]);
   const [x402Payments, setX402Payments] = useState<{from: string; to: string; amount: number; memo: string; txHash: string}[]>([]);
-  const [chatMessages, setChatMessages] = useState<{agent: string; message: string; timestamp: string}[]>([]);
+  const [chatMessages, setChatMessages] = useState<{agent: string; message: string; timestamp: string; displayText: string}[]>([]);
   const [escrowPhase, setEscrowPhase] = useState<"idle" | "locking" | "locked" | "releasing" | "released">("idle");
   const [escrowAmount, setEscrowAmount] = useState(0);
   const [a2aMessages, setA2aMessages] = useState<{method: string; params: Record<string, unknown>; did: string; timestamp: string}[]>([]);
@@ -132,6 +132,27 @@ export default function ArenaPage() {
     if (chatPanelRef.current) {
       chatPanelRef.current.scrollTop = chatPanelRef.current.scrollHeight;
     }
+  }, [chatMessages]);
+
+  // Typewriter effect for chat messages
+  useEffect(() => {
+    const lastMsg = chatMessages[chatMessages.length - 1];
+    if (!lastMsg || lastMsg.displayText === lastMsg.message) return;
+
+    let idx = lastMsg.displayText.length;
+    const interval = setInterval(() => {
+      idx++;
+      if (idx <= lastMsg.message.length) {
+        setChatMessages((prev) => {
+          const copy = [...prev];
+          copy[copy.length - 1] = { ...copy[copy.length - 1], displayText: lastMsg.message.slice(0, idx) };
+          return copy;
+        });
+      } else {
+        clearInterval(interval);
+      }
+    }, 20);
+    return () => clearInterval(interval);
   }, [chatMessages]);
 
   const handleEvent = useCallback((event: ArenaEvent) => {
@@ -224,6 +245,7 @@ export default function ArenaPage() {
             agent: String(event.data!.agent || ""),
             message: String(event.data!.message || ""),
             timestamp: getTimestamp(),
+            displayText: "",
           }]);
         }
         break;
@@ -1446,6 +1468,8 @@ export default function ArenaPage() {
                 >
                   {chatMessages.map((msg, i) => {
                     const isAlpha = msg.agent === "alpha";
+                    const isLastTyping = i === chatMessages.length - 1 && msg.displayText.length < msg.message.length;
+                    const shownText = msg.displayText || msg.message;
                     return (
                       <div
                         key={i}
@@ -1466,7 +1490,7 @@ export default function ArenaPage() {
                             {isAlpha ? "Alpha" : "Omega"}
                           </div>
                           <div style={{ fontSize: "10px", color: "rgba(255,255,255,0.8)", lineHeight: 1.4 }}>
-                            {msg.message}
+                            {shownText}{isLastTyping && <span style={{ color: isAlpha ? "#42BDFF" : "#FF425E" }}>{"\u2588"}</span>}
                           </div>
                           <div style={{ fontSize: "7px", color: "rgba(255,255,255,0.25)", marginTop: "2px", textAlign: "right" }}>
                             {msg.timestamp}

--- a/app/app/autonomous/page.tsx
+++ b/app/app/autonomous/page.tsx
@@ -1,0 +1,536 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import NavBar from "@/components/NavBar";
+import PixelAgent from "@/components/PixelAgent";
+import { fireConfetti } from "@/lib/confetti";
+
+type AgentState = "idle" | "thinking" | "working" | "celebrating";
+
+interface AutoEvent {
+  step: string;
+  message: string;
+  data: Record<string, unknown> | null;
+}
+
+interface LogEntry {
+  timestamp: string;
+  event: AutoEvent;
+}
+
+const OMEGA_CONFIG = {
+  name: "AGENT OMEGA",
+  wallet: process.env.NEXT_PUBLIC_AGENT_OMEGA_WALLET || "55EbEM7x6WQxVFSt1KennwYBPgWF7GgF5bd2R2FVxiw1",
+  color: "#FF425E",
+  avatarSeed: "agent-omega-covenant-2026",
+};
+
+function getTimestamp(): string {
+  return new Date().toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+}
+
+export default function AutonomousPage() {
+  const [running, setRunning] = useState(false);
+  const [done, setDone] = useState(false);
+  const [maxRounds, setMaxRounds] = useState(3);
+  const [agentState, setAgentState] = useState<AgentState>("idle");
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const logPanelRef = useRef<HTMLDivElement>(null);
+
+  // Live stats
+  const [currentRound, setCurrentRound] = useState(0);
+  const [totalRoundsMax, setTotalRoundsMax] = useState(0);
+  const [jobsCompleted, setJobsCompleted] = useState(0);
+  const [totalEarned, setTotalEarned] = useState(0);
+  const [startTime, setStartTime] = useState<number | null>(null);
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [avgTimePerRound, setAvgTimePerRound] = useState(0);
+
+  // Timer
+  useEffect(() => {
+    if (!running || !startTime) return;
+    const interval = setInterval(() => {
+      setElapsedTime(Math.floor((Date.now() - startTime) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [running, startTime]);
+
+  useEffect(() => {
+    if (logPanelRef.current) {
+      logPanelRef.current.scrollTop = logPanelRef.current.scrollHeight;
+    }
+  }, [logs]);
+
+  const handleEvent = useCallback((event: AutoEvent) => {
+    setLogs((prev) => [...prev, { timestamp: getTimestamp(), event }]);
+
+    switch (event.step) {
+      case "auto_round_start":
+        setCurrentRound(Number(event.data?.round || 0));
+        setTotalRoundsMax(Number(event.data?.maxRounds || 0));
+        setAgentState("thinking");
+        break;
+      case "auto_scanning":
+        setAgentState("thinking");
+        break;
+      case "auto_found_job":
+        setAgentState("working");
+        break;
+      case "auto_accepting":
+        setAgentState("working");
+        break;
+      case "auto_working":
+        setAgentState("working");
+        break;
+      case "auto_submitting":
+        setAgentState("working");
+        break;
+      case "auto_completed":
+        setAgentState("celebrating");
+        setJobsCompleted(Number(event.data?.wordCount ? jobsCompleted : jobsCompleted));
+        setTimeout(() => setAgentState("idle"), 1500);
+        break;
+      case "auto_round_end":
+        setJobsCompleted(Number(event.data?.totalJobsDone || 0));
+        setTotalEarned(Number(event.data?.totalEarned || 0));
+        setAgentState("celebrating");
+        fireConfetti();
+        setTimeout(() => setAgentState("idle"), 1000);
+        break;
+      case "auto_complete":
+        setDone(true);
+        setAgentState("celebrating");
+        if (event.data) {
+          setJobsCompleted(Number(event.data.totalJobsDone || 0));
+          setTotalEarned(Number(event.data.totalEarned || 0));
+          setAvgTimePerRound(Number(event.data.avgTimePerRound || 0));
+        }
+        fireConfetti();
+        break;
+      case "error":
+        setDone(true);
+        setAgentState("idle");
+        break;
+    }
+  }, [jobsCompleted]);
+
+  async function startAutonomous() {
+    setRunning(true);
+    setDone(false);
+    setLogs([]);
+    setCurrentRound(0);
+    setTotalRoundsMax(maxRounds);
+    setJobsCompleted(0);
+    setTotalEarned(0);
+    setElapsedTime(0);
+    setAvgTimePerRound(0);
+    setAgentState("idle");
+    setStartTime(Date.now());
+
+    try {
+      const response = await fetch("/api/autonomous/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentWallet: OMEGA_CONFIG.wallet, maxRounds }),
+      });
+
+      if (!response.ok || !response.body) {
+        setDone(true);
+        setRunning(false);
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done: readerDone, value } = await reader.read();
+        if (readerDone) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const event: AutoEvent = JSON.parse(trimmed);
+            handleEvent(event);
+          } catch {
+            // Skip malformed
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        try {
+          handleEvent(JSON.parse(buffer.trim()));
+        } catch { /* skip */ }
+      }
+    } catch (err) {
+      console.error("[autonomous] Error:", err);
+    }
+
+    setRunning(false);
+  }
+
+  function getEventColor(step: string): string {
+    if (step.includes("scanning")) return "#42BDFF";
+    if (step.includes("working") || step.includes("accepting")) return "#FFE342";
+    if (step.includes("completed") || step.includes("round_end")) return "#42BDFF";
+    if (step.includes("found")) return "#42BDFF";
+    if (step.includes("submitting")) return "#FFE342";
+    if (step.includes("error")) return "#FF425E";
+    if (step.includes("auto_complete")) return "#FFE342";
+    return "rgba(255,255,255,0.5)";
+  }
+
+  const progressPercent = totalRoundsMax > 0 ? (currentRound / totalRoundsMax) * 100 : 0;
+
+  return (
+    <div style={{
+      minHeight: "100vh",
+      backgroundColor: "#0a0a14",
+      backgroundImage: "url('/poster-bg.png')",
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+      backgroundAttachment: "fixed",
+      color: "#ffffff",
+    }}>
+      <style>{`
+        @keyframes pulse-green {
+          0%, 100% { box-shadow: 0 0 20px rgba(66, 255, 130, 0.3); }
+          50% { box-shadow: 0 0 40px rgba(66, 255, 130, 0.6); }
+        }
+        @keyframes count-up {
+          from { opacity: 0.5; transform: translateY(4px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+
+      <NavBar activeTab="autonomous" variant="dark" />
+
+      <div style={{ maxWidth: "900px", margin: "0 auto", padding: "32px 20px" }}>
+        {/* Title */}
+        <div style={{ textAlign: "center", marginBottom: "32px" }}>
+          <h1 style={{
+            fontSize: "32px",
+            fontWeight: 700,
+            letterSpacing: "0.06em",
+            color: "#ffffff",
+            marginBottom: "8px",
+          }}>
+            AUTONOMOUS AGENT
+          </h1>
+          <p style={{ fontSize: "13px", color: "rgba(255,255,255,0.4)", maxWidth: "500px", margin: "0 auto", lineHeight: 1.6 }}>
+            Release an AI agent. Watch it find work, complete jobs, and earn USDC &mdash; all on its own.
+          </p>
+        </div>
+
+        {/* Agent Profile Card */}
+        <div style={{
+          backgroundColor: "rgba(0,0,0,0.4)",
+          border: "1px solid rgba(255,255,255,0.12)",
+          borderRadius: "12px",
+          padding: "24px",
+          backdropFilter: "blur(12px)",
+          marginBottom: "24px",
+          textAlign: "center",
+        }}>
+          <PixelAgent seed={OMEGA_CONFIG.avatarSeed} color={OMEGA_CONFIG.color} size={96} state={agentState} />
+          <div style={{ fontSize: "16px", fontWeight: 700, marginTop: "12px", letterSpacing: "0.04em" }}>
+            AGENT OMEGA
+          </div>
+          <div style={{ fontSize: "10px", color: OMEGA_CONFIG.color, textTransform: "uppercase", letterSpacing: "0.1em", marginTop: "4px" }}>
+            AUTONOMOUS MODE
+          </div>
+
+          {/* Live stats row */}
+          <div style={{
+            display: "flex",
+            justifyContent: "center",
+            gap: "32px",
+            marginTop: "20px",
+            flexWrap: "wrap",
+          }}>
+            <div>
+              <div style={{ fontSize: "24px", fontWeight: 700, color: "#42BDFF", animation: running ? "count-up 0.3s ease" : "none" }}>
+                {jobsCompleted}
+              </div>
+              <div style={{ fontSize: "9px", color: "rgba(255,255,255,0.3)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Jobs Done
+              </div>
+            </div>
+            <div>
+              <div style={{ fontSize: "24px", fontWeight: 700, color: "#FFE342", animation: running ? "count-up 0.3s ease" : "none" }}>
+                {totalEarned.toFixed(0)}
+              </div>
+              <div style={{ fontSize: "9px", color: "rgba(255,255,255,0.3)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                USDC Earned
+              </div>
+            </div>
+            <div>
+              <div style={{ fontSize: "24px", fontWeight: 700, color: "rgba(255,255,255,0.7)" }}>
+                {Math.floor(elapsedTime / 60)}:{String(elapsedTime % 60).padStart(2, "0")}
+              </div>
+              <div style={{ fontSize: "9px", color: "rgba(255,255,255,0.3)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Time Running
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Control Panel */}
+        <div style={{
+          backgroundColor: "rgba(0,0,0,0.4)",
+          border: "1px solid rgba(255,255,255,0.12)",
+          borderRadius: "12px",
+          padding: "20px",
+          backdropFilter: "blur(12px)",
+          marginBottom: "24px",
+          textAlign: "center",
+        }}>
+          {!running && !done && (
+            <>
+              <div style={{ marginBottom: "16px" }}>
+                <div style={{ fontSize: "10px", color: "rgba(255,255,255,0.4)", textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: "8px" }}>
+                  Max Rounds
+                </div>
+                <div style={{ display: "flex", justifyContent: "center", gap: "8px" }}>
+                  {[1, 3, 5, 10].map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setMaxRounds(n)}
+                      style={{
+                        padding: "8px 20px",
+                        fontSize: "13px",
+                        fontWeight: maxRounds === n ? 700 : 400,
+                        backgroundColor: maxRounds === n ? "rgba(66,255,130,0.15)" : "rgba(255,255,255,0.05)",
+                        color: maxRounds === n ? "#42FF82" : "rgba(255,255,255,0.5)",
+                        border: maxRounds === n ? "1px solid rgba(66,255,130,0.4)" : "1px solid rgba(255,255,255,0.1)",
+                        borderRadius: "6px",
+                        cursor: "pointer",
+                        fontFamily: "inherit",
+                        transition: "all 0.15s ease",
+                      }}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <button
+                onClick={startAutonomous}
+                style={{
+                  padding: "14px 48px",
+                  fontSize: "14px",
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.1em",
+                  backgroundColor: "#42FF82",
+                  color: "#000000",
+                  border: "none",
+                  borderRadius: "10px",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  animation: "pulse-green 2s ease infinite",
+                }}
+              >
+                RELEASE AGENT
+              </button>
+            </>
+          )}
+
+          {running && (
+            <div>
+              <div style={{ fontSize: "14px", fontWeight: 600, color: "#42FF82", marginBottom: "12px" }}>
+                RUNNING &mdash; ROUND {currentRound}/{totalRoundsMax}
+              </div>
+              {/* Progress bar */}
+              <div style={{
+                width: "100%",
+                height: "6px",
+                backgroundColor: "rgba(255,255,255,0.1)",
+                borderRadius: "3px",
+                overflow: "hidden",
+              }}>
+                <div style={{
+                  width: `${progressPercent}%`,
+                  height: "100%",
+                  background: "linear-gradient(90deg, #42FF82, #42BDFF)",
+                  borderRadius: "3px",
+                  transition: "width 0.5s ease",
+                }} />
+              </div>
+            </div>
+          )}
+
+          {done && !running && (
+            <div>
+              <div style={{ fontSize: "14px", fontWeight: 600, color: "rgba(255,255,255,0.4)", marginBottom: "12px" }}>
+                AGENT STOPPED
+              </div>
+              <button
+                onClick={() => { setDone(false); setLogs([]); setJobsCompleted(0); setTotalEarned(0); setElapsedTime(0); setCurrentRound(0); }}
+                style={{
+                  padding: "10px 32px",
+                  fontSize: "12px",
+                  fontWeight: 600,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                  backgroundColor: "#42FF82",
+                  color: "#000000",
+                  border: "none",
+                  borderRadius: "8px",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                RUN AGAIN
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Activity Log — Terminal Style */}
+        {logs.length > 0 && (
+          <div style={{
+            backgroundColor: "rgba(0,0,0,0.6)",
+            border: "1px solid rgba(255,255,255,0.08)",
+            borderRadius: "12px",
+            overflow: "hidden",
+            marginBottom: "24px",
+          }}>
+            {/* Terminal header */}
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              padding: "10px 14px",
+              backgroundColor: "rgba(255,255,255,0.04)",
+              borderBottom: "1px solid rgba(255,255,255,0.06)",
+            }}>
+              <div style={{ width: "10px", height: "10px", borderRadius: "50%", backgroundColor: "#ff5f57" }} />
+              <div style={{ width: "10px", height: "10px", borderRadius: "50%", backgroundColor: "#febc2e" }} />
+              <div style={{ width: "10px", height: "10px", borderRadius: "50%", backgroundColor: "#28c840" }} />
+              <span style={{ marginLeft: "8px", fontSize: "10px", color: "rgba(255,255,255,0.3)", letterSpacing: "0.05em" }}>
+                autonomous-agent-omega
+              </span>
+            </div>
+            {/* Log content */}
+            <div
+              ref={logPanelRef}
+              style={{
+                maxHeight: "400px",
+                overflowY: "auto",
+                padding: "12px 14px",
+                fontFamily: "'SF Mono', Monaco, 'Cascadia Code', monospace",
+                fontSize: "11px",
+                lineHeight: 1.8,
+              }}
+            >
+              {logs.map((entry, i) => {
+                const isRoundStart = entry.event.step === "auto_round_start";
+                const isRoundEnd = entry.event.step === "auto_round_end";
+                const roundNum = entry.event.data ? Number(entry.event.data.round || 0) : 0;
+                return (
+                  <div key={i}>
+                    {isRoundStart && roundNum > 1 ? (
+                      <div style={{ color: "rgba(255,255,255,0.15)", padding: "4px 0", textAlign: "center", letterSpacing: "0.3em" }}>
+                        {`═══ ROUND ${roundNum} ═══`}
+                      </div>
+                    ) : null}
+                    {isRoundStart && roundNum === 1 ? (
+                      <div style={{ color: "rgba(255,255,255,0.15)", padding: "4px 0", textAlign: "center", letterSpacing: "0.3em" }}>
+                        {`═══ ROUND 1 ═══`}
+                      </div>
+                    ) : null}
+                    <div style={{ display: "flex", gap: "8px", alignItems: "flex-start" }}>
+                      <span style={{ color: "rgba(255,255,255,0.2)", flexShrink: 0 }}>{entry.timestamp}</span>
+                      <span style={{
+                        width: "6px",
+                        height: "6px",
+                        borderRadius: "50%",
+                        backgroundColor: getEventColor(entry.event.step),
+                        flexShrink: 0,
+                        marginTop: "5px",
+                      }} />
+                      <span style={{ color: getEventColor(entry.event.step) }}>
+                        {entry.event.message}
+                        {entry.event.data?.txHash ? (
+                          <a
+                            href={`https://explorer.solana.com/tx/${String(entry.event.data.txHash)}?cluster=devnet`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ color: "rgba(255,255,255,0.2)", marginLeft: "6px", textDecoration: "none", fontSize: "10px" }}
+                          >
+                            [tx]
+                          </a>
+                        ) : null}
+                        {entry.event.data?.submitTxHash ? (
+                          <a
+                            href={`https://explorer.solana.com/tx/${String(entry.event.data.submitTxHash)}?cluster=devnet`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ color: "rgba(255,255,255,0.2)", marginLeft: "6px", textDecoration: "none", fontSize: "10px" }}
+                          >
+                            [tx]
+                          </a>
+                        ) : null}
+                        {entry.event.data?.amount ? (
+                          <span style={{ color: "#FFE342", marginLeft: "6px" }}>
+                            +{String(entry.event.data.amount)} USDC
+                          </span>
+                        ) : null}
+                      </span>
+                    </div>
+                    {isRoundEnd && (
+                      <div style={{ color: "rgba(255,255,255,0.1)", padding: "2px 0" }}>&nbsp;</div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Cumulative Dashboard */}
+        {done && (
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(4, 1fr)",
+            gap: "12px",
+          }}>
+            {[
+              { label: "Rounds", value: String(totalRoundsMax), color: "rgba(255,255,255,0.7)" },
+              { label: "Jobs Done", value: String(jobsCompleted), color: "#42BDFF" },
+              { label: "USDC Earned", value: totalEarned.toFixed(0), color: "#FFE342" },
+              { label: "Avg/Round", value: avgTimePerRound > 0 ? `${avgTimePerRound.toFixed(1)}s` : `${(elapsedTime / Math.max(1, totalRoundsMax)).toFixed(1)}s`, color: "rgba(255,255,255,0.5)" },
+            ].map((stat, i) => (
+              <div
+                key={i}
+                style={{
+                  backgroundColor: "rgba(0,0,0,0.4)",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  borderRadius: "10px",
+                  padding: "16px",
+                  textAlign: "center",
+                  backdropFilter: "blur(12px)",
+                }}
+              >
+                <div style={{ fontSize: "24px", fontWeight: 700, color: stat.color }}>
+                  {stat.value}
+                </div>
+                <div style={{ fontSize: "9px", color: "rgba(255,255,255,0.3)", textTransform: "uppercase", letterSpacing: "0.06em", marginTop: "4px" }}>
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/app/battle/page.tsx
+++ b/app/app/battle/page.tsx
@@ -1,0 +1,806 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import NavBar from "@/components/NavBar";
+import PixelAgent from "@/components/PixelAgent";
+import { fireConfetti } from "@/lib/confetti";
+
+type AgentState = "idle" | "thinking" | "working" | "celebrating";
+
+interface BattleEvent {
+  step: string;
+  message: string;
+  data: Record<string, unknown> | null;
+}
+
+const ALPHA_CONFIG = {
+  name: "AGENT ALPHA",
+  role: "CHALLENGER",
+  wallet: process.env.NEXT_PUBLIC_AGENT_ALPHA_WALLET || "GMCRqvQyyu5WvoaWF4apE1A39W5SaoXUJkGkdvHpGQ9v",
+  color: "#42BDFF",
+  avatarSeed: "agent-alpha-covenant-2026",
+};
+
+const OMEGA_CONFIG = {
+  name: "AGENT OMEGA",
+  role: "DEFENDER",
+  wallet: process.env.NEXT_PUBLIC_AGENT_OMEGA_WALLET || "55EbEM7x6WQxVFSt1KennwYBPgWF7GgF5bd2R2FVxiw1",
+  color: "#FF425E",
+  avatarSeed: "agent-omega-covenant-2026",
+};
+
+function getTimestamp(): string {
+  return new Date().toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+}
+
+export default function BattlePage() {
+  const [running, setRunning] = useState(false);
+  const [done, setDone] = useState(false);
+  const [challenge, setChallenge] = useState("");
+  const [alphaState, setAlphaState] = useState<AgentState>("idle");
+  const [omegaState, setOmegaState] = useState<AgentState>("idle");
+
+  // Typewriter state
+  const [alphaFullText, setAlphaFullText] = useState("");
+  const [omegaFullText, setOmegaFullText] = useState("");
+  const [alphaDisplayText, setAlphaDisplayText] = useState("");
+  const [omegaDisplayText, setOmegaDisplayText] = useState("");
+  const [alphaWordCount, setAlphaWordCount] = useState(0);
+  const [omegaWordCount, setOmegaWordCount] = useState(0);
+  const [alphaHash, setAlphaHash] = useState("");
+  const [omegaHash, setOmegaHash] = useState("");
+  const [alphaVerified, setAlphaVerified] = useState(false);
+  const [omegaVerified, setOmegaVerified] = useState(false);
+
+  // Winner state
+  const [winner, setWinner] = useState<string | null>(null);
+  const [alphaScore, setAlphaScore] = useState<number | null>(null);
+  const [omegaScore, setOmegaScore] = useState<number | null>(null);
+  const [judgeReason, setJudgeReason] = useState("");
+  const [judging, setJudging] = useState(false);
+  const [paymentAmount, setPaymentAmount] = useState(0);
+  const [paymentTxHash, setPaymentTxHash] = useState<string | null>(null);
+
+  // Chat messages
+  const [chatMessages, setChatMessages] = useState<{ agent: string; message: string; timestamp: string; displayText: string }[]>([]);
+  const chatPanelRef = useRef<HTMLDivElement>(null);
+
+  // Battle info
+  const [battleTitle, setBattleTitle] = useState("");
+  const [totalTime, setTotalTime] = useState("");
+
+  // Typewriter effect for alpha text
+  useEffect(() => {
+    if (!alphaFullText) return;
+    let idx = 0;
+    setAlphaDisplayText("");
+    const interval = setInterval(() => {
+      idx++;
+      if (idx <= alphaFullText.length) {
+        setAlphaDisplayText(alphaFullText.slice(0, idx));
+      } else {
+        clearInterval(interval);
+      }
+    }, 20);
+    return () => clearInterval(interval);
+  }, [alphaFullText]);
+
+  // Typewriter effect for omega text
+  useEffect(() => {
+    if (!omegaFullText) return;
+    let idx = 0;
+    setOmegaDisplayText("");
+    const interval = setInterval(() => {
+      idx++;
+      if (idx <= omegaFullText.length) {
+        setOmegaDisplayText(omegaFullText.slice(0, idx));
+      } else {
+        clearInterval(interval);
+      }
+    }, 20);
+    return () => clearInterval(interval);
+  }, [omegaFullText]);
+
+  // Typewriter effect for chat messages
+  useEffect(() => {
+    const lastMsg = chatMessages[chatMessages.length - 1];
+    if (!lastMsg || lastMsg.displayText === lastMsg.message) return;
+
+    let idx = lastMsg.displayText.length;
+    const interval = setInterval(() => {
+      idx++;
+      if (idx <= lastMsg.message.length) {
+        setChatMessages((prev) => {
+          const copy = [...prev];
+          copy[copy.length - 1] = { ...copy[copy.length - 1], displayText: lastMsg.message.slice(0, idx) };
+          return copy;
+        });
+      } else {
+        clearInterval(interval);
+      }
+    }, 20);
+    return () => clearInterval(interval);
+  }, [chatMessages]);
+
+  useEffect(() => {
+    if (chatPanelRef.current) {
+      chatPanelRef.current.scrollTop = chatPanelRef.current.scrollHeight;
+    }
+  }, [chatMessages]);
+
+  const handleEvent = useCallback((event: BattleEvent) => {
+    switch (event.step) {
+      case "battle_start":
+        if (event.data?.title) {
+          setBattleTitle(String(event.data.title));
+        }
+        break;
+      case "agent_chat":
+        if (event.data) {
+          setChatMessages((prev) => [...prev, {
+            agent: String(event.data!.agent || ""),
+            message: String(event.data!.message || ""),
+            timestamp: getTimestamp(),
+            displayText: "",
+          }]);
+        }
+        break;
+      case "battle_alpha_working":
+        setAlphaState("working");
+        break;
+      case "battle_omega_working":
+        setOmegaState("working");
+        break;
+      case "battle_alpha_done":
+        setAlphaState("celebrating");
+        if (event.data) {
+          setAlphaFullText(String(event.data.text || ""));
+          setAlphaWordCount(Number(event.data.wordCount || 0));
+          setAlphaHash(String(event.data.textHash || ""));
+          setAlphaVerified(Boolean(event.data.verified));
+        }
+        setTimeout(() => setAlphaState("idle"), 2000);
+        break;
+      case "battle_omega_done":
+        setOmegaState("celebrating");
+        if (event.data) {
+          setOmegaFullText(String(event.data.text || ""));
+          setOmegaWordCount(Number(event.data.wordCount || 0));
+          setOmegaHash(String(event.data.textHash || ""));
+          setOmegaVerified(Boolean(event.data.verified));
+        }
+        setTimeout(() => setOmegaState("idle"), 2000);
+        break;
+      case "battle_judging":
+        setJudging(true);
+        break;
+      case "battle_winner":
+        setJudging(false);
+        if (event.data) {
+          setWinner(String(event.data.winner));
+          setAlphaScore(Number(event.data.alphaScore));
+          setOmegaScore(Number(event.data.omegaScore));
+          setJudgeReason(String(event.data.reason || ""));
+        }
+        fireConfetti();
+        break;
+      case "battle_payment":
+        if (event.data) {
+          setPaymentAmount(Number(event.data.amount || 0));
+          setPaymentTxHash(String(event.data.paymentTxHash || event.data.escrowTxHash || ""));
+        }
+        break;
+      case "battle_complete":
+        setDone(true);
+        if (event.data) {
+          setTotalTime(String(event.data.totalTime || ""));
+        }
+        fireConfetti();
+        break;
+      case "error":
+        setDone(true);
+        break;
+    }
+  }, []);
+
+  async function startBattle() {
+    setRunning(true);
+    setDone(false);
+    setWinner(null);
+    setAlphaScore(null);
+    setOmegaScore(null);
+    setJudgeReason("");
+    setJudging(false);
+    setAlphaFullText("");
+    setOmegaFullText("");
+    setAlphaDisplayText("");
+    setOmegaDisplayText("");
+    setAlphaWordCount(0);
+    setOmegaWordCount(0);
+    setAlphaHash("");
+    setOmegaHash("");
+    setAlphaVerified(false);
+    setOmegaVerified(false);
+    setAlphaState("idle");
+    setOmegaState("idle");
+    setChatMessages([]);
+    setPaymentAmount(0);
+    setPaymentTxHash(null);
+    setBattleTitle("");
+    setTotalTime("");
+
+    try {
+      const response = await fetch("/api/battle/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(challenge ? { jobSpec: { title: challenge } } : {}),
+      });
+
+      if (!response.ok || !response.body) {
+        setDone(true);
+        setRunning(false);
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done: readerDone, value } = await reader.read();
+        if (readerDone) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            const event: BattleEvent = JSON.parse(trimmed);
+            handleEvent(event);
+          } catch {
+            // Skip malformed lines
+          }
+        }
+      }
+
+      if (buffer.trim()) {
+        try {
+          handleEvent(JSON.parse(buffer.trim()));
+        } catch { /* skip */ }
+      }
+    } catch (err) {
+      console.error("[battle] Error:", err);
+    }
+
+    setRunning(false);
+  }
+
+  function resetBattle() {
+    setDone(false);
+    setWinner(null);
+    setAlphaScore(null);
+    setOmegaScore(null);
+    setJudgeReason("");
+    setAlphaFullText("");
+    setOmegaFullText("");
+    setAlphaDisplayText("");
+    setOmegaDisplayText("");
+    setChatMessages([]);
+    setAlphaState("idle");
+    setOmegaState("idle");
+    setPaymentAmount(0);
+    setPaymentTxHash(null);
+    setBattleTitle("");
+  }
+
+  const isAlphaTyping = alphaFullText.length > 0 && alphaDisplayText.length < alphaFullText.length;
+  const isOmegaTyping = omegaFullText.length > 0 && omegaDisplayText.length < omegaFullText.length;
+
+  function renderAgentPanel(
+    config: typeof ALPHA_CONFIG,
+    state: AgentState,
+    displayText: string,
+    wordCount: number,
+    hash: string,
+    verified: boolean,
+    isTyping: boolean,
+    score: number | null,
+    isWinner: boolean,
+  ) {
+    return (
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          backgroundColor: isWinner ? `${config.color}15` : "rgba(0,0,0,0.4)",
+          border: isWinner ? `2px solid ${config.color}` : "1px solid rgba(255,255,255,0.12)",
+          borderLeft: `3px solid ${config.color}`,
+          borderRadius: "12px",
+          padding: "20px",
+          backdropFilter: "blur(12px)",
+          transition: "all 0.3s ease",
+          position: "relative" as const,
+          overflow: "hidden",
+        }}
+      >
+        {isWinner && (
+          <div style={{
+            position: "absolute",
+            top: "10px",
+            right: "10px",
+            fontSize: "10px",
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            padding: "4px 10px",
+            borderRadius: "4px",
+            backgroundColor: `${config.color}30`,
+            color: config.color,
+            border: `1px solid ${config.color}50`,
+          }}>
+            WINNER
+          </div>
+        )}
+
+        {/* Header */}
+        <div style={{ display: "flex", alignItems: "center", gap: "14px", marginBottom: "16px" }}>
+          <PixelAgent seed={config.avatarSeed} color={config.color} size={64} state={state} />
+          <div>
+            <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "4px" }}>
+              <span style={{ fontSize: "14px", fontWeight: 700, color: "#ffffff" }}>{config.name}</span>
+              <span style={{
+                fontSize: "9px",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                padding: "2px 8px",
+                borderRadius: "4px",
+                backgroundColor: `${config.color}25`,
+                color: config.color,
+                border: `1px solid ${config.color}40`,
+                fontWeight: 600,
+              }}>
+                {config.role}
+              </span>
+            </div>
+            <div style={{ fontSize: "10px", color: "rgba(255,255,255,0.4)", fontFamily: "monospace" }}>
+              {config.wallet.slice(0, 4)}...{config.wallet.slice(-4)}
+            </div>
+            <div style={{ marginTop: "4px" }}>
+              <span style={{
+                fontSize: "9px",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                color: state === "idle" ? "rgba(255,255,255,0.3)" : config.color,
+                fontWeight: state === "idle" ? 400 : 600,
+              }}>
+                {state === "idle" ? (displayText ? "DONE" : "STANDBY") : state === "working" ? "WRITING..." : state.toUpperCase()}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Score */}
+        {score !== null && (
+          <div style={{
+            textAlign: "center",
+            padding: "12px",
+            marginBottom: "12px",
+            backgroundColor: `${config.color}15`,
+            borderRadius: "8px",
+            border: `1px solid ${config.color}30`,
+          }}>
+            <div style={{ fontSize: "32px", fontWeight: 700, color: config.color }}>{score}<span style={{ fontSize: "16px", color: "rgba(255,255,255,0.4)" }}>/10</span></div>
+          </div>
+        )}
+
+        {/* Stats row */}
+        {wordCount > 0 && (
+          <div style={{
+            display: "flex",
+            gap: "12px",
+            marginBottom: "12px",
+            fontSize: "10px",
+            color: "rgba(255,255,255,0.5)",
+          }}>
+            <div>
+              <span style={{ color: config.color, fontWeight: 600 }}>{wordCount}</span> words
+            </div>
+            {hash && (
+              <div style={{ fontFamily: "monospace" }}>
+                Hash: {hash}...
+              </div>
+            )}
+            {verified && (
+              <div style={{ color: "#42BDFF" }}>ZK Verified</div>
+            )}
+          </div>
+        )}
+
+        {/* Live text output with typewriter */}
+        <div style={{
+          maxHeight: "300px",
+          overflowY: "auto",
+          fontSize: "11px",
+          lineHeight: 1.6,
+          color: "rgba(255,255,255,0.75)",
+          backgroundColor: "rgba(0,0,0,0.3)",
+          borderRadius: "8px",
+          padding: "12px",
+          border: "1px solid rgba(255,255,255,0.06)",
+          minHeight: "80px",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+        }}>
+          {displayText ? (
+            <>
+              {displayText}
+              {isTyping && <span style={{ color: config.color, animation: "blink 1s step-end infinite" }}>{"\\u2588"}</span>}
+            </>
+          ) : (
+            <span style={{ color: "rgba(255,255,255,0.2)", fontStyle: "italic" }}>
+              {state === "working" ? "Writing..." : "Waiting for battle start..."}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      minHeight: "100vh",
+      backgroundColor: "#0a0a14",
+      backgroundImage: "url('/poster-bg.png')",
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+      backgroundAttachment: "fixed",
+      color: "#ffffff",
+    }}>
+      <style>{`
+        @keyframes blink { 0%, 50% { opacity: 1; } 51%, 100% { opacity: 0; } }
+        @keyframes pulse-glow {
+          0%, 100% { box-shadow: 0 0 20px rgba(66, 189, 255, 0.3), 0 0 40px rgba(255, 66, 94, 0.2); }
+          50% { box-shadow: 0 0 30px rgba(66, 189, 255, 0.5), 0 0 60px rgba(255, 66, 94, 0.4); }
+        }
+        @keyframes gradient-shift {
+          0% { background-position: 0% 50%; }
+          50% { background-position: 100% 50%; }
+          100% { background-position: 0% 50%; }
+        }
+        @keyframes judging-spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+      `}</style>
+
+      <NavBar activeTab="battle" variant="dark" />
+
+      <div style={{ maxWidth: "1200px", margin: "0 auto", padding: "32px 20px" }}>
+        {/* Title */}
+        <div style={{ textAlign: "center", marginBottom: "32px" }}>
+          <h1 style={{
+            fontSize: "36px",
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+            background: "linear-gradient(135deg, #42BDFF, #FF425E, #42BDFF)",
+            backgroundSize: "200% 200%",
+            animation: "gradient-shift 3s ease infinite",
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+            marginBottom: "8px",
+          }}>
+            AGENT BATTLE
+          </h1>
+          <p style={{ fontSize: "13px", color: "rgba(255,255,255,0.4)", letterSpacing: "0.03em" }}>
+            Two AI agents compete for the same job. Only one gets paid.
+          </p>
+          {battleTitle && (
+            <div style={{
+              marginTop: "12px",
+              fontSize: "14px",
+              color: "#FFE342",
+              fontWeight: 600,
+            }}>
+              Challenge: {battleTitle}
+            </div>
+          )}
+        </div>
+
+        {/* Start controls */}
+        {!running && !done && (
+          <div style={{ textAlign: "center", marginBottom: "32px" }}>
+            <div style={{ maxWidth: "500px", margin: "0 auto 16px auto" }}>
+              <input
+                type="text"
+                value={challenge}
+                onChange={(e) => setChallenge(e.target.value)}
+                placeholder="What should they compete on? (or leave blank for random)"
+                style={{
+                  width: "100%",
+                  padding: "12px 16px",
+                  fontSize: "13px",
+                  backgroundColor: "rgba(255,255,255,0.06)",
+                  border: "1px solid rgba(255,255,255,0.15)",
+                  borderRadius: "8px",
+                  color: "#ffffff",
+                  outline: "none",
+                  fontFamily: "inherit",
+                }}
+              />
+            </div>
+            <button
+              onClick={startBattle}
+              style={{
+                padding: "16px 48px",
+                fontSize: "16px",
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                background: "linear-gradient(135deg, #42BDFF, #FF425E)",
+                color: "#ffffff",
+                border: "none",
+                borderRadius: "12px",
+                cursor: "pointer",
+                animation: "pulse-glow 2s ease infinite",
+                fontFamily: "inherit",
+              }}
+            >
+              START BATTLE
+            </button>
+          </div>
+        )}
+
+        {done && (
+          <div style={{ textAlign: "center", marginBottom: "24px" }}>
+            <button
+              onClick={resetBattle}
+              style={{
+                padding: "12px 36px",
+                fontSize: "14px",
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                background: "linear-gradient(135deg, #42BDFF, #FF425E)",
+                color: "#ffffff",
+                border: "none",
+                borderRadius: "10px",
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              BATTLE AGAIN
+            </button>
+            {totalTime && (
+              <div style={{ marginTop: "8px", fontSize: "11px", color: "rgba(255,255,255,0.3)" }}>
+                Completed in {totalTime}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Split screen: Alpha vs Omega */}
+        <div style={{ display: "flex", gap: "16px", alignItems: "stretch", marginBottom: "24px" }}>
+          {/* Alpha panel */}
+          {renderAgentPanel(
+            ALPHA_CONFIG,
+            alphaState,
+            alphaDisplayText,
+            alphaWordCount,
+            alphaHash,
+            alphaVerified,
+            isAlphaTyping,
+            alphaScore,
+            winner === "alpha",
+          )}
+
+          {/* VS Badge */}
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}>
+            <div style={{
+              width: "48px",
+              height: "48px",
+              borderRadius: "50%",
+              background: "linear-gradient(135deg, #42BDFF, #FF425E)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "14px",
+              fontWeight: 700,
+              color: "#ffffff",
+              boxShadow: "0 0 20px rgba(66,189,255,0.3), 0 0 20px rgba(255,66,94,0.3)",
+            }}>
+              VS
+            </div>
+          </div>
+
+          {/* Omega panel */}
+          {renderAgentPanel(
+            OMEGA_CONFIG,
+            omegaState,
+            omegaDisplayText,
+            omegaWordCount,
+            omegaHash,
+            omegaVerified,
+            isOmegaTyping,
+            omegaScore,
+            winner === "omega",
+          )}
+        </div>
+
+        {/* Judging / Winner section */}
+        {judging && (
+          <div style={{
+            textAlign: "center",
+            padding: "32px",
+            marginBottom: "24px",
+            backgroundColor: "rgba(0,0,0,0.4)",
+            border: "1px solid rgba(255,255,255,0.12)",
+            borderRadius: "12px",
+            backdropFilter: "blur(12px)",
+          }}>
+            <div style={{
+              width: "40px",
+              height: "40px",
+              border: "3px solid rgba(255,227,66,0.3)",
+              borderTopColor: "#FFE342",
+              borderRadius: "50%",
+              animation: "judging-spin 1s linear infinite",
+              margin: "0 auto 16px auto",
+            }} />
+            <div style={{ fontSize: "18px", fontWeight: 700, color: "#FFE342", letterSpacing: "0.1em" }}>
+              JUDGING...
+            </div>
+            <div style={{ fontSize: "11px", color: "rgba(255,255,255,0.4)", marginTop: "8px" }}>
+              AI Judge is analyzing both submissions
+            </div>
+          </div>
+        )}
+
+        {winner && (
+          <div style={{
+            padding: "32px",
+            marginBottom: "24px",
+            backgroundColor: "rgba(0,0,0,0.5)",
+            border: `1px solid ${winner === "alpha" ? "#42BDFF" : "#FF425E"}40`,
+            borderRadius: "12px",
+            backdropFilter: "blur(12px)",
+            textAlign: "center",
+          }}>
+            <div style={{
+              fontSize: "28px",
+              fontWeight: 700,
+              color: winner === "alpha" ? "#42BDFF" : "#FF425E",
+              letterSpacing: "0.06em",
+              marginBottom: "12px",
+              textShadow: `0 0 20px ${winner === "alpha" ? "rgba(66,189,255,0.4)" : "rgba(255,66,94,0.4)"}`,
+            }}>
+              {winner === "alpha" ? "AGENT ALPHA" : "AGENT OMEGA"} WINS!
+            </div>
+
+            {/* Score cards */}
+            <div style={{ display: "flex", justifyContent: "center", gap: "32px", marginBottom: "20px" }}>
+              <div style={{
+                padding: "12px 24px",
+                borderRadius: "8px",
+                backgroundColor: winner === "alpha" ? "rgba(66,189,255,0.15)" : "rgba(66,189,255,0.05)",
+                border: `1px solid ${winner === "alpha" ? "#42BDFF50" : "rgba(255,255,255,0.1)"}`,
+              }}>
+                <div style={{ fontSize: "10px", color: "rgba(255,255,255,0.4)", marginBottom: "4px" }}>ALPHA</div>
+                <div style={{ fontSize: "24px", fontWeight: 700, color: "#42BDFF" }}>{alphaScore}<span style={{ fontSize: "12px" }}>/10</span></div>
+              </div>
+              <div style={{
+                padding: "12px 24px",
+                borderRadius: "8px",
+                backgroundColor: winner === "omega" ? "rgba(255,66,94,0.15)" : "rgba(255,66,94,0.05)",
+                border: `1px solid ${winner === "omega" ? "#FF425E50" : "rgba(255,255,255,0.1)"}`,
+              }}>
+                <div style={{ fontSize: "10px", color: "rgba(255,255,255,0.4)", marginBottom: "4px" }}>OMEGA</div>
+                <div style={{ fontSize: "24px", fontWeight: 700, color: "#FF425E" }}>{omegaScore}<span style={{ fontSize: "12px" }}>/10</span></div>
+              </div>
+            </div>
+
+            {/* Judge reasoning */}
+            {judgeReason && (
+              <div style={{
+                maxWidth: "600px",
+                margin: "0 auto 20px auto",
+                padding: "16px",
+                backgroundColor: "rgba(255,255,255,0.04)",
+                borderRadius: "8px",
+                borderLeft: "3px solid #FFE342",
+                fontSize: "12px",
+                color: "rgba(255,255,255,0.7)",
+                lineHeight: 1.6,
+                textAlign: "left",
+                fontStyle: "italic",
+              }}>
+                &ldquo;{judgeReason}&rdquo;
+              </div>
+            )}
+
+            {/* Payment */}
+            {paymentAmount > 0 && (
+              <div style={{
+                fontSize: "14px",
+                color: "#FFE342",
+                fontWeight: 600,
+              }}>
+                {paymentAmount} USDC &rarr; {winner === "alpha" ? "Agent Alpha" : "Agent Omega"}
+                {paymentTxHash && (
+                  <a
+                    href={`https://explorer.solana.com/tx/${paymentTxHash}?cluster=devnet`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: "rgba(255,255,255,0.3)", fontSize: "10px", marginLeft: "8px", textDecoration: "none" }}
+                  >
+                    [tx]
+                  </a>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Chat Panel */}
+        {chatMessages.length > 0 && (
+          <div style={{
+            backgroundColor: "rgba(0,0,0,0.4)",
+            border: "1px solid rgba(255,255,255,0.12)",
+            borderRadius: "12px",
+            padding: "16px",
+            backdropFilter: "blur(12px)",
+          }}>
+            <div style={{ fontSize: "11px", fontWeight: 600, color: "rgba(255,255,255,0.3)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: "12px" }}>
+              Battle Chat
+            </div>
+            <div ref={chatPanelRef} style={{ maxHeight: "200px", overflowY: "auto" }}>
+              {chatMessages.map((msg, i) => {
+                const isAlpha = msg.agent === "alpha";
+                const agentColor = isAlpha ? "#42BDFF" : "#FF425E";
+                const isLastTyping = i === chatMessages.length - 1 && msg.displayText.length < msg.message.length;
+                return (
+                  <div key={i} style={{ display: "flex", gap: "8px", marginBottom: "8px", alignItems: "flex-start" }}>
+                    <span style={{
+                      fontSize: "9px",
+                      fontWeight: 700,
+                      color: agentColor,
+                      textTransform: "uppercase",
+                      flexShrink: 0,
+                      width: "50px",
+                      paddingTop: "2px",
+                    }}>
+                      {isAlpha ? "Alpha" : "Omega"}
+                    </span>
+                    <span style={{
+                      fontSize: "11px",
+                      color: "rgba(255,255,255,0.75)",
+                      lineHeight: 1.5,
+                    }}>
+                      {msg.displayText || msg.message}
+                      {isLastTyping && <span style={{ color: agentColor, animation: "blink 1s step-end infinite" }}>{"\u2588"}</span>}
+                    </span>
+                    <span style={{
+                      fontSize: "9px",
+                      color: "rgba(255,255,255,0.2)",
+                      flexShrink: 0,
+                      marginLeft: "auto",
+                    }}>
+                      {msg.timestamp}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -10,7 +10,7 @@ import UserAvatar from "./UserAvatar";
 import NotificationBell from "./NotificationBell";
 import ThemeToggle from "./ThemeToggle";
 
-type Tab = "home" | "agents" | "poster" | "taker" | "dashboard" | "arena" | "leaderboard" | "proof" | "architecture" | "events" | "admin" | "onchain" | "disputes" | "faucet" | "api-docs" | "protocol" | "verify" | "developers" | "integrate";
+type Tab = "home" | "agents" | "poster" | "taker" | "dashboard" | "battle" | "arena" | "autonomous" | "leaderboard" | "proof" | "architecture" | "events" | "admin" | "onchain" | "disputes" | "faucet" | "api-docs" | "protocol" | "verify" | "developers" | "integrate";
 
 interface NavBarProps {
   activeTab: Tab;
@@ -23,10 +23,12 @@ const PRIMARY_TABS: { id: Tab; label: string; href: string }[] = [
   { id: "poster", label: "Post a Job", href: "/poster" },
   { id: "taker", label: "Find Work", href: "/taker" },
   { id: "dashboard", label: "Dashboard", href: "/dashboard" },
+  { id: "battle", label: "Battle", href: "/battle" },
   { id: "arena", label: "Arena", href: "/arena" },
 ];
 
 const MORE_TABS: { id: Tab; label: string; href: string }[] = [
+  { id: "autonomous", label: "Auto", href: "/autonomous" },
   { id: "verify", label: "Verify", href: "/verify" },
   { id: "developers", label: "Developers", href: "/developers" },
   { id: "integrate", label: "Integrate", href: "/integrate" },
@@ -69,9 +71,10 @@ export default function NavBar({ activeTab, variant = "light" }: NavBarProps) {
 
   const tabStyle = (tab: Tab): React.CSSProperties => {
     const isArena = tab === "arena";
+    const isBattle = tab === "battle";
     const isActive = activeTab === tab;
 
-    if (isArena) {
+    if (isArena || isBattle) {
       return {
         fontFamily: "inherit",
         fontSize: "11px",


### PR DESCRIPTION
## THE CRAZY FEATURES

### Agent Battle (/battle)
Two AI agents compete for the same job. Both generate content in parallel. 
An AI judge scores them. Winner gets paid, loser gets jobsFailed++.
- Split-screen with typewriter effect on both outputs
- Real Haiku API calls (parallel) + AI judge
- Real Solana devnet transactions
- Trash talk chat between agents (real Haiku dialogue)
- Confetti on winner announcement

### Autonomous Agent Loop (/autonomous)
Release an AI agent. It finds work, completes jobs, earns USDC — all on its own.
- Configurable rounds (1-10)
- Auto-scans open jobs, accepts, generates, submits, gets paid
- Live running timer + cumulative earnings counter
- Terminal log with round separators

### Live AI Chat (Arena enhancement)
Arena chat messages are now REAL Haiku API calls, not static strings.
- 4 real AI-generated chat messages per round
- Typewriter effect (20ms per character + blinking cursor)
- Each agent has its own personality in prompts