### PR TITLE
fix(admin): add password login to /admin page (C-03 follow-up)

### DIFF
--- a/app/app/admin/page.tsx
+++ b/app/app/admin/page.tsx
@@ -129,18 +129,51 @@ function formatDate(dateStr: string): string {
   });
 }
 
+const SECRET_STORAGE_KEY = "covenant.admin.secret";
+
 export default function AdminPage() {
   const [activeTab, setActiveTab] = useState<TabKey>("jobs");
   const [data, setData] = useState<AdminData | null>(null);
   const [transactions, setTransactions] = useState<TransactionRow[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // Bearer secret used to authenticate against /api/admin (which is now
+  // fail-closed per audit C-03). Persisted in sessionStorage so the page
+  // doesn't re-prompt on every reload within the same tab.
+  const [secret, setSecret] = useState<string | null>(null);
+  const [secretInput, setSecretInput] = useState("");
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authChecking, setAuthChecking] = useState(false);
+
+  // Load any previously stored secret on mount.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.sessionStorage.getItem(SECRET_STORAGE_KEY);
+    if (stored) setSecret(stored);
+  }, []);
+
   const fetchData = useCallback(async () => {
+    if (!secret) {
+      // No secret yet — don't poll, don't churn. The login form below
+      // will trigger fetchData once the user submits.
+      setLoading(false);
+      return;
+    }
     try {
+      const headers = { Authorization: `Bearer ${secret}` };
       const [adminRes, txRes] = await Promise.all([
-        fetch("/api/admin"),
+        fetch("/api/admin", { headers }),
         fetch("/api/transactions"),
       ]);
+      if (adminRes.status === 401) {
+        // Stored secret no longer works — drop it and force re-login.
+        if (typeof window !== "undefined") {
+          window.sessionStorage.removeItem(SECRET_STORAGE_KEY);
+        }
+        setSecret(null);
+        setAuthError("Stored admin secret was rejected. Please re-enter.");
+        return;
+      }
       if (adminRes.ok) {
         const json = await adminRes.json();
         setData(json);
@@ -154,13 +187,57 @@ export default function AdminPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [secret]);
 
   useEffect(() => {
     fetchData();
+    if (!secret) return; // don't poll while logged out
     const interval = setInterval(fetchData, 10000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, secret]);
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    if (!secretInput.trim()) return;
+    setAuthChecking(true);
+    setAuthError(null);
+    try {
+      const res = await fetch("/api/admin", {
+        headers: { Authorization: `Bearer ${secretInput.trim()}` },
+      });
+      if (res.status === 401) {
+        setAuthError("Invalid secret. Try again.");
+        setAuthChecking(false);
+        return;
+      }
+      if (!res.ok) {
+        setAuthError(`Server error (${res.status}). Try again.`);
+        setAuthChecking(false);
+        return;
+      }
+      // Success — persist and let the effect re-fetch.
+      const trimmed = secretInput.trim();
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem(SECRET_STORAGE_KEY, trimmed);
+      }
+      setSecret(trimmed);
+      setSecretInput("");
+      setAuthChecking(false);
+    } catch {
+      setAuthError("Network error. Try again.");
+      setAuthChecking(false);
+    }
+  }
+
+  function handleLogout() {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem(SECRET_STORAGE_KEY);
+    }
+    setSecret(null);
+    setData(null);
+    setTransactions([]);
+    setAuthError(null);
+  }
 
   const cellStyle: React.CSSProperties = {
     padding: "8px 12px",
@@ -524,13 +601,115 @@ export default function AdminPage() {
       <div style={{ position: "relative", zIndex: 2 }}>
         <NavBar activeTab="admin" variant="dark" />
 
+        {/* Login form (shown only when not authenticated) */}
+        {!secret && (
+          <div style={{ padding: "48px 24px", display: "flex", justifyContent: "center" }}>
+            <form
+              onSubmit={handleLogin}
+              style={{
+                width: "100%",
+                maxWidth: "420px",
+                backgroundColor: "rgba(255,255,255,0.07)",
+                backdropFilter: "blur(16px)",
+                border: "1px solid rgba(255,255,255,0.15)",
+                borderRadius: "10px",
+                padding: "32px",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: "13px",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "rgba(255,255,255,0.6)",
+                  marginBottom: "8px",
+                  fontWeight: 700,
+                }}
+              >
+                Admin login
+              </div>
+              <div
+                style={{
+                  fontSize: "12px",
+                  color: "rgba(255,255,255,0.4)",
+                  marginBottom: "20px",
+                  lineHeight: 1.5,
+                }}
+              >
+                Enter the ADMIN_SECRET (or CRON_SECRET fallback) to view
+                jobs, profiles, reputations, and submissions.
+              </div>
+              <input
+                type="password"
+                autoFocus
+                value={secretInput}
+                onChange={(e) => setSecretInput(e.target.value)}
+                placeholder="Admin secret"
+                style={{
+                  width: "100%",
+                  padding: "12px 14px",
+                  fontFamily: "inherit",
+                  fontSize: "13px",
+                  color: "#ffffff",
+                  backgroundColor: "rgba(0,0,0,0.3)",
+                  border: "1px solid rgba(255,255,255,0.15)",
+                  borderRadius: "6px",
+                  outline: "none",
+                  marginBottom: "12px",
+                  boxSizing: "border-box",
+                }}
+              />
+              {authError && (
+                <div
+                  style={{
+                    fontSize: "12px",
+                    color: "#fca5a5",
+                    marginBottom: "12px",
+                  }}
+                >
+                  {authError}
+                </div>
+              )}
+              <button
+                type="submit"
+                disabled={authChecking || !secretInput.trim()}
+                style={{
+                  width: "100%",
+                  padding: "12px",
+                  fontFamily: "inherit",
+                  fontSize: "12px",
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "#000000",
+                  backgroundColor:
+                    authChecking || !secretInput.trim()
+                      ? "rgba(255,254,178,0.4)"
+                      : "#fffeb2",
+                  border: "none",
+                  borderRadius: "6px",
+                  cursor:
+                    authChecking || !secretInput.trim()
+                      ? "not-allowed"
+                      : "pointer",
+                  transition: "all 0.15s ease",
+                }}
+              >
+                {authChecking ? "Checking…" : "Sign in"}
+              </button>
+            </form>
+          </div>
+        )}
+
         {/* Tabs */}
+        {secret && (
         <div
           style={{
             display: "flex",
             gap: "0",
             borderBottom: "1px solid rgba(255,255,255,0.1)",
             padding: "0 24px",
+            alignItems: "center",
           }}
         >
           {TABS.map((tab) => (
@@ -558,9 +737,31 @@ export default function AdminPage() {
               {tab.label}
             </button>
           ))}
+          <button
+            onClick={handleLogout}
+            style={{
+              marginLeft: "auto",
+              fontFamily: "inherit",
+              fontSize: "10px",
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              padding: "6px 12px",
+              cursor: "pointer",
+              border: "1px solid rgba(255,255,255,0.2)",
+              borderRadius: "4px",
+              backgroundColor: "transparent",
+              color: "rgba(255,255,255,0.6)",
+              transition: "all 0.15s ease",
+            }}
+            title="Forget admin secret in this tab"
+          >
+            Logout
+          </button>
         </div>
+        )}
 
         {/* Table content */}
+        {secret && (
         <div style={{ padding: "24px" }}>
           <div
             style={{
@@ -607,6 +808,7 @@ export default function AdminPage() {
             </div>
           )}
         </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Sorun

C-03 fix \`/api/admin\` endpoint'ini fail-closed yaptıktan sonra \`/admin\` sayfasında **jobs / profiles / reputations / submissions** tab'ları boş görünmeye başladı. Sebep: frontend hâlâ \`fetch(\"/api/admin\")\` çağrısını **header'sız** atıyordu → 401 → \`adminRes.ok === false\` → \`setData\` çağrılmıyor.

\`/api/transactions\` ise hiç auth gerektirmiyor, o yüzden o tab dolu kalıp regression'u "kısmi" gösteriyordu.

## Çözüm

\`app/app/admin/page.tsx\`'e sessionStorage tabanlı bir login akışı eklendi:

1. **Mount**: önceki sessionStorage secret'ı yüklenir
2. **Yoksa**: ortada bir "Admin login" formu render edilir (password input + Sign in)
3. **Submit**: \`/api/admin\`'e bir kez \`Authorization: Bearer <input>\` ile istek atılır
   - 200 → secret sessionStorage'a yazılır, sayfa yenilenir
   - 401 → "Invalid secret" hatası gösterilir
4. **Polling**: 10 sn'lik fetch döngüsü artık header gönderir
5. **Rotated env**: sunucu 401 dönerse stored secret silinir, login tekrar açılır
6. **Logout**: tab bar'da küçük "Logout" butonu — sessionStorage'ı temizler

## Güvenlik notları

- Secret yalnızca tarayıcı sekmesinde tutulur (\`sessionStorage\`, tab kapanınca silinir)
- localStorage/cookie kullanılmıyor — XSS yüzeyi minimum
- Hiçbir secret repo'ya / env'e gömülmüyor — kullanıcı her sekmede bir kez girer
- Doğru çözüm wallet-based auth (#15 / C-02) — bu PR onun yerine geçici bir UX patch'i

## Test plan

- [ ] \`/admin\` sayfasını aç → login formu görmeli
- [ ] Yanlış secret gir → "Invalid secret" hatası
- [ ] Doğru \`ADMIN_SECRET\` (veya \`CRON_SECRET\`) gir → tablolar dolmalı
- [ ] Sayfayı yenile (sekmeyi kapatmadan) → otomatik açılmalı
- [ ] Sekmeyi kapat + tekrar aç → login formu tekrar
- [ ] "Logout" → login formuna dön

## Diff

1 dosya, ~200 satır eklendi (büyük kısmı login formu styling'i + auth state).

Refs: docs/AUDIT.md C-03