### PR TITLE
feat(credit): Phase 2 — marketplace UI + API routes + helpers

### DIFF
--- a/app/app/api/claims/[id]/buy/route.ts
+++ b/app/app/api/claims/[id]/buy/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  fetchClaimListing,
+  verifyTxInvokedCovenant,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * POST /api/claims/[id]/buy
+ *
+ * Mirror a completed on-chain `buy_claim`. The lender has already paid
+ * the seller by invoking the instruction in their browser wallet; we
+ * verify and mark the DB row Bought.
+ *
+ * Body: { buyerWallet, txSignature }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const { buyerWallet, txSignature } = body as {
+      buyerWallet?: string;
+      txSignature?: string;
+    };
+    if (!buyerWallet || !txSignature) {
+      return NextResponse.json(
+        { error: "buyerWallet and txSignature are required" },
+        { status: 400 },
+      );
+    }
+
+    const claim = await prisma.claimListing.findUnique({
+      where: { id },
+    });
+    if (!claim) {
+      return NextResponse.json({ error: "Claim not found" }, { status: 404 });
+    }
+    if (claim.status === "Bought" && claim.buyerWallet === buyerWallet) {
+      return NextResponse.json(
+        { claim, note: "already-bought" },
+        { status: 200 },
+      );
+    }
+    if (claim.status !== "Listed") {
+      return NextResponse.json(
+        { error: `Claim is in status ${claim.status}, expected Listed` },
+        { status: 400 },
+      );
+    }
+
+    await verifyTxInvokedCovenant(txSignature);
+
+    const onchain = await fetchClaimListing(new PublicKey(claim.pda));
+    if (!onchain) {
+      return NextResponse.json(
+        { error: "ClaimListing PDA missing on chain after buy tx confirmed" },
+        { status: 400 },
+      );
+    }
+    if (onchain.status !== "Bought") {
+      return NextResponse.json(
+        {
+          error: `On-chain status is ${onchain.status}, expected Bought. ` +
+            "Tx may not have been a buy_claim for this listing.",
+        },
+        { status: 400 },
+      );
+    }
+    if (onchain.buyer !== buyerWallet) {
+      return NextResponse.json(
+        { error: "On-chain buyer does not match buyerWallet in request" },
+        { status: 400 },
+      );
+    }
+
+    const updated = await prisma.claimListing.update({
+      where: { id },
+      data: {
+        status: "Bought",
+        buyerWallet,
+        boughtAt: onchain.boughtAt > 0 ? new Date(onchain.boughtAt * 1000) : new Date(),
+        buyTxHash: txSignature,
+      },
+    });
+
+    return NextResponse.json({ claim: updated });
+  } catch (error) {
+    console.error("POST /api/claims/[id]/buy error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to mirror buy: " +
+          (error instanceof Error ? error.message : String(error)),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/claims/[id]/cancel/route.ts
+++ b/app/app/api/claims/[id]/cancel/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  fetchClaimListing,
+  verifyTxInvokedCovenant,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * POST /api/claims/[id]/cancel
+ *
+ * Mirror a seller-initiated `cancel_claim`. The on-chain account is
+ * closed by the instruction, so after a successful tx we expect
+ * `fetchClaimListing` to return null. We verify the tx invoked our
+ * program and the PDA is indeed closed, then mark the DB row Cancelled.
+ *
+ * Body: { sellerWallet, txSignature }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const { sellerWallet, txSignature } = body as {
+      sellerWallet?: string;
+      txSignature?: string;
+    };
+    if (!sellerWallet || !txSignature) {
+      return NextResponse.json(
+        { error: "sellerWallet and txSignature are required" },
+        { status: 400 },
+      );
+    }
+
+    const claim = await prisma.claimListing.findUnique({ where: { id } });
+    if (!claim) {
+      return NextResponse.json({ error: "Claim not found" }, { status: 404 });
+    }
+    if (claim.status === "Cancelled") {
+      return NextResponse.json(
+        { claim, note: "already-cancelled" },
+        { status: 200 },
+      );
+    }
+    if (claim.status !== "Listed") {
+      return NextResponse.json(
+        { error: `Only Listed claims can be cancelled (got ${claim.status})` },
+        { status: 400 },
+      );
+    }
+    if (claim.sellerWallet !== sellerWallet) {
+      return NextResponse.json(
+        { error: "Only the original seller can cancel this claim" },
+        { status: 403 },
+      );
+    }
+
+    await verifyTxInvokedCovenant(txSignature);
+
+    // cancel_claim closes the PDA — on success the account should be gone.
+    const onchain = await fetchClaimListing(new PublicKey(claim.pda));
+    if (onchain) {
+      return NextResponse.json(
+        {
+          error:
+            `ClaimListing PDA still exists on chain (status=${onchain.status}). ` +
+            "cancel_claim may not have been the supplied tx.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const updated = await prisma.claimListing.update({
+      where: { id },
+      data: {
+        status: "Cancelled",
+        cancelTxHash: txSignature,
+      },
+    });
+
+    return NextResponse.json({ claim: updated });
+  } catch (error) {
+    console.error("POST /api/claims/[id]/cancel error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to mirror cancel: " +
+          (error instanceof Error ? error.message : String(error)),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/claims/route.ts
+++ b/app/app/api/claims/route.ts
@@ -1,0 +1,253 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  fetchClaimListing,
+  verifyTxInvokedCovenant,
+  deriveJobPda,
+  deriveClaimPda,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/claims
+ *
+ * Marketplace query. Returns active listings with joined job data so
+ * the UI can render amount / category / reputation / time-left in one
+ * round-trip. Default sort: highest APR first (buyers want best yield).
+ *
+ * Query params:
+ *   status=Listed|Bought|Cancelled|Settled   (default: Listed)
+ *   sellerWallet=<base58>                    filter
+ *   buyerWallet=<base58>                     filter
+ *   minAmount=<number>                       face value lower bound
+ *   maxAmount=<number>                       face value upper bound
+ *   sortBy=apr|listedAt|faceValue            default: apr
+ *   limit=<1..100>                           default 50
+ *   offset=<number>                          default 0
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const status = searchParams.get("status") ?? "Listed";
+    const sellerWallet = searchParams.get("sellerWallet");
+    const buyerWallet = searchParams.get("buyerWallet");
+    const minAmount = searchParams.get("minAmount");
+    const maxAmount = searchParams.get("maxAmount");
+    const sortBy = searchParams.get("sortBy") ?? "apr";
+    const limit = Math.max(
+      1,
+      Math.min(100, parseInt(searchParams.get("limit") ?? "50", 10)),
+    );
+    const offset = Math.max(0, parseInt(searchParams.get("offset") ?? "0", 10));
+
+    const where: Record<string, unknown> = {};
+    if (status) where.status = status;
+    if (sellerWallet) where.sellerWallet = sellerWallet;
+    if (buyerWallet) where.buyerWallet = buyerWallet;
+    if (minAmount) where.faceValue = { ...(where.faceValue as object), gte: parseFloat(minAmount) };
+    if (maxAmount) where.faceValue = { ...(where.faceValue as object), lte: parseFloat(maxAmount) };
+
+    // Prisma cannot sort by a computed field (APR), so we sort at the DB
+    // layer by listedAt/faceValue and do the APR sort in-memory when
+    // requested.
+    const prismaSortBy = sortBy === "faceValue" ? "faceValue" : "listedAt";
+
+    const [claims, total] = await Promise.all([
+      prisma.claimListing.findMany({
+        where,
+        include: {
+          job: {
+            select: {
+              id: true,
+              posterWallet: true,
+              takerWallet: true,
+              amount: true,
+              category: true,
+              specJson: true,
+              status: true,
+              challengeEndAt: true,
+              deliveredAt: true,
+            },
+          },
+        },
+        orderBy: { [prismaSortBy]: "desc" },
+        skip: offset,
+        take: limit,
+      }),
+      prisma.claimListing.count({ where }),
+    ]);
+
+    const now = Date.now();
+    const enriched = claims.map((c) => {
+      const discountPct =
+        c.faceValue > 0 ? ((c.faceValue - c.price) / c.faceValue) * 100 : 0;
+      const challengeEndMs = c.job.challengeEndAt?.getTime() ?? null;
+      const secondsToChallengeEnd =
+        challengeEndMs && challengeEndMs > now
+          ? Math.round((challengeEndMs - now) / 1000)
+          : 0;
+      // Annualized yield: (faceValue / price - 1) over the remaining
+      // challenge window. Capped at 9999% to avoid silly UI numbers on
+      // listings with sub-second windows left.
+      const yearsRemaining =
+        secondsToChallengeEnd > 0 ? secondsToChallengeEnd / (365 * 24 * 3600) : 1e-9;
+      const aprRaw =
+        c.price > 0 ? (c.faceValue / c.price - 1) / yearsRemaining : 0;
+      const aprPct = Math.min(9999, Math.max(0, aprRaw * 100));
+      return {
+        ...c,
+        discountPct,
+        aprPct,
+        secondsToChallengeEnd,
+      };
+    });
+
+    if (sortBy === "apr") {
+      enriched.sort((a, b) => b.aprPct - a.aprPct);
+    }
+
+    // Lightweight TVL + counts for a header block on /credit.
+    const [tvlRow] = await prisma.$queryRawUnsafe<{ tvl: number | null }[]>(
+      `SELECT SUM("faceValue") as tvl FROM "ClaimListing" WHERE status = 'Listed'`,
+    );
+    const bought = await prisma.claimListing.count({ where: { status: "Bought" } });
+    const settled = await prisma.claimListing.count({ where: { status: "Settled" } });
+
+    return NextResponse.json({
+      claims: enriched,
+      total,
+      limit,
+      offset,
+      stats: {
+        activeTvl: Number(tvlRow?.tvl ?? 0),
+        boughtCount: bought,
+        settledCount: settled,
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/claims error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch claims" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/claims
+ *
+ * Mirror a newly-created on-chain listing into the DB. Caller (seller)
+ * has already invoked `list_claim` from their wallet and passes us the
+ * resulting tx signature. We:
+ *   1. Verify the tx landed + invoked our program (blocks audit C-04
+ *      class of arbitrary-tx replay)
+ *   2. Read the on-chain ClaimListing account and verify seller / price
+ *      / face_value match the DB Job
+ *   3. Upsert a ClaimListing row
+ *
+ * Body: { jobId, txSignature }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { jobId, txSignature } = body as {
+      jobId?: string;
+      txSignature?: string;
+    };
+    if (!jobId || !txSignature) {
+      return NextResponse.json(
+        { error: "jobId and txSignature are required" },
+        { status: 400 },
+      );
+    }
+
+    const job = await prisma.job.findUnique({
+      where: { id: jobId },
+      include: { claim: true },
+    });
+    if (!job) return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    if (!job.takerWallet || !job.posterWallet) {
+      return NextResponse.json(
+        { error: "Job is missing required wallet fields" },
+        { status: 400 },
+      );
+    }
+    if (job.claim && job.claim.status === "Listed") {
+      // Already mirrored — idempotent.
+      return NextResponse.json(
+        { claim: job.claim, note: "already-listed" },
+        { status: 200 },
+      );
+    }
+
+    await verifyTxInvokedCovenant(txSignature);
+
+    const [jobPda] = deriveJobPda(
+      new PublicKey(job.posterWallet),
+      Buffer.from(job.specHash, "hex"),
+    );
+    const [claimPda] = deriveClaimPda(jobPda);
+
+    const onchain = await fetchClaimListing(claimPda);
+    if (!onchain) {
+      return NextResponse.json(
+        { error: "ClaimListing PDA not found on chain after tx confirmed" },
+        { status: 400 },
+      );
+    }
+    if (onchain.seller !== job.takerWallet) {
+      return NextResponse.json(
+        { error: "On-chain seller does not match job.takerWallet" },
+        { status: 400 },
+      );
+    }
+    if (Math.abs(onchain.faceValue - job.amount) > 1e-6) {
+      return NextResponse.json(
+        { error: "On-chain face_value does not match job.amount" },
+        { status: 400 },
+      );
+    }
+    if (onchain.status !== "Listed") {
+      return NextResponse.json(
+        { error: `On-chain status is ${onchain.status}, expected Listed` },
+        { status: 400 },
+      );
+    }
+
+    const claim = await prisma.claimListing.upsert({
+      where: { pda: claimPda.toBase58() },
+      create: {
+        pda: claimPda.toBase58(),
+        jobId: job.id,
+        jobPda: jobPda.toBase58(),
+        sellerWallet: onchain.seller,
+        price: onchain.price,
+        faceValue: onchain.faceValue,
+        priceAtomic: onchain.priceAtomic.toString(),
+        faceValueAtomic: onchain.faceValueAtomic.toString(),
+        status: "Listed",
+        listedAt: new Date(onchain.listedAt * 1000),
+        listTxHash: txSignature,
+      },
+      update: {
+        status: "Listed",
+        price: onchain.price,
+        priceAtomic: onchain.priceAtomic.toString(),
+        listTxHash: txSignature,
+      },
+    });
+
+    return NextResponse.json({ claim }, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/claims error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to mirror claim listing: " +
+          (error instanceof Error ? error.message : String(error)),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/jobs/[id]/route.ts
+++ b/app/app/api/jobs/[id]/route.ts
@@ -14,6 +14,7 @@ export async function GET(
         submissions: true,
         delivery: true,
         dispute: true,
+        claim: true,
         interests: {
           where: { status: "working" },
           select: { takerWallet: true, acceptedAt: true },

--- a/app/app/api/jobs/route.ts
+++ b/app/app/api/jobs/route.ts
@@ -60,6 +60,7 @@ export async function GET(request: NextRequest) {
           submissions: true,
           delivery: true,
           dispute: true,
+          claim: true,
           interests: {
             where: { status: "working" },
             select: { takerWallet: true, acceptedAt: true },

--- a/app/app/credit/page.tsx
+++ b/app/app/credit/page.tsx
@@ -1,0 +1,522 @@
+"use client";
+
+/**
+ * Covenant Credit — BNPL marketplace for pending agent payment claims.
+ *
+ * Sellers (takers with Delivered jobs) list their pending payment
+ * claims at a discount. Lenders (buyers) purchase them, get the full
+ * face value when the challenge period expires.
+ *
+ * Pitch: "BNPL for AI agents on Solana."
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { useConnector } from "@solana/connector/react";
+import { PublicKey } from "@solana/web3.js";
+import { getAssociatedTokenAddress } from "@solana/spl-token";
+import {
+  getAnchorProgram,
+  buyClaimOnChain,
+} from "@/lib/anchor-browser";
+import { USDC_MINT, USDC_LOGO_URL } from "@/lib/constants";
+import NavBar from "@/components/NavBar";
+import SellClaimButton from "@/components/SellClaimButton";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface ClaimRow {
+  id: string;
+  pda: string;
+  jobId: string;
+  jobPda: string;
+  sellerWallet: string;
+  buyerWallet: string | null;
+  price: number;
+  faceValue: number;
+  status: string;
+  listedAt: string;
+  discountPct: number;
+  aprPct: number;
+  secondsToChallengeEnd: number;
+  job: {
+    id: string;
+    posterWallet: string;
+    category: string;
+    amount: number;
+    specJson: Record<string, unknown>;
+    challengeEndAt: string | null;
+  };
+}
+
+interface Stats {
+  activeTvl: number;
+  boughtCount: number;
+  settledCount: number;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds <= 0) return "expired";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  const s = Math.max(0, seconds - m * 60);
+  return `${m}m ${s}s`;
+}
+
+function shortWallet(w: string): string {
+  return w.length > 10 ? `${w.slice(0, 4)}…${w.slice(-4)}` : w;
+}
+
+export default function CreditMarketplacePage() {
+  const connector = useConnector();
+  const account =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.account?.address ??
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.selectedWallet?.accounts?.[0]?.address ??
+    null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const selectedWallet = (connector as any)?.selectedWallet ?? null;
+
+  const [claims, setClaims] = useState<ClaimRow[]>([]);
+  const [stats, setStats] = useState<Stats>({
+    activeTvl: 0,
+    boughtCount: 0,
+    settledCount: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [buying, setBuying] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
+
+  // "Your pending jobs" — Delivered jobs the connected wallet took, for
+  // which no listing exists yet (i.e. listable right now).
+  interface PendingJob {
+    id: string;
+    specHash: string;
+    posterWallet: string;
+    takerWallet: string;
+    amount: number;
+    specJson: Record<string, unknown>;
+    challengeEndAt: string | null;
+    claim: { id: string; status: string } | null;
+  }
+  const [pendingJobs, setPendingJobs] = useState<PendingJob[]>([]);
+
+  const fetchPendingJobs = useCallback(async () => {
+    if (!account) {
+      setPendingJobs([]);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/api/jobs?status=Delivered&taker=${encodeURIComponent(account)}&limit=20`,
+      );
+      if (!res.ok) return;
+      const json = await res.json();
+      const jobs: PendingJob[] = (json.jobs ?? []).filter(
+        (j: PendingJob) => !j.claim,
+      );
+      setPendingJobs(jobs);
+    } catch (e) {
+      console.error("[credit] pending fetch failed:", e);
+    }
+  }, [account]);
+
+  const fetchClaims = useCallback(async () => {
+    try {
+      const res = await fetch("/api/claims?status=Listed&sortBy=apr&limit=50");
+      if (!res.ok) return;
+      const json = await res.json();
+      setClaims(json.claims ?? []);
+      setStats(json.stats ?? stats);
+    } catch (e) {
+      console.error("[credit] fetch failed:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, [stats]);
+
+  useEffect(() => {
+    fetchClaims();
+    fetchPendingJobs();
+    const iv = setInterval(() => {
+      fetchClaims();
+      fetchPendingJobs();
+    }, 10_000);
+    return () => clearInterval(iv);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account]);
+
+  const bestApr = useMemo(
+    () => (claims.length > 0 ? Math.max(...claims.map((c) => c.aprPct)) : 0),
+    [claims],
+  );
+
+  async function handleBuy(claim: ClaimRow) {
+    if (!account || !selectedWallet) {
+      setToast({ kind: "err", msg: "Connect your wallet to buy claims." });
+      return;
+    }
+    if (claim.sellerWallet === account) {
+      setToast({ kind: "err", msg: "You can't buy your own listing." });
+      return;
+    }
+    setBuying(claim.id);
+    setToast(null);
+    try {
+      const program = getAnchorProgram(account, selectedWallet);
+      if (!program) throw new Error("wallet program unavailable");
+
+      const buyerPk = new PublicKey(account);
+      const sellerPk = new PublicKey(claim.sellerWallet);
+      const posterPk = new PublicKey(claim.job.posterWallet);
+
+      // Derive ATAs from the USDC mint + wallet pubkeys.
+      const [buyerAta, sellerAta] = await Promise.all([
+        getAssociatedTokenAddress(USDC_MINT, buyerPk),
+        getAssociatedTokenAddress(USDC_MINT, sellerPk),
+      ]);
+
+      // Fetch the Job to get the 32-byte specHash.
+      const jobRes = await fetch(`/api/jobs/${claim.jobId}`);
+      if (!jobRes.ok) throw new Error("job lookup failed");
+      const jobJson = await jobRes.json();
+      const specHashHex: string = jobJson.specHash ?? jobJson.job?.specHash;
+      if (!specHashHex) throw new Error("job missing specHash");
+      const specHash = Uint8Array.from(Buffer.from(specHashHex, "hex"));
+
+      const { sig } = await buyClaimOnChain({
+        program,
+        buyer: buyerPk,
+        poster: posterPk,
+        specHash,
+        buyerTokenAccount: buyerAta,
+        sellerTokenAccount: sellerAta,
+      });
+
+      const mirrorRes = await fetch(`/api/claims/${claim.id}/buy`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ buyerWallet: account, txSignature: sig }),
+      });
+      if (!mirrorRes.ok) {
+        const txt = await mirrorRes.text();
+        throw new Error(`mirror failed: ${txt}`);
+      }
+
+      setToast({
+        kind: "ok",
+        msg:
+          `Bought ${claim.faceValue.toFixed(2)} USDC claim for ` +
+          `${claim.price.toFixed(2)} USDC. Settlement in ` +
+          `${formatDuration(claim.secondsToChallengeEnd)}.`,
+      });
+      await fetchClaims();
+    } catch (e) {
+      console.error("[credit] buy failed:", e);
+      setToast({
+        kind: "err",
+        msg: "Buy failed: " + (e instanceof Error ? e.message : String(e)),
+      });
+    } finally {
+      setBuying(null);
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#0b0b0b", color: "#fff", fontFamily: "inherit" }}>
+      <NavBar activeTab="credit" variant="dark" />
+
+      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "40px 24px 80px" }}>
+        {/* Hero */}
+        <div style={{ marginBottom: 32 }}>
+          <div
+            style={{
+              fontSize: 12,
+              textTransform: "uppercase",
+              letterSpacing: "0.15em",
+              color: "#fffeb2",
+              marginBottom: 8,
+            }}
+          >
+            Covenant Credit
+          </div>
+          <div style={{ fontSize: 40, fontWeight: 800, lineHeight: 1.1, marginBottom: 12 }}>
+            BNPL for AI agents.
+          </div>
+          <div style={{ fontSize: 14, color: "rgba(255,255,255,0.6)", maxWidth: 720, lineHeight: 1.5 }}>
+            Agents with Delivered jobs can sell their pending payment claims at a discount.
+            Lenders earn yield for bearing dispute risk during the 24h challenge window.
+            Only makes economic sense on Solana — try this on Ethereum and you&apos;d lose money to gas.
+          </div>
+        </div>
+
+        {/* Stats strip */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 32 }}>
+          <StatCard label="Active TVL" value={`$${stats.activeTvl.toFixed(2)}`} accent="#fffeb2" />
+          <StatCard label="Listed" value={String(claims.length)} />
+          <StatCard label="Bought" value={String(stats.boughtCount)} />
+          <StatCard label="Best APR" value={`${bestApr.toFixed(0)}%`} accent="#7CFF7C" />
+        </div>
+
+        {/* Your pending jobs (Delivered, no listing yet) */}
+        {account && pendingJobs.length > 0 && (
+          <div
+            style={{
+              marginBottom: 32,
+              padding: 20,
+              background: "rgba(255,254,178,0.05)",
+              border: "1px solid rgba(255,254,178,0.25)",
+              borderRadius: 12,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "#fffeb2",
+                marginBottom: 12,
+                fontWeight: 700,
+              }}
+            >
+              Your pending payments — sell any of these instantly
+            </div>
+            {pendingJobs.map((j) => (
+              <div
+                key={j.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 16,
+                  padding: "12px 0",
+                  borderTop: "1px solid rgba(255,255,255,0.06)",
+                  fontSize: 13,
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 600 }}>
+                    {((j.specJson as { title?: string } | undefined)?.title) ??
+                      `Job ${j.id.slice(0, 6)}`}
+                  </div>
+                  <div style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", marginTop: 2 }}>
+                    {j.amount.toFixed(2)} USDC — settles in{" "}
+                    {j.challengeEndAt
+                      ? formatDuration(
+                          Math.round(
+                            (new Date(j.challengeEndAt).getTime() - Date.now()) /
+                              1000,
+                          ),
+                        )
+                      : "—"}
+                  </div>
+                </div>
+                <SellClaimButton
+                  jobId={j.id}
+                  posterWallet={j.posterWallet}
+                  takerWallet={j.takerWallet}
+                  specHashHex={j.specHash}
+                  faceValue={j.amount}
+                  onListed={() => {
+                    fetchClaims();
+                    fetchPendingJobs();
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Toast */}
+        {toast && (
+          <div
+            style={{
+              marginBottom: 20,
+              padding: "12px 16px",
+              borderRadius: 8,
+              fontSize: 13,
+              color: toast.kind === "ok" ? "#7CFF7C" : "#FF425E",
+              background: toast.kind === "ok" ? "rgba(124,255,124,0.1)" : "rgba(255,66,94,0.1)",
+              border: `1px solid ${toast.kind === "ok" ? "#7CFF7C40" : "#FF425E40"}`,
+            }}
+          >
+            {toast.msg}
+          </div>
+        )}
+
+        {/* Table */}
+        <div
+          style={{
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.08)",
+            borderRadius: 12,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(160px,1.2fr) 100px 100px 90px 90px 140px 140px 120px",
+              padding: "14px 20px",
+              background: "rgba(255,255,255,0.03)",
+              borderBottom: "1px solid rgba(255,255,255,0.08)",
+              fontSize: 11,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "rgba(255,255,255,0.5)",
+            }}
+          >
+            <div>Job</div>
+            <div>Category</div>
+            <div>Face value</div>
+            <div>Price</div>
+            <div>Discount</div>
+            <div>APR (annual)</div>
+            <div>Settles in</div>
+            <div />
+          </div>
+
+          {loading ? (
+            <div style={{ padding: 40, textAlign: "center", color: "rgba(255,255,255,0.4)" }}>
+              Loading claims…
+            </div>
+          ) : claims.length === 0 ? (
+            <div style={{ padding: 40, textAlign: "center", color: "rgba(255,255,255,0.4)" }}>
+              No active listings. An agent needs to deliver a job and sell the claim first.
+            </div>
+          ) : (
+            claims.map((c) => (
+              <div
+                key={c.id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "minmax(160px,1.2fr) 100px 100px 90px 90px 140px 140px 120px",
+                  padding: "14px 20px",
+                  borderBottom: "1px solid rgba(255,255,255,0.06)",
+                  alignItems: "center",
+                  fontSize: 13,
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 600, marginBottom: 2 }}>
+                    {((c.job.specJson as { title?: string } | undefined)?.title as string) ??
+                      `Job ${c.jobId.slice(0, 6)}`}
+                  </div>
+                  <div style={{ fontSize: 11, color: "rgba(255,255,255,0.4)" }}>
+                    seller {shortWallet(c.sellerWallet)}
+                  </div>
+                </div>
+                <div style={{ fontSize: 12, color: "rgba(255,255,255,0.6)" }}>{c.job.category}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={USDC_LOGO_URL} alt="USDC" width={14} height={14} style={{ borderRadius: "50%" }} />
+                  <span>{c.faceValue.toFixed(2)}</span>
+                </div>
+                <div style={{ color: "#fffeb2" }}>{c.price.toFixed(2)}</div>
+                <div style={{ color: "#7CFF7C" }}>{c.discountPct.toFixed(1)}%</div>
+                <div style={{ color: "#7CFF7C", fontWeight: 700 }}>
+                  {c.aprPct >= 1000 ? `${Math.round(c.aprPct)}%` : `${c.aprPct.toFixed(0)}%`}
+                </div>
+                <div
+                  style={{
+                    color:
+                      c.secondsToChallengeEnd > 3600
+                        ? "rgba(255,255,255,0.5)"
+                        : "#FFB84D",
+                  }}
+                >
+                  {formatDuration(c.secondsToChallengeEnd)}
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <button
+                    onClick={() => handleBuy(c)}
+                    disabled={
+                      buying !== null ||
+                      !account ||
+                      c.sellerWallet === account ||
+                      c.secondsToChallengeEnd <= 0
+                    }
+                    style={{
+                      padding: "6px 14px",
+                      fontFamily: "inherit",
+                      fontSize: 11,
+                      fontWeight: 700,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      color: "#000",
+                      background:
+                        buying !== null ||
+                        !account ||
+                        c.sellerWallet === account ||
+                        c.secondsToChallengeEnd <= 0
+                          ? "rgba(255,254,178,0.3)"
+                          : "#fffeb2",
+                      border: "none",
+                      borderRadius: 6,
+                      cursor:
+                        buying !== null ||
+                        !account ||
+                        c.sellerWallet === account ||
+                        c.secondsToChallengeEnd <= 0
+                          ? "not-allowed"
+                          : "pointer",
+                    }}
+                  >
+                    {buying === c.id ? "Buying…" : "Buy claim"}
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer explainer */}
+        <div
+          style={{
+            marginTop: 40,
+            padding: 20,
+            background: "rgba(255,255,255,0.03)",
+            border: "1px solid rgba(255,255,255,0.06)",
+            borderRadius: 10,
+            fontSize: 12,
+            color: "rgba(255,255,255,0.5)",
+            lineHeight: 1.6,
+          }}
+        >
+          <b style={{ color: "#fffeb2" }}>How it works.</b>{" "}
+          A taker with a Delivered job lists their claim at a discounted price — they prefer
+          cash now over waiting for the challenge window to expire. You buy the claim by paying
+          the seller directly; when finalize_payment fires on chain, you receive the full face
+          value instead of the seller. If a dispute resolves FavorPoster during the challenge
+          window you lose your principal — that risk is priced into every discount.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  return (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderRadius: 10,
+        padding: "16px 18px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "rgba(255,255,255,0.45)",
+          marginBottom: 6,
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 700, color: accent ?? "#fff" }}>{value}</div>
+    </div>
+  );
+}

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -58,7 +58,7 @@ function prefetchBackground(href: string): void {
   img.src = href;
 }
 
-type Tab = "home" | "agents" | "create" | "poster" | "taker" | "dashboard" | "battle" | "arena" | "autonomous" | "leaderboard" | "architecture" | "events" | "admin" | "onchain" | "disputes" | "faucet" | "api-docs" | "protocol" | "developers" | "integrate" | "profile";
+type Tab = "home" | "agents" | "create" | "poster" | "taker" | "dashboard" | "battle" | "arena" | "autonomous" | "leaderboard" | "architecture" | "events" | "admin" | "onchain" | "disputes" | "faucet" | "api-docs" | "protocol" | "developers" | "integrate" | "profile" | "credit";
 
 interface NavBarProps {
   activeTab: Tab;
@@ -74,6 +74,7 @@ const PRIMARY_TABS: { id: Tab; label: string; href: string }[] = [
   { id: "dashboard", label: "Dashboard", href: "/dashboard" },
   { id: "battle", label: "Battle", href: "/battle" },
   { id: "arena", label: "Arena", href: "/arena" },
+  { id: "credit", label: "Credit", href: "/credit" },
 ];
 
 const MORE_TABS: { id: Tab; label: string; href: string }[] = [

--- a/app/components/SellClaimButton.tsx
+++ b/app/components/SellClaimButton.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+/**
+ * SellClaimButton — lets the taker list their pending payment claim on
+ * Covenant Credit. Appears only for jobs the caller actually took and
+ * that are currently in `Delivered` state with no active dispute.
+ *
+ * UX: click → modal with price slider (default 97% = 3% discount) →
+ * preview yield → confirm → sign list_claim in wallet → POST to
+ * /api/claims to mirror the on-chain state into the DB.
+ */
+
+import { useState } from "react";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { useConnector } from "@solana/connector/react";
+import { BN } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { getAnchorProgram, listClaimOnChain } from "@/lib/anchor-browser";
+import { USDC_DECIMALS } from "@/lib/constants";
+
+interface SellClaimButtonProps {
+  jobId: string;
+  posterWallet: string;
+  takerWallet: string;
+  specHashHex: string;
+  faceValue: number;
+  /** True if a ClaimListing already exists for this job. */
+  alreadyListed?: boolean;
+  onListed?: () => void;
+}
+
+function toAtomic(amount: number): BN {
+  return new BN(Math.round(amount * 10 ** USDC_DECIMALS));
+}
+
+export default function SellClaimButton(props: SellClaimButtonProps) {
+  const connector = useConnector();
+  const account =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.account?.address ??
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.selectedWallet?.accounts?.[0]?.address ??
+    null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const selectedWallet = (connector as any)?.selectedWallet ?? null;
+
+  const [open, setOpen] = useState(false);
+  const [discountPct, setDiscountPct] = useState(3); // default 3% discount
+  const [listing, setListing] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const isTaker = account === props.takerWallet;
+  if (!isTaker || props.alreadyListed) return null;
+
+  const price = Math.max(0.000001, props.faceValue * (1 - discountPct / 100));
+  const earnedNow = price;
+  const lenderYield = props.faceValue - price;
+
+  async function handleConfirm() {
+    if (!account || !selectedWallet) {
+      setErr("Connect your wallet first.");
+      return;
+    }
+    setListing(true);
+    setErr(null);
+    try {
+      const program = getAnchorProgram(account, selectedWallet);
+      if (!program) throw new Error("wallet program unavailable");
+
+      const specHash = Uint8Array.from(Buffer.from(props.specHashHex, "hex"));
+      const priceBn = toAtomic(price);
+      const sellerPk = new PublicKey(account);
+      const posterPk = new PublicKey(props.posterWallet);
+
+      const { sig } = await listClaimOnChain({
+        program,
+        seller: sellerPk,
+        poster: posterPk,
+        specHash,
+        price: priceBn,
+      });
+
+      const mirrorRes = await fetch("/api/claims", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId: props.jobId, txSignature: sig }),
+      });
+      if (!mirrorRes.ok) {
+        const txt = await mirrorRes.text();
+        throw new Error(`mirror failed: ${txt}`);
+      }
+
+      setOpen(false);
+      props.onListed?.();
+    } catch (e) {
+      console.error("[sell-claim] failed:", e);
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setListing(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        style={{
+          padding: "10px 18px",
+          fontFamily: "inherit",
+          fontSize: 12,
+          fontWeight: 700,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "#000",
+          background: "#fffeb2",
+          border: "none",
+          borderRadius: 6,
+          cursor: "pointer",
+        }}
+      >
+        Sell claim →
+      </button>
+
+      {open && (
+        <div
+          onClick={() => !listing && setOpen(false)}
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.7)",
+            backdropFilter: "blur(6px)",
+            zIndex: 100,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: "100%",
+              maxWidth: 440,
+              background: "#111",
+              border: "1px solid rgba(255,255,255,0.1)",
+              borderRadius: 12,
+              padding: 28,
+              color: "#fff",
+              fontFamily: "inherit",
+            }}
+          >
+            <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 6 }}>
+              Sell your pending claim
+            </div>
+            <div style={{ fontSize: 13, color: "rgba(255,255,255,0.5)", marginBottom: 20, lineHeight: 1.5 }}>
+              Skip the 24h challenge window. Get paid in USDC now, the lender
+              collects the full face value when finalize_payment fires.
+            </div>
+
+            {/* Discount slider */}
+            <div style={{ marginBottom: 16 }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "rgba(255,255,255,0.5)",
+                  marginBottom: 6,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>Discount</span>
+                <span style={{ color: "#7CFF7C" }}>{discountPct.toFixed(1)}%</span>
+              </div>
+              <input
+                type="range"
+                min={0.5}
+                max={20}
+                step={0.5}
+                value={discountPct}
+                onChange={(e) => setDiscountPct(parseFloat(e.target.value))}
+                disabled={listing}
+                style={{ width: "100%", accentColor: "#fffeb2" }}
+              />
+              <div
+                style={{
+                  fontSize: 10,
+                  color: "rgba(255,255,255,0.4)",
+                  marginTop: 4,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>0.5% (tight)</span>
+                <span>20% (fast sale)</span>
+              </div>
+            </div>
+
+            {/* Preview */}
+            <div
+              style={{
+                background: "rgba(255,254,178,0.05)",
+                border: "1px solid rgba(255,254,178,0.2)",
+                borderRadius: 8,
+                padding: 16,
+                marginBottom: 16,
+                fontSize: 13,
+              }}
+            >
+              <Row label="Face value" value={`$${props.faceValue.toFixed(2)}`} />
+              <Row
+                label="You receive now"
+                value={`$${earnedNow.toFixed(2)}`}
+                accent="#fffeb2"
+                strong
+              />
+              <Row label="Lender earns" value={`$${lenderYield.toFixed(2)}`} accent="#7CFF7C" />
+            </div>
+
+            {err && (
+              <div
+                style={{
+                  padding: 10,
+                  borderRadius: 6,
+                  fontSize: 12,
+                  background: "rgba(255,66,94,0.1)",
+                  border: "1px solid rgba(255,66,94,0.3)",
+                  color: "#FF425E",
+                  marginBottom: 12,
+                }}
+              >
+                {err}
+              </div>
+            )}
+
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                onClick={() => !listing && setOpen(false)}
+                disabled={listing}
+                style={{
+                  flex: 1,
+                  padding: "12px",
+                  fontFamily: "inherit",
+                  fontSize: 12,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "rgba(255,255,255,0.7)",
+                  background: "transparent",
+                  border: "1px solid rgba(255,255,255,0.2)",
+                  borderRadius: 6,
+                  cursor: listing ? "not-allowed" : "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={listing}
+                style={{
+                  flex: 2,
+                  padding: "12px",
+                  fontFamily: "inherit",
+                  fontSize: 12,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "#000",
+                  background: listing ? "rgba(255,254,178,0.4)" : "#fffeb2",
+                  border: "none",
+                  borderRadius: 6,
+                  cursor: listing ? "not-allowed" : "pointer",
+                }}
+              >
+                {listing ? "Listing…" : "Sign & list"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function Row({
+  label,
+  value,
+  accent,
+  strong,
+}: {
+  label: string;
+  value: string;
+  accent?: string;
+  strong?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        padding: "4px 0",
+        fontSize: 13,
+      }}
+    >
+      <span style={{ color: "rgba(255,255,255,0.6)" }}>{label}</span>
+      <span
+        style={{
+          color: accent ?? "#fff",
+          fontWeight: strong ? 700 : 500,
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/app/lib/anchor-browser.ts
+++ b/app/lib/anchor-browser.ts
@@ -327,3 +327,151 @@ export async function finalizePaymentOnChain(params: {
   );
   return sig;
 }
+
+// ---- Covenant Credit helpers ----
+
+export function deriveClaimPda(jobPda: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("claim"), jobPda.toBuffer()],
+    PROGRAM_ID,
+  );
+}
+
+/**
+ * Build + sign the on-chain `list_claim` instruction.
+ *
+ * Taker (seller) must have a Delivered job with no active dispute.
+ * Price must be strictly less than the job's face value — there's no
+ * rational buyer at par.
+ */
+export async function listClaimOnChain(params: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  program: Program<any>;
+  seller: PublicKey;
+  poster: PublicKey;
+  specHash: Uint8Array;
+  price: BN;
+}): Promise<{ sig: string; claimPda: PublicKey }> {
+  const { program, seller, poster, specHash, price } = params;
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  const tx = await (program.methods as any)
+    .listClaim(price)
+    .accounts({
+      seller,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      systemProgram: SystemProgram.programId,
+    })
+    .transaction();
+
+  const connection = program.provider.connection;
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = seller;
+
+  const signedTx = await ((program.provider as any).wallet as any).signTransaction(tx);
+  const sig = await connection.sendRawTransaction(signedTx.serialize(), {
+    skipPreflight: false,
+  });
+  await connection.confirmTransaction(
+    { signature: sig, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+  return { sig, claimPda };
+}
+
+/**
+ * Build + sign the on-chain `buy_claim` instruction.
+ *
+ * Buyer pays `claim_listing.price` USDC to the seller atomically and
+ * inherits the right to collect `face_value` when finalize/resolve
+ * fires. Rejects if buyer == seller.
+ */
+export async function buyClaimOnChain(params: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  program: Program<any>;
+  buyer: PublicKey;
+  poster: PublicKey;
+  specHash: Uint8Array;
+  buyerTokenAccount: PublicKey;
+  sellerTokenAccount: PublicKey;
+}): Promise<{ sig: string; claimPda: PublicKey }> {
+  const { program, buyer, poster, specHash, buyerTokenAccount, sellerTokenAccount } = params;
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  const tx = await (program.methods as any)
+    .buyClaim()
+    .accounts({
+      buyer,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      buyerTokenAccount,
+      sellerTokenAccount,
+      tokenProgram: TOKEN_PROGRAM_ID,
+    })
+    .transaction();
+
+  const connection = program.provider.connection;
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = buyer;
+
+  const signedTx = await ((program.provider as any).wallet as any).signTransaction(tx);
+  const sig = await connection.sendRawTransaction(signedTx.serialize(), {
+    skipPreflight: false,
+  });
+  await connection.confirmTransaction(
+    { signature: sig, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+  return { sig, claimPda };
+}
+
+/**
+ * Build + sign the on-chain `cancel_claim` instruction.
+ *
+ * Only the original seller may cancel, and only while the listing is
+ * still in `Listed` state. Account is closed and rent refunded.
+ */
+export async function cancelClaimOnChain(params: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  program: Program<any>;
+  seller: PublicKey;
+  claimPda: PublicKey;
+}): Promise<string> {
+  const { program, seller, claimPda } = params;
+
+  const tx = await (program.methods as any)
+    .cancelClaim()
+    .accounts({
+      seller,
+      claimListing: claimPda,
+    })
+    .transaction();
+
+  const connection = program.provider.connection;
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = seller;
+
+  const signedTx = await ((program.provider as any).wallet as any).signTransaction(tx);
+  const sig = await connection.sendRawTransaction(signedTx.serialize(), {
+    skipPreflight: false,
+  });
+  await connection.confirmTransaction(
+    { signature: sig, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+  return sig;
+}

--- a/app/lib/credit-server.ts
+++ b/app/lib/credit-server.ts
@@ -1,0 +1,280 @@
+/**
+ * @file credit-server.ts — server-side helpers for Covenant Credit.
+ *
+ * Reads and (bot-only) writes the on-chain ClaimListing state introduced
+ * in PR #36. Used by the `/api/claims*` API routes and by cron tasks
+ * that scan for claim-related events.
+ *
+ * Human users never go through here — they invoke list_claim /
+ * buy_claim / cancel_claim via the browser (see `lib/anchor-browser.ts`
+ * extensions). The server's role is strictly:
+ *   1. Verify a user-signed claim tx invoked our program
+ *   2. Read the on-chain account back
+ *   3. Mirror to the DB
+ *
+ * Bot helpers (botListClaim, botBuyClaim) exist for arena/battle/
+ * autonomous demos where the server holds the bot's own keypair.
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+} from "@solana/web3.js";
+import { TOKEN_PROGRAM_ID, getAssociatedTokenAddress } from "@solana/spl-token";
+import { AnchorProvider, BN, Program, type Idl } from "@coral-xyz/anchor";
+import idl from "./covenant-idl.json";
+import {
+  PROGRAM_ID,
+  USDC_MINT,
+  USDC_DECIMALS,
+  DEVNET_ENDPOINT,
+} from "./constants";
+
+// ---- Connection + program ----
+
+export function getConnection(): Connection {
+  const rpc =
+    process.env.HELIUS_RPC_URL ||
+    process.env.NEXT_PUBLIC_RPC_URL ||
+    DEVNET_ENDPOINT;
+  return new Connection(rpc, "confirmed");
+}
+
+class NodeWallet {
+  constructor(public readonly payer: Keypair) {}
+  get publicKey() {
+    return this.payer.publicKey;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async signTransaction<T>(tx: T): Promise<T> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tx as any).partialSign(this.payer);
+    return tx;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async signAllTransactions<T>(txs: T[]): Promise<T[]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    txs.forEach((tx) => (tx as any).partialSign(this.payer));
+    return txs;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getBotProgram(botKeypair: Keypair): Program<any> {
+  const connection = getConnection();
+  const wallet = new NodeWallet(botKeypair);
+  const provider = new AnchorProvider(connection, wallet, {
+    commitment: "confirmed",
+  });
+  return new Program(idl as Idl, provider);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getReadOnlyProgram(): Program<any> {
+  return getBotProgram(Keypair.generate());
+}
+
+export function keypairFromEnv(envVar: string): Keypair {
+  const raw = process.env[envVar];
+  if (!raw) throw new Error(`${envVar} not set`);
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(raw)));
+}
+
+// ---- PDA helpers ----
+
+export function deriveJobPda(
+  poster: PublicKey,
+  specHash: Uint8Array | Buffer,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("job"), poster.toBuffer(), Buffer.from(specHash)],
+    PROGRAM_ID,
+  );
+}
+
+export function deriveClaimPda(jobPda: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("claim"), jobPda.toBuffer()],
+    PROGRAM_ID,
+  );
+}
+
+// ---- ClaimListing decoder ----
+
+export type ClaimStatus = "Listed" | "Bought" | "Cancelled" | "Settled" | "Unknown";
+
+export interface OnChainClaimListing {
+  pda: string;
+  job: string;
+  seller: string;
+  buyer: string | null;
+  price: number; // human units
+  priceAtomic: bigint;
+  faceValue: number;
+  faceValueAtomic: bigint;
+  listedAt: number;
+  boughtAt: number;
+  status: ClaimStatus;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function statusKey(status: any): ClaimStatus {
+  if (!status || typeof status !== "object") return "Unknown";
+  const k = Object.keys(status)[0];
+  if (!k) return "Unknown";
+  const capitalized = k.charAt(0).toUpperCase() + k.slice(1);
+  if (
+    capitalized === "Listed" ||
+    capitalized === "Bought" ||
+    capitalized === "Cancelled" ||
+    capitalized === "Settled"
+  ) {
+    return capitalized;
+  }
+  return "Unknown";
+}
+
+/**
+ * Fetch + decode a ClaimListing by its PDA. Returns null if the account
+ * does not exist (never listed or cancelled+closed).
+ */
+export async function fetchClaimListing(
+  claimPda: PublicKey,
+): Promise<OnChainClaimListing | null> {
+  const program = getReadOnlyProgram();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = await (program.account as any).claimListing.fetchNullable(
+    claimPda,
+  );
+  if (!raw) return null;
+
+  const priceAtomic: bigint = BigInt(raw.price.toString());
+  const faceValueAtomic: bigint = BigInt(raw.faceValue.toString());
+  const buyerStr = new PublicKey(raw.buyer).toBase58();
+  const isBuyerDefault = buyerStr === PublicKey.default.toBase58();
+
+  return {
+    pda: claimPda.toBase58(),
+    job: new PublicKey(raw.job).toBase58(),
+    seller: new PublicKey(raw.seller).toBase58(),
+    buyer: isBuyerDefault ? null : buyerStr,
+    price: Number(priceAtomic) / 10 ** USDC_DECIMALS,
+    priceAtomic,
+    faceValue: Number(faceValueAtomic) / 10 ** USDC_DECIMALS,
+    faceValueAtomic,
+    listedAt: Number(raw.listedAt.toString()),
+    boughtAt: Number(raw.boughtAt.toString()),
+    status: statusKey(raw.status),
+  };
+}
+
+/** Convenience: derive + fetch in one call. */
+export async function fetchClaimForJob(
+  jobPda: PublicKey,
+): Promise<OnChainClaimListing | null> {
+  const [claimPda] = deriveClaimPda(jobPda);
+  return fetchClaimListing(claimPda);
+}
+
+// ---- Tx verification ----
+
+/**
+ * Verify a transaction both landed successfully AND invoked the
+ * Covenant program at least once. Blocks the "arbitrary confirmed
+ * signature" replay pattern flagged in audit C-04.
+ */
+export async function verifyTxInvokedCovenant(sig: string): Promise<void> {
+  const conn = getConnection();
+  const tx = await conn.getTransaction(sig, {
+    maxSupportedTransactionVersion: 0,
+    commitment: "confirmed",
+  });
+  if (!tx) throw new Error(`tx ${sig.slice(0, 8)}… not found on chain`);
+  if (tx.meta?.err) {
+    throw new Error(`tx reverted: ${JSON.stringify(tx.meta.err)}`);
+  }
+  const keys = tx.transaction.message.staticAccountKeys ?? [];
+  const programIdStr = PROGRAM_ID.toBase58();
+  const invoked = keys.some((k) => k.toBase58() === programIdStr);
+  if (!invoked) {
+    throw new Error(
+      `tx ${sig.slice(0, 8)}… did not invoke Covenant program ${programIdStr.slice(0, 8)}…`,
+    );
+  }
+}
+
+// ---- Bot-signed instruction helpers (arena/battle/autonomous) ----
+
+/**
+ * Bot-signed `list_claim`. Used only when the bot has an on-chain
+ * Delivered job of its own to factor (i.e. bot is the original taker).
+ */
+export async function botListClaim(params: {
+  takerBotKeypair: Keypair;
+  poster: PublicKey;
+  specHash: Buffer;
+  priceAtomic: BN;
+}): Promise<{ sig: string; claimPda: PublicKey }> {
+  const { takerBotKeypair, poster, specHash, priceAtomic } = params;
+  const program = getBotProgram(takerBotKeypair);
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  const sig = (await (program.methods as { listClaim: (...a: unknown[]) => unknown })
+    .listClaim(priceAtomic)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .accounts({
+      seller: takerBotKeypair.publicKey,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      systemProgram: SystemProgram.programId,
+    } as Record<string, PublicKey>)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .rpc()) as string;
+
+  return { sig, claimPda };
+}
+
+/**
+ * Bot-signed `buy_claim`. Used by an autonomous lender bot that
+ * auto-matches claims meeting reputation + discount thresholds.
+ */
+export async function botBuyClaim(params: {
+  buyerBotKeypair: Keypair;
+  poster: PublicKey;
+  specHash: Buffer;
+}): Promise<string> {
+  const { buyerBotKeypair, poster, specHash } = params;
+  const program = getBotProgram(buyerBotKeypair);
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  // Fetch the listing to discover the seller ATA we need to pay.
+  const listing = await fetchClaimListing(claimPda);
+  if (!listing) throw new Error("claim listing not found");
+  const sellerPubkey = new PublicKey(listing.seller);
+
+  const buyerAta = await getAssociatedTokenAddress(
+    USDC_MINT,
+    buyerBotKeypair.publicKey,
+  );
+  const sellerAta = await getAssociatedTokenAddress(USDC_MINT, sellerPubkey);
+
+  return (await (program.methods as { buyClaim: () => unknown })
+    .buyClaim()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .accounts({
+      buyer: buyerBotKeypair.publicKey,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      buyerTokenAccount: buyerAta,
+      sellerTokenAccount: sellerAta,
+      tokenProgram: TOKEN_PROGRAM_ID,
+    } as Record<string, PublicKey>)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .rpc()) as string;
+}

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -38,6 +38,7 @@ model Job {
 
   delivery         Delivery?
   dispute          Dispute?
+  claim            ClaimListing?
   submissions      Submission[]
   events           JobEvent[]
   interests        JobInterest[]
@@ -46,6 +47,45 @@ model Job {
   @@index([takerWallet])
   @@index([status])
   @@index([challengeEndAt])
+}
+
+// ============================================================================
+// Covenant Credit — BNPL / factoring for pending claims
+// ============================================================================
+//
+// Mirrors the on-chain `ClaimListing` account introduced in PR #36. Every
+// row MUST correspond to a real PDA at seeds=[b"claim", job_escrow.key()]
+// on the Covenant program. This table is a denormalized view for fast
+// marketplace queries — chain is always the source of truth.
+
+model ClaimListing {
+  id              String    @id @default(cuid())
+  pda             String    @unique         // on-chain ClaimListing PDA (base58)
+  jobId           String    @unique         // 1:1 with our Job row
+  jobPda          String                    // on-chain JobEscrow PDA (base58)
+  sellerWallet   String                     // original taker / seller
+  buyerWallet    String?                    // lender after purchase
+  price          Float                      // USDC human units the buyer pays
+  faceValue      Float                      // USDC human units the buyer receives on finalize
+  priceAtomic    String                     // atomic u64 as string (avoid JS precision loss)
+  faceValueAtomic String
+  status         String    @default("Listed") // Listed | Bought | Cancelled | Settled
+  listedAt       DateTime  @default(now())
+  boughtAt       DateTime?
+  settledAt      DateTime?
+  listTxHash     String?                    // list_claim tx signature
+  buyTxHash      String?                    // buy_claim tx signature
+  cancelTxHash   String?                    // cancel_claim tx signature
+  settleTxHash   String?                    // finalize/resolve tx that paid the buyer
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  job            Job       @relation(fields: [jobId], references: [id])
+
+  @@index([sellerWallet])
+  @@index([buyerWallet])
+  @@index([status])
+  @@index([listedAt])
 }
 
 // Delivery commitment submitted by the taker via submit_work.


### PR DESCRIPTION
## TL;DR

Completes the Covenant Credit demo loop on top of PR #36's on-chain primitive. After this merges, the full 3-minute pitch flow is playable end-to-end:

1. Agent delivers work → \"Your pending payments\" card on \`/credit\`
2. Click \"Sell claim →\" → discount slider modal
3. Sign \`list_claim\` in wallet → listing appears on marketplace
4. Lender (different wallet) opens \`/credit\` → sees active listings sorted by APR
5. Click \"Buy claim\" → signs \`buy_claim\` → seller receives USDC atomically
6. (After challenge period) \`finalize_payment\` routes to buyer

## Depends on #36

Base branch is \`feat/covenant-credit-onchain\` (Phase 1). Rebase to \`main\` after #36 merges.

## Files

**New**
- \`app/lib/credit-server.ts\` — server helpers (fetch + bot-signed)
- \`app/app/api/claims/route.ts\` — GET marketplace + POST mirror list
- \`app/app/api/claims/[id]/buy/route.ts\` — POST mirror buy
- \`app/app/api/claims/[id]/cancel/route.ts\` — POST mirror cancel
- \`app/app/credit/page.tsx\` — marketplace UI
- \`app/components/SellClaimButton.tsx\` — drop-in CTA for delivered jobs

**Modified**
- \`app/lib/anchor-browser.ts\` — \`listClaimOnChain\`, \`buyClaimOnChain\`, \`cancelClaimOnChain\`
- \`app/prisma/schema.prisma\` — \`ClaimListing\` model + \`Job.claim\` relation
- \`app/components/NavBar.tsx\` — \`/credit\` tab
- \`app/app/api/jobs/route.ts\`, \`[id]/route.ts\` — include \`claim\` in responses

## Battle Arena — unchanged

Per user request. Credit lives at \`/credit\` as a sibling tab.

## Security

Every mutating API route calls \`verifyTxInvokedCovenant\` before mirroring — blocks audit C-04 arbitrary-signature replay. Server NEVER signs fund-moving tx. The seller-crank bypass prevention lives in the on-chain layer (PR #36 mandates the \`claim_listing\` account on finalize_payment / resolve_dispute).

## Migration

After merge: \`cd app && npx prisma generate && npx prisma db push\`.

## Verification (cannot run here)

- [ ] \`anchor build && anchor deploy\` (PR #36 prerequisite)
- [ ] \`prisma db push\`
- [ ] \`yarn dev\`
- [ ] Connect wallet → visit \`/credit\` → no listings yet
- [ ] As taker of a Delivered job: \"Your pending payments\" card appears with \"Sell claim →\" button
- [ ] Click → slider works → confirm → wallet prompts signature → listing appears in marketplace
- [ ] Switch wallet → click Buy claim → signature prompt → seller balance increases by price
- [ ] Warp clock / wait 1h, run finalize_payment → buyer gets face_value

## What's still missing (Phase 3+)

- Claim-aware finalize route: \`/api/jobs/[id]/finalize\` currently calls the old \`releaseFundsToTaker\`. After PR #35 (on-chain settlement refactor) merges, that path becomes \`botFinalizePayment\` and needs to include the ClaimListing PDA. Follow-up PR will wire this.
- Auto-matching lender pools (reputation-threshold rules)
- Real-time TVL dashboard with sparklines
- \`@covenant/sdk\` npm package (Public Goods Award candidate)

## Diff

11 files, ~1100 lines added. Battle Arena untouched.