### PR TITLE
fix: battle prediction & win banner show custom agent names

### DIFF
--- a/app/app/battle/page.tsx
+++ b/app/app/battle/page.tsx
@@ -2215,7 +2215,7 @@ export default function BattlePage() {
                       letterSpacing: "0.08em",
                     }}
                   >
-                    AGENT ALPHA
+                    {useCustomAgents && selectedAlpha ? selectedAlpha.name : ALPHA_CONFIG.name}
                   </button>
                   <button
                     className="prediction-btn"
@@ -2250,7 +2250,7 @@ export default function BattlePage() {
                       letterSpacing: "0.08em",
                     }}
                   >
-                    AGENT OMEGA
+                    {useCustomAgents && selectedOmega ? selectedOmega.name : OMEGA_CONFIG.name}
                   </button>
                 </div>
               ) : (
@@ -2258,7 +2258,9 @@ export default function BattlePage() {
                   <div style={{ fontSize: "13px", color: "rgba(255,255,255,0.5)", marginBottom: "12px" }}>
                     You picked{" "}
                     <span style={{ color: userPrediction === "alpha" ? ALPHA_COLOR : OMEGA_COLOR, fontWeight: 700 }}>
-                      {userPrediction === "alpha" ? "AGENT ALPHA" : "AGENT OMEGA"}
+                      {userPrediction === "alpha"
+                        ? (useCustomAgents && selectedAlpha ? selectedAlpha.name : ALPHA_CONFIG.name)
+                        : (useCustomAgents && selectedOmega ? selectedOmega.name : OMEGA_CONFIG.name)}
                     </span>
                   </div>
                 </div>
@@ -2697,7 +2699,9 @@ export default function BattlePage() {
                 marginBottom: "8px",
               }}
             >
-              {winner === "alpha" ? "AGENT ALPHA" : "AGENT OMEGA"} WINS!
+              {winner === "alpha"
+                ? (useCustomAgents && selectedAlpha ? selectedAlpha.name : ALPHA_CONFIG.name)
+                : (useCustomAgents && selectedOmega ? selectedOmega.name : OMEGA_CONFIG.name)} WINS!
             </div>
 
             {/* Score display */}


### PR DESCRIPTION
## Sorun

Custom agent seçilerek battle yapıldığında "WHO WILL WIN?" tahmin bölümündeki butonlar ve "You picked ..." metni hâlâ \`AGENT ALPHA\` / \`AGENT OMEGA\` gösteriyordu. Sonuç ekranındaki büyük "WINS!" başlığı da aynı hatayı yapıyordu.

Önceki fix (678826d) sadece fighting/results-card fazını kapsamış, bu üç noktayı atlamıştı.

## Değişiklik

\`app/app/battle/page.tsx\` üç yer:

1. Prediction butonu — Alpha label
2. Prediction butonu — Omega label
3. "You picked ..." ifadesindeki agent adı
4. Win banner ("AGENT X WINS!")

Hepsi sayfanın geri kalanıyla aynı kalıba çevrildi:
\`useCustomAgents && selectedAlpha ? selectedAlpha.name : ALPHA_CONFIG.name\`

## Test plan

- [ ] Custom agents seçerek battle başlat → "WHO WILL WIN?" butonlarında ve win banner'ında seçtiğin agent adlarını gör
- [ ] Default Alpha/Omega ile battle başlat → "AGENT ALPHA" / "AGENT OMEGA" görünmeli (regression yok)
- [ ] Tahmin yap → "You picked AGENT X" custom agent adını göstermeli

## Notlar

Backend (\`/api/battle/predict\`) zaten "alpha"/"omega" sembolik etiketler kullanıyor — orada değişiklik yok. Sadece display katmanı.

Diff: 4 satır eklendi, 2 satır silindi (1 dosya).