### PR TITLE
fix(anchor): constrain raise_dispute bond mint to job_escrow.token_mint (H-01)

### DIFF
--- a/programs/covenant/src/instructions/raise_dispute.rs
+++ b/programs/covenant/src/instructions/raise_dispute.rs
@@ -41,6 +41,9 @@ pub struct RaiseDispute<'info> {
     )]
     pub poster_token_account: Box<Account<'info, TokenAccount>>,
 
+    #[account(
+        constraint = token_mint.key() == job_escrow.token_mint @ CovError::MintMismatch,
+    )]
     pub token_mint: Box<Account<'info, Mint>>,
     pub token_program: Program<'info, Token>,
     pub system_program: Program<'info, System>,


### PR DESCRIPTION
Closes #18

## Summary
Fixes audit finding **H-01** (HIGH severity). The `raise_dispute` instruction accepted any `Mint` account passed by the poster, with no binding to the job's escrow mint.

### Impact (before fix)
1. **DoS of resolve_dispute.** If the bond mint differs from the escrow mint, `resolve_dispute` later fails on the bond → taker/poster transfer due to mint mismatch, leaving the escrow locked.
2. **Economic bypass of min_bond.** A worthless token's atomic units trivially satisfy the `bond >= min_bond` check, since `min_bond` is denominated in the escrow's mint's atomic units but `bond` was validated against an arbitrary mint.

## Before / After

**Before** (`programs/covenant/src/instructions/raise_dispute.rs:44`):
```rust
    pub token_mint: Box<Account<'info, Mint>>,
```

**After**:
```rust
    #[account(
        constraint = token_mint.key() == job_escrow.token_mint @ CovError::MintMismatch,
    )]
    pub token_mint: Box<Account<'info, Mint>>,
```

`CovError::MintMismatch` already exists in `programs/covenant/src/errors.rs`.

## Test plan
- [ ] Negative test (bond mint ≠ escrow mint rejected with `MintMismatch`) to be added in a separate PR.
- [ ] Existing positive path (matching mint) remains unaffected — constraint is satisfied when `token_mint == job_escrow.token_mint`.
- [ ] No other files touched; `resolve_dispute.rs` and tests are out of scope for this PR.