### PR TITLE
test: enable H-01 negative test (constraint landed in #25)

### DIFF
--- a/tests/covenant.ts
+++ b/tests/covenant.ts
@@ -816,13 +816,10 @@ describe("covenant — negative paths (M-06)", () => {
   });
 
   /**
-   * H-01: raise_dispute should reject a bond_token_account whose mint
-   * differs from job_escrow.token_mint.
-   *
-   * SKIP until the constraint lands (#18). Once added, switch `it.skip`
-   * to `it` — the test is wired to actually exercise the bug.
+   * H-01: raise_dispute rejects a bond_token_account whose mint differs
+   * from job_escrow.token_mint. Constraint landed in #25.
    */
-  it.skip("rejects raise_dispute with bond mint != escrow mint (H-01)", async () => {
+  it("rejects raise_dispute with bond mint != escrow mint (H-01)", async () => {
     const { specHash, jobPda } = await freshJob(0x15, 10_000_000);
 
     await program.methods


### PR DESCRIPTION
## Summary

#31 added a bond-mint-mismatch negative test for raise_dispute, but kept it as \`it.skip\` because the constraint hadn't merged yet. #25 landed the constraint, so the test should now run.

## Change

One-line flip + comment update in \`tests/covenant.ts\`:
- \`it.skip(...)\` → \`it(...)\`
- Stale "SKIP until..." note removed; replaced with a one-liner referencing #25

## Test plan

- [ ] \`anchor test\` against localnet
- [ ] Confirm the H-01 test now actually runs and passes (rejects with \`MintMismatch\`)
- [ ] Confirm no other tests regressed