### PR TITLE
fix: sync program ID across lib.rs / .env.example (M-01)

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -40,6 +40,6 @@ FAL_KEY=
 
 # === OPTIONAL ===
 # Override the on-chain program ID.
-COVENANT_PROGRAM_ID=AJAJPkC8oRsVaSYgVh36TKbMKZtzn8kKHcQXwZEn2vrQ
+COVENANT_PROGRAM_ID=5hstj5grBUL1BeSaPLYpgkD6n3ALasmbseRvKRFfCVNT
 # How many recent signatures /api/cron/reconcile scans per run.
 RECONCILE_SCAN_LIMIT=500

--- a/programs/covenant/src/lib.rs
+++ b/programs/covenant/src/lib.rs
@@ -18,7 +18,7 @@ pub mod state;
 use instructions::*;
 use state::{ARBITRATOR_COUNT, DisputeResolution};
 
-declare_id!("AJAJPkC8oRsVaSYgVh36TKbMKZtzn8kKHcQXwZEn2vrQ");
+declare_id!("5hstj5grBUL1BeSaPLYpgkD6n3ALasmbseRvKRFfCVNT");
 
 #[program]
 pub mod covenant {


### PR DESCRIPTION
## Summary

Audit finding **M-01**: three sources disagreed on the Solana program ID.

| Source | Value (before) |
|---|---|
| `Anchor.toml` | `5hstj5grBUL1BeSaPLYpgkD6n3ALasmbseRvKRFfCVNT` |
| `README.md` (Live table) | `5hstj5…` |
| `app/lib/constants.ts` | `5hstj5…` |
| `app/lib/covenant-idl.json` | `5hstj5…` |
| `programs/covenant/src/lib.rs` | **`AJAJPkC8oRsVaSYgVh36TKbMKZtzn8kKHcQXwZEn2vrQ`** |
| `app/.env.example` | **`AJAJPk…`** |

This PR canonicalizes on `5hstj5grBUL1BeSaPLYpgkD6n3ALasmbseRvKRFfCVNT` — the value already used by `Anchor.toml`, the README, the app constants, and the IDL — by updating the two stragglers (`programs/covenant/src/lib.rs` and `app/.env.example`).

Diff is 2 lines across 2 files. No build, no test, no other touches.

## ⚠️ Redeploy implication — please read before merging

`declare_id!` in the Rust program is the compiled-in program ID. Changing it rebuilds the program targeting a **different** address.

- If any maintainer has already deployed the program under the old ID `AJAJPkC8oRsVaSYgVh36TKbMKZtzn8kKHcQXwZEn2vrQ` and is relying on that deployment, this change will break their local/devnet workflow until they either:
  1. Redeploy the program to the canonical `5hstj5…` address (matching `Anchor.toml` + the README), **or**
  2. Revert this commit locally and keep their existing deployment.
- The audit (docs/AUDIT.md) flagged this as **Medium** specifically because of the deploy-time confusion it creates — the README and `Anchor.toml` already advertise `5hstj5…`, so anyone following published docs was already out of sync with the on-chain bytes that `lib.rs` was producing.
- **This commit does not itself redeploy.** It only aligns the source-of-truth declarations. Redeployment to `5hstj5…` is left to the maintainers.

Please confirm the intended canonical address before merging. If the team instead wants to canonicalize on `AJAJPk…` (the previous `lib.rs` value), close this PR and open a counter-PR updating `Anchor.toml`, `README.md`, `app/lib/constants.ts`, and `app/lib/covenant-idl.json` the other direction.

## Test plan

- [ ] Confirm with maintainers which address is actually deployed on devnet
- [ ] If `5hstj5…` is the live deployment: merge as-is, no further action needed
- [ ] If `AJAJPk…` is the live deployment: do **not** merge — redeploy to `5hstj5…` first, or reverse the direction of this PR
- [ ] `grep -rn "AJAJPk" .` returns zero hits post-merge (verified in this branch)
- [ ] `anchor build` succeeds with the new ID (not run in this PR — minimal diff only)