### PR TITLE
fix(admin): close fail-open auth in /api/admin (C-03)

### DIFF
--- a/app/app/api/admin/route.ts
+++ b/app/app/api/admin/route.ts
@@ -5,11 +5,14 @@ export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
   const ADMIN_SECRET = process.env.ADMIN_SECRET || process.env.CRON_SECRET;
-  if (ADMIN_SECRET) {
-    const auth = req.headers.get("authorization");
-    if (auth !== `Bearer ${ADMIN_SECRET}`) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  if (!ADMIN_SECRET) {
+    console.error(
+      "[admin] ADMIN_SECRET/CRON_SECRET unset; admin endpoint will refuse all requests"
+    );
+  }
+  const auth = req.headers.get("authorization");
+  if (!ADMIN_SECRET || auth !== `Bearer ${ADMIN_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {


### PR DESCRIPTION
Closes #16

## Summary

Fixes critical audit finding **C-03**: `/api/admin` fails open when `ADMIN_SECRET`/`CRON_SECRET` is unset, silently bypassing the bearer check and exposing the full database (jobs, profiles, reputations, submissions).

## Before

```ts
const ADMIN_SECRET = process.env.ADMIN_SECRET || process.env.CRON_SECRET;
if (ADMIN_SECRET) {
  const auth = req.headers.get("authorization");
  if (auth !== `Bearer ${ADMIN_SECRET}`) {
    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
  }
}
// falls through to returning ALL DB contents if ADMIN_SECRET is undefined
```

If neither env var was set, the `if (ADMIN_SECRET)` block was skipped entirely and the endpoint returned the full DB to any unauthenticated caller.

## After

```ts
const ADMIN_SECRET = process.env.ADMIN_SECRET || process.env.CRON_SECRET;
if (!ADMIN_SECRET) {
  console.error(
    "[admin] ADMIN_SECRET/CRON_SECRET unset; admin endpoint will refuse all requests"
  );
}
const auth = req.headers.get("authorization");
if (!ADMIN_SECRET || auth !== `Bearer ${ADMIN_SECRET}`) {
  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
}
```

Now fail-closed: if the secret is missing OR the header doesn't match, return 401. A one-time `console.error` surfaces misconfigured deploys in logs.

## Test plan

Manual verification with `curl`:

- [ ] **Secret unset, no auth header** → `401 Unauthorized` (was: 200 + full DB)
  ```bash
  unset ADMIN_SECRET CRON_SECRET
  curl -i http://localhost:3000/api/admin
  ```
- [ ] **Secret unset, auth header present** → `401 Unauthorized`
  ```bash
  curl -i -H "Authorization: Bearer anything" http://localhost:3000/api/admin
  ```
- [ ] **Secret set, no auth header** → `401 Unauthorized`
  ```bash
  ADMIN_SECRET=test curl -i http://localhost:3000/api/admin
  ```
- [ ] **Secret set, wrong bearer** → `401 Unauthorized`
  ```bash
  curl -i -H "Authorization: Bearer wrong" http://localhost:3000/api/admin
  ```
- [ ] **Secret set, correct bearer** → `200` + data
  ```bash
  curl -i -H "Authorization: Bearer $ADMIN_SECRET" http://localhost:3000/api/admin
  ```
- [ ] Verify `[admin] ADMIN_SECRET/CRON_SECRET unset...` log line appears when env is missing.

Negative-path automated tests will follow in a separate PR.