### PR TITLE
fix(api): require wallet signature on /api/keys (H-03)

### DIFF
--- a/app/app/api/keys/route.ts
+++ b/app/app/api/keys/route.ts
@@ -1,11 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { verifyWalletSignature } from "@/lib/wallet-auth";
 import crypto from "crypto";
 
 export async function GET(req: NextRequest) {
   const wallet = req.nextUrl.searchParams.get("wallet");
+  const signature = req.nextUrl.searchParams.get("signature");
+  const message = req.nextUrl.searchParams.get("message");
+  const ts = req.nextUrl.searchParams.get("ts");
+
   if (!wallet) {
     return NextResponse.json({ error: "wallet is required" }, { status: 400 });
+  }
+  if (!signature || !message || ts === null) {
+    return NextResponse.json(
+      { error: "signature, message, and ts are required" },
+      { status: 400 }
+    );
+  }
+
+  const expectedMessage = `cvn:keys:list:${wallet}:${ts}`;
+  const verified = verifyWalletSignature({
+    wallet,
+    signature,
+    message,
+    expectedMessage,
+    ts,
+  });
+  if (!verified.ok) {
+    return NextResponse.json({ error: verified.reason }, { status: 401 });
   }
 
   try {
@@ -26,13 +49,31 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { wallet, name } = body;
+    const { wallet, name, signature, message, ts } = body;
 
     if (!wallet) {
       return NextResponse.json(
         { error: "wallet is required" },
         { status: 400 }
       );
+    }
+    if (!signature || !message || ts === undefined || ts === null) {
+      return NextResponse.json(
+        { error: "signature, message, and ts are required" },
+        { status: 400 }
+      );
+    }
+
+    const expectedMessage = `cvn:keys:create:${wallet}:${ts}`;
+    const verified = verifyWalletSignature({
+      wallet,
+      signature,
+      message,
+      expectedMessage,
+      ts,
+    });
+    if (!verified.ok) {
+      return NextResponse.json({ error: verified.reason }, { status: 401 });
     }
 
     // Generate a random 32-char hex key prefixed with "cvn_"

--- a/app/lib/wallet-auth.ts
+++ b/app/lib/wallet-auth.ts
@@ -1,0 +1,115 @@
+import bs58 from "bs58";
+import nacl from "tweetnacl";
+
+/**
+ * Maximum clock skew between client and server for a signed request to be
+ * considered fresh, in milliseconds. Requests with a `ts` older (or further
+ * in the future) than this are rejected as stale/replayed.
+ */
+const MAX_TIMESTAMP_SKEW_MS = 5 * 60_000;
+
+export type VerifyWalletSignatureArgs = {
+  wallet: string;
+  signature: string;
+  message: string;
+  expectedMessage: string;
+  ts: number | string;
+};
+
+export type VerifyWalletSignatureResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Verify that `signature` is a valid Ed25519 signature of `message` produced
+ * by the private key corresponding to the Solana `wallet` public key, and
+ * that the request is fresh (`ts` within MAX_TIMESTAMP_SKEW_MS of now) and
+ * the client-supplied `message` matches the server-computed `expectedMessage`
+ * verbatim.
+ *
+ * Pure function — no Next.js / framework dependencies. Safe to import from
+ * any server-side module.
+ */
+export function verifyWalletSignature(
+  args: VerifyWalletSignatureArgs
+): VerifyWalletSignatureResult {
+  const { wallet, signature, message, expectedMessage, ts } = args;
+
+  if (!wallet || typeof wallet !== "string") {
+    return { ok: false, reason: "missing wallet" };
+  }
+  if (!signature || typeof signature !== "string") {
+    return { ok: false, reason: "missing signature" };
+  }
+  if (!message || typeof message !== "string") {
+    return { ok: false, reason: "missing message" };
+  }
+  if (ts === undefined || ts === null || ts === "") {
+    return { ok: false, reason: "missing ts" };
+  }
+
+  // Normalize ts: accept unix ms (number or numeric string) or ISO string.
+  let tsMs: number;
+  if (typeof ts === "number") {
+    tsMs = ts;
+  } else {
+    const asNum = Number(ts);
+    if (Number.isFinite(asNum) && asNum > 0) {
+      tsMs = asNum;
+    } else {
+      const parsed = Date.parse(ts);
+      if (Number.isNaN(parsed)) {
+        return { ok: false, reason: "invalid ts" };
+      }
+      tsMs = parsed;
+    }
+  }
+  if (!Number.isFinite(tsMs)) {
+    return { ok: false, reason: "invalid ts" };
+  }
+
+  if (Math.abs(Date.now() - tsMs) > MAX_TIMESTAMP_SKEW_MS) {
+    return { ok: false, reason: "stale request" };
+  }
+
+  // Canonical message must match byte-for-byte.
+  if (message !== expectedMessage) {
+    return { ok: false, reason: "message mismatch" };
+  }
+
+  // Decode signature (base58) and public key (base58).
+  let signatureBytes: Uint8Array;
+  let pubkeyBytes: Uint8Array;
+  try {
+    signatureBytes = bs58.decode(signature);
+  } catch {
+    return { ok: false, reason: "invalid signature encoding" };
+  }
+  try {
+    pubkeyBytes = bs58.decode(wallet);
+  } catch {
+    return { ok: false, reason: "invalid wallet encoding" };
+  }
+
+  if (signatureBytes.length !== 64) {
+    return { ok: false, reason: "invalid signature length" };
+  }
+  if (pubkeyBytes.length !== 32) {
+    return { ok: false, reason: "invalid wallet length" };
+  }
+
+  const messageBytes = new TextEncoder().encode(message);
+
+  let ok: boolean;
+  try {
+    ok = nacl.sign.detached.verify(messageBytes, signatureBytes, pubkeyBytes);
+  } catch {
+    return { ok: false, reason: "verify failed" };
+  }
+
+  if (!ok) {
+    return { ok: false, reason: "invalid signature" };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
Closes #20

## Summary

Both `GET /api/keys` and `POST /api/keys` previously accepted any `wallet`
value with zero authentication, allowing anyone to list or mint API keys
under arbitrary wallets (audit finding **H-03**).

This PR gates both handlers on a fresh Ed25519 signature proving control
of the wallet.

### Canonical message format

The client signs one of:

- `cvn:keys:list:${wallet}:${ts}`   — for `GET`
- `cvn:keys:create:${wallet}:${ts}` — for `POST`

…where `ts` is a unix-ms timestamp (or ISO string). The server:

1. Rejects if `|now - ts| > 5 min` (stale / replayed).
2. Rejects if the client-supplied `message` does not byte-exactly equal
   the server-computed canonical string.
3. Base58-decodes `signature` (must be 64 bytes) and `wallet` (must be
   32 bytes).
4. Verifies with `tweetnacl.sign.detached.verify`.
5. Any failure returns HTTP **401** with `{ error: <reason> }`.

### Transport

- **GET** — `signature`, `message`, `ts` are passed as query params alongside `wallet`.
- **POST** — `signature`, `message`, `ts` are included in the JSON body alongside `wallet` and `name`.

### Code layout

- New pure helper `app/lib/wallet-auth.ts` exporting
  `verifyWalletSignature(args)`. No Next.js dependency — only `bs58` and
  `tweetnacl` (both already in `package.json`). This is the foundation
  referenced by #15 (C-02) for cross-cutting API auth and can be reused
  on other routes.
- `app/app/api/keys/route.ts` calls the helper in both handlers and
  returns 401 on failure.

## Test plan

- [ ] Generate an Ed25519 keypair; derive base58 wallet address.
- [ ] `ts=$(node -e 'console.log(Date.now())')`, sign `cvn:keys:create:<wallet>:<ts>`, base58-encode the 64-byte signature.
- [ ] `curl -X POST http://localhost:3000/api/keys -H 'content-type: application/json' -d '{"wallet":"<wallet>","name":"test","message":"cvn:keys:create:<wallet>:<ts>","signature":"<b58sig>","ts":<ts>}'` → **200** with new key.
- [ ] Same request with a tampered `wallet` (keeping signature) → **401** `invalid signature`.
- [ ] Same request with `ts` 10 minutes in the past → **401** `stale request`.
- [ ] `curl "http://localhost:3000/api/keys?wallet=<wallet>&message=cvn:keys:list:<wallet>:<ts>&signature=<b58sig>&ts=<ts>"` after signing the list message → **200** with keys array.
- [ ] `curl "http://localhost:3000/api/keys?wallet=<wallet>"` (no sig) → **400** `signature, message, and ts are required`.
- [ ] `curl -X POST .../api/keys -d '{"wallet":"<other-wallet>","name":"x"}'` (no sig) → **400**.