### PR TITLE
feat(credit): Phase 3 — claim-aware finalize + live visualizer + SDK BNPL

### DIFF
--- a/app/app/api/claims/stats/route.ts
+++ b/app/app/api/claims/stats/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+/**
+ * GET /api/claims/stats
+ *
+ * Aggregate time-series stats for the /credit/dashboard visualizer.
+ * Buckets claims by hour over the last 7 days and exposes four
+ * rolling series:
+ *   - tvl[]        — active-listing face value per hour
+ *   - boughtCount[] — purchases closed per hour
+ *   - settledCount[] — finalizations routed to buyers per hour
+ *   - avgApr[]      — average APR of listings active in that bucket
+ *
+ * Plus point-in-time totals used by the hero strip.
+ */
+export async function GET() {
+  try {
+    const now = Date.now();
+    const HOUR = 3600_000;
+    const BUCKETS = 24 * 7;
+    const start = now - BUCKETS * HOUR;
+
+    // Point-in-time totals (fast).
+    const [listed, bought, settled, cancelled] = await Promise.all([
+      prisma.claimListing.findMany({
+        where: { status: "Listed" },
+        include: { job: { select: { challengeEndAt: true, amount: true } } },
+      }),
+      prisma.claimListing.count({ where: { status: "Bought" } }),
+      prisma.claimListing.count({ where: { status: "Settled" } }),
+      prisma.claimListing.count({ where: { status: "Cancelled" } }),
+    ]);
+
+    const activeTvl = listed.reduce((sum, c) => sum + c.faceValue, 0);
+
+    // Compute current APR distribution.
+    const aprs: number[] = [];
+    for (const c of listed) {
+      if (!c.job.challengeEndAt) continue;
+      const secondsLeft = Math.max(
+        1,
+        Math.round((c.job.challengeEndAt.getTime() - now) / 1000),
+      );
+      const years = secondsLeft / (365 * 24 * 3600);
+      const apr = ((c.faceValue / c.price) - 1) / years;
+      if (isFinite(apr)) aprs.push(Math.min(9999, apr * 100));
+    }
+    aprs.sort((a, b) => a - b);
+    const aprMedian = aprs.length > 0 ? aprs[Math.floor(aprs.length / 2)] : 0;
+    const aprP90 =
+      aprs.length > 0 ? aprs[Math.min(aprs.length - 1, Math.floor(aprs.length * 0.9))] : 0;
+
+    // Bucket historical events by hour for sparklines.
+    const rows = await prisma.claimListing.findMany({
+      where: {
+        OR: [
+          { listedAt: { gte: new Date(start) } },
+          { boughtAt: { gte: new Date(start) } },
+          { settledAt: { gte: new Date(start) } },
+        ],
+      },
+      select: {
+        listedAt: true,
+        boughtAt: true,
+        settledAt: true,
+        faceValue: true,
+        price: true,
+      },
+    });
+
+    const tvl = new Array<number>(BUCKETS).fill(0);
+    const boughtSeries = new Array<number>(BUCKETS).fill(0);
+    const settledSeries = new Array<number>(BUCKETS).fill(0);
+    const volumeSeries = new Array<number>(BUCKETS).fill(0);
+
+    for (const r of rows) {
+      if (r.listedAt) {
+        const b = Math.floor((r.listedAt.getTime() - start) / HOUR);
+        if (b >= 0 && b < BUCKETS) tvl[b] += r.faceValue;
+      }
+      if (r.boughtAt) {
+        const b = Math.floor((r.boughtAt.getTime() - start) / HOUR);
+        if (b >= 0 && b < BUCKETS) {
+          boughtSeries[b] += 1;
+          volumeSeries[b] += r.price;
+        }
+      }
+      if (r.settledAt) {
+        const b = Math.floor((r.settledAt.getTime() - start) / HOUR);
+        if (b >= 0 && b < BUCKETS) settledSeries[b] += 1;
+      }
+    }
+
+    // Cumulative TVL (listings are created, then eventually removed; we
+    // approximate with running sum of listed face values bucketed at list
+    // time — imperfect but fine for a hackathon demo sparkline).
+    const tvlCumulative: number[] = [];
+    let running = 0;
+    for (const v of tvl) {
+      running += v;
+      tvlCumulative.push(running);
+    }
+
+    return NextResponse.json({
+      now,
+      bucketHours: BUCKETS,
+      totals: {
+        activeListings: listed.length,
+        activeTvl,
+        boughtCount: bought,
+        settledCount: settled,
+        cancelledCount: cancelled,
+      },
+      apr: {
+        median: aprMedian,
+        p90: aprP90,
+        distribution: aprs,
+      },
+      series: {
+        tvlCumulative,
+        boughtPerHour: boughtSeries,
+        settledPerHour: settledSeries,
+        volumePerHour: volumeSeries,
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/claims/stats error:", error);
+    return NextResponse.json(
+      { error: "Failed to compute claim stats" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/cron/finalize/route.ts
+++ b/app/app/api/cron/finalize/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { releaseFundsToTaker } from "@/lib/escrow";
+import {
+  finalizeWithClaim,
+  keypairFromEnv,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
 
 // Always dynamic — this route talks to Prisma on every request.
 export const dynamic = "force-dynamic";
@@ -74,13 +79,43 @@ export async function GET(req: NextRequest) {
     error?: string;
   }> = [];
 
+  // Load crank keypair once; fall back to DEPLOYER_KEYPAIR if not set.
+  const crankEnv = process.env.CRANK_KEYPAIR ? "CRANK_KEYPAIR" : "DEPLOYER_KEYPAIR";
+  let crankKp;
+  try {
+    crankKp = keypairFromEnv(crankEnv);
+  } catch {
+    crankKp = null;
+  }
+
   for (const job of candidates) {
     if (!job.takerWallet) {
       results.push({ jobId: job.id, ok: false, error: "no taker wallet" });
       continue;
     }
     try {
-      const { txHash } = await releaseFundsToTaker(job.takerWallet, job.amount);
+      // On-chain path (claim-aware) if the job has both pda + escrowAta.
+      let txHash: string;
+      let routedToBuyer = false;
+      let settlementBuyer: string | null = null;
+
+      if (job.pda && job.escrowAta && crankKp) {
+        const result = await finalizeWithClaim({
+          crankKeypair: crankKp,
+          poster: new PublicKey(job.posterWallet),
+          taker: new PublicKey(job.takerWallet),
+          specHash: Buffer.from(job.specHash, "hex"),
+          escrowTokenAccount: new PublicKey(job.escrowAta),
+        });
+        txHash = result.sig;
+        routedToBuyer = result.routedToBuyer;
+        settlementBuyer = result.buyer;
+      } else {
+        // Legacy custodial path for pre-on-chain jobs.
+        const r = await releaseFundsToTaker(job.takerWallet, job.amount);
+        txHash = r.txHash;
+      }
+
       await prisma.$transaction(async (tx) => {
         await tx.job.update({
           where: { id: job.id },
@@ -110,6 +145,8 @@ export async function GET(req: NextRequest) {
               taker: job.takerWallet,
               paymentTxHash: txHash,
               crank: "cron",
+              routedToBuyer,
+              buyer: settlementBuyer,
             },
           },
         });
@@ -118,11 +155,28 @@ export async function GET(req: NextRequest) {
             txHash,
             type: "finalize_payment",
             jobId: job.id,
-            wallet: job.takerWallet as string,
+            wallet: (routedToBuyer && settlementBuyer) || (job.takerWallet as string),
             amount: job.amount,
             status: "confirmed",
           },
         });
+
+        // Mirror Covenant Credit settlement.
+        if (routedToBuyer && settlementBuyer) {
+          const claim = await tx.claimListing.findUnique({
+            where: { jobId: job.id },
+          });
+          if (claim && claim.status === "Bought") {
+            await tx.claimListing.update({
+              where: { id: claim.id },
+              data: {
+                status: "Settled",
+                settledAt: new Date(),
+                settleTxHash: txHash,
+              },
+            });
+          }
+        }
       });
       results.push({ jobId: job.id, ok: true, paymentTxHash: txHash });
     } catch (err) {

--- a/app/app/api/jobs/[id]/finalize/route.ts
+++ b/app/app/api/jobs/[id]/finalize/route.ts
@@ -5,6 +5,11 @@ import { releaseFundsToTaker } from "@/lib/escrow";
 import { awardXP, XP_REWARDS } from "@/lib/xp";
 import { checkAndUnlock } from "@/lib/achievements";
 import { PROTOCOL_FEE_BPS } from "@/lib/constants";
+import {
+  finalizeWithClaim,
+  keypairFromEnv,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
 import crypto from "crypto";
 
 /**
@@ -85,18 +90,61 @@ export async function POST(
       });
     }
 
-    // 2. Release escrow (skip for agent-fulfilled jobs — no real USDC was locked)
+    // 2. Release escrow. Two paths:
+    //   A. On-chain: job has `pda` + `escrowAta` → use the permissionless
+    //      `finalize_payment` crank via lib/credit-server.finalizeWithClaim.
+    //      If a ClaimListing exists in Bought state, proceeds route to
+    //      the buyer; otherwise to the taker. Reputation always credits
+    //      the original taker.
+    //   B. Legacy custodial: job was created before on-chain escrow
+    //      landed — fall back to releaseFundsToTaker. The custodial
+    //      pool still holds those funds.
+    //   C. Synthetic agent job: no funds to move, just marker.
     const isAgentJob = job.takerWallet.startsWith("covenant-agent-");
     let paymentTxHash: string | null = null;
+    let routedToBuyer = false;
+    let settlementBuyer: string | null = null;
+
     if (isAgentJob) {
       paymentTxHash = "agent:finalized:" + crypto.randomBytes(12).toString("hex");
+    } else if (job.pda && job.escrowAta) {
+      // Path A — on-chain, claim-aware.
+      try {
+        const crankEnv = process.env.CRANK_KEYPAIR ? "CRANK_KEYPAIR" : "DEPLOYER_KEYPAIR";
+        const crankKp = keypairFromEnv(crankEnv);
+        const result = await finalizeWithClaim({
+          crankKeypair: crankKp,
+          poster: new PublicKey(job.posterWallet),
+          taker: new PublicKey(job.takerWallet),
+          specHash: Buffer.from(job.specHash, "hex"),
+          escrowTokenAccount: new PublicKey(job.escrowAta),
+        });
+        paymentTxHash = result.sig;
+        routedToBuyer = result.routedToBuyer;
+        settlementBuyer = result.buyer;
+      } catch (err) {
+        console.error("[finalize] on-chain finalizeWithClaim failed:", err);
+        await prisma.job.updateMany({
+          where: { id, status: "Finalized" },
+          data: { status: "Delivered" },
+        });
+        return NextResponse.json(
+          {
+            error:
+              "On-chain finalize failed; funds remain locked in the PDA escrow. " +
+              "Another crank (frontend or manual) can retry.",
+            detail: err instanceof Error ? err.message : String(err),
+          },
+          { status: 500 },
+        );
+      }
     } else {
+      // Path B — legacy custodial fallback.
       try {
         const result = await releaseFundsToTaker(job.takerWallet, job.amount);
         paymentTxHash = result.txHash;
       } catch (err) {
-        console.error("[finalize] escrow release failed:", err);
-        // Revert status so it can be retried
+        console.error("[finalize] custodial release failed:", err);
         await prisma.job.updateMany({
           where: { id, status: "Finalized" },
           data: { status: "Delivered" },
@@ -109,6 +157,30 @@ export async function POST(
           },
           { status: 500 },
         );
+      }
+    }
+
+    // 2b. If a Covenant Credit claim was routed to a buyer, mirror the
+    //     settlement into the DB so the marketplace reflects terminal
+    //     state.
+    if (routedToBuyer && paymentTxHash && settlementBuyer) {
+      try {
+        const claim = await prisma.claimListing.findUnique({
+          where: { jobId: id },
+        });
+        if (claim && claim.status === "Bought") {
+          await prisma.claimListing.update({
+            where: { id: claim.id },
+            data: {
+              status: "Settled",
+              settledAt: new Date(),
+              settleTxHash: paymentTxHash,
+            },
+          });
+        }
+      } catch (err) {
+        console.error("[finalize] claim settlement mirror failed:", err);
+        // non-blocking
       }
     }
 

--- a/app/app/credit/dashboard/page.tsx
+++ b/app/app/credit/dashboard/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+/**
+ * Covenant Credit — real-time visualizer.
+ *
+ * One-glance dashboard that tells the protocol story: how much claim
+ * paper is live, what it's priced at, how fast it's moving. Intended
+ * as a Twitter-shareable artifact during the hackathon.
+ *
+ * All charts are pure SVG (no charting library) — keeps the bundle
+ * small and the demo dependency-free.
+ */
+
+import { useEffect, useState } from "react";
+import NavBar from "@/components/NavBar";
+
+interface StatsResponse {
+  now: number;
+  bucketHours: number;
+  totals: {
+    activeListings: number;
+    activeTvl: number;
+    boughtCount: number;
+    settledCount: number;
+    cancelledCount: number;
+  };
+  apr: {
+    median: number;
+    p90: number;
+    distribution: number[];
+  };
+  series: {
+    tvlCumulative: number[];
+    boughtPerHour: number[];
+    settledPerHour: number[];
+    volumePerHour: number[];
+  };
+}
+
+function Sparkline({
+  values,
+  width = 560,
+  height = 80,
+  stroke = "#fffeb2",
+  fill = "rgba(255,254,178,0.1)",
+}: {
+  values: number[];
+  width?: number;
+  height?: number;
+  stroke?: string;
+  fill?: string;
+}) {
+  if (values.length === 0) {
+    return (
+      <div
+        style={{ width, height, color: "rgba(255,255,255,0.3)", fontSize: 11 }}
+      >
+        no data
+      </div>
+    );
+  }
+
+  const max = Math.max(1, ...values);
+  const min = Math.min(0, ...values);
+  const range = max - min || 1;
+  const step = width / Math.max(1, values.length - 1);
+
+  const toY = (v: number) =>
+    height - ((v - min) / range) * height * 0.9 - height * 0.05;
+
+  const linePath = values
+    .map((v, i) => `${i === 0 ? "M" : "L"} ${(i * step).toFixed(2)} ${toY(v).toFixed(2)}`)
+    .join(" ");
+
+  const areaPath =
+    linePath +
+    ` L ${(values.length - 1) * step} ${height} L 0 ${height} Z`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      style={{ display: "block" }}
+    >
+      <path d={areaPath} fill={fill} stroke="none" />
+      <path d={linePath} fill="none" stroke={stroke} strokeWidth={1.5} />
+    </svg>
+  );
+}
+
+function Histogram({
+  values,
+  buckets = 20,
+  width = 560,
+  height = 80,
+  stroke = "#7CFF7C",
+}: {
+  values: number[];
+  buckets?: number;
+  width?: number;
+  height?: number;
+  stroke?: string;
+}) {
+  if (values.length === 0) {
+    return (
+      <div
+        style={{ width, height, color: "rgba(255,255,255,0.3)", fontSize: 11 }}
+      >
+        no claims yet
+      </div>
+    );
+  }
+
+  const capped = values.map((v) => Math.min(1500, v));
+  const max = Math.max(100, ...capped);
+  const bucketWidth = max / buckets;
+  const histogram = new Array<number>(buckets).fill(0);
+  for (const v of capped) {
+    const b = Math.min(buckets - 1, Math.floor(v / bucketWidth));
+    histogram[b] += 1;
+  }
+  const maxCount = Math.max(1, ...histogram);
+
+  const barWidth = width / buckets;
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+      {histogram.map((count, i) => {
+        const h = (count / maxCount) * (height - 4);
+        return (
+          <rect
+            key={i}
+            x={i * barWidth + 1}
+            y={height - h}
+            width={barWidth - 2}
+            height={h}
+            fill={stroke}
+            opacity={0.8}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function formatMoney(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+export default function CreditDashboardPage() {
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    async function tick() {
+      try {
+        const res = await fetch("/api/claims/stats");
+        if (!res.ok) return;
+        const json = await res.json();
+        if (alive) {
+          setStats(json);
+          setLoading(false);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    tick();
+    const iv = setInterval(tick, 5000);
+    return () => {
+      alive = false;
+      clearInterval(iv);
+    };
+  }, []);
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#0b0b0b", color: "#fff", fontFamily: "inherit" }}>
+      <NavBar activeTab="credit" variant="dark" />
+
+      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "40px 24px 80px" }}>
+        <div style={{ marginBottom: 32 }}>
+          <div
+            style={{
+              fontSize: 12,
+              textTransform: "uppercase",
+              letterSpacing: "0.15em",
+              color: "#fffeb2",
+              marginBottom: 8,
+            }}
+          >
+            Covenant Credit — Live Visualizer
+          </div>
+          <div style={{ fontSize: 34, fontWeight: 800, marginBottom: 8 }}>
+            Agent paper is flowing.
+          </div>
+          <div style={{ fontSize: 13, color: "rgba(255,255,255,0.5)" }}>
+            Updated every 5 seconds · 7-day rolling window
+          </div>
+        </div>
+
+        {/* Hero stats */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(5, 1fr)",
+            gap: 12,
+            marginBottom: 40,
+          }}
+        >
+          <Tile
+            label="Active TVL"
+            value={stats ? formatMoney(stats.totals.activeTvl) : "—"}
+            accent="#fffeb2"
+          />
+          <Tile
+            label="Active listings"
+            value={stats ? String(stats.totals.activeListings) : "—"}
+          />
+          <Tile
+            label="Bought"
+            value={stats ? String(stats.totals.boughtCount) : "—"}
+            accent="#7CFF7C"
+          />
+          <Tile
+            label="Settled"
+            value={stats ? String(stats.totals.settledCount) : "—"}
+            accent="#7CFF7C"
+          />
+          <Tile
+            label="Median APR"
+            value={stats ? `${Math.round(stats.apr.median)}%` : "—"}
+            accent="#7CFF7C"
+          />
+        </div>
+
+        {/* Sparklines */}
+        <ChartCard title="TVL listed (cumulative, 7d)">
+          <Sparkline values={stats?.series.tvlCumulative ?? []} />
+        </ChartCard>
+
+        <ChartCard title="Claims bought per hour">
+          <Sparkline
+            values={stats?.series.boughtPerHour ?? []}
+            stroke="#7CFF7C"
+            fill="rgba(124,255,124,0.08)"
+          />
+        </ChartCard>
+
+        <ChartCard title="Claims settled per hour (routed to buyers)">
+          <Sparkline
+            values={stats?.series.settledPerHour ?? []}
+            stroke="#4DA6FF"
+            fill="rgba(77,166,255,0.08)"
+          />
+        </ChartCard>
+
+        <ChartCard title="Buy volume per hour (USDC flowing to sellers)">
+          <Sparkline
+            values={stats?.series.volumePerHour ?? []}
+            stroke="#FFB84D"
+            fill="rgba(255,184,77,0.08)"
+          />
+        </ChartCard>
+
+        <ChartCard
+          title={`APR distribution across active listings (median ${
+            stats ? Math.round(stats.apr.median) : 0
+          }% · p90 ${stats ? Math.round(stats.apr.p90) : 0}%)`}
+        >
+          <Histogram values={stats?.apr.distribution ?? []} />
+        </ChartCard>
+
+        <div
+          style={{
+            marginTop: 40,
+            padding: 20,
+            background: "rgba(255,255,255,0.03)",
+            border: "1px solid rgba(255,255,255,0.06)",
+            borderRadius: 10,
+            fontSize: 12,
+            color: "rgba(255,255,255,0.5)",
+            lineHeight: 1.6,
+          }}
+        >
+          {loading
+            ? "Loading stats…"
+            : "All data is computed from on-chain ClaimListing PDAs mirrored into the DB. Chain is the source of truth; this dashboard is a denormalized view."}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: string;
+}) {
+  return (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderRadius: 10,
+        padding: "16px 18px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "rgba(255,255,255,0.45)",
+          marginBottom: 6,
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 700, color: accent ?? "#fff" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ChartCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.06)",
+        borderRadius: 10,
+        padding: "16px 20px",
+        marginBottom: 16,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 11,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "rgba(255,255,255,0.5)",
+          marginBottom: 10,
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ overflowX: "auto" }}>{children}</div>
+    </div>
+  );
+}

--- a/app/app/credit/page.tsx
+++ b/app/app/credit/page.tsx
@@ -232,14 +232,37 @@ export default function CreditMarketplacePage() {
         <div style={{ marginBottom: 32 }}>
           <div
             style={{
-              fontSize: 12,
-              textTransform: "uppercase",
-              letterSpacing: "0.15em",
-              color: "#fffeb2",
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
               marginBottom: 8,
             }}
           >
-            Covenant Credit
+            <div
+              style={{
+                fontSize: 12,
+                textTransform: "uppercase",
+                letterSpacing: "0.15em",
+                color: "#fffeb2",
+              }}
+            >
+              Covenant Credit
+            </div>
+            <a
+              href="/credit/dashboard"
+              style={{
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "rgba(255,255,255,0.6)",
+                textDecoration: "none",
+                padding: "4px 10px",
+                border: "1px solid rgba(255,255,255,0.15)",
+                borderRadius: 4,
+              }}
+            >
+              Live dashboard →
+            </a>
           </div>
           <div style={{ fontSize: 40, fontWeight: 800, lineHeight: 1.1, marginBottom: 12 }}>
             BNPL for AI agents.

--- a/app/lib/credit-server.ts
+++ b/app/lib/credit-server.ts
@@ -278,3 +278,109 @@ export async function botBuyClaim(params: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .rpc()) as string;
 }
+
+// ---- Claim-aware finalize crank ----
+
+/**
+ * Derive the expected `reputation` PDA for a taker.
+ */
+export function deriveReputationPda(wallet: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("reputation"), wallet.toBuffer()],
+    PROGRAM_ID,
+  );
+}
+
+/**
+ * Permissionless finalize crank that correctly routes payment when a
+ * claim has been sold.
+ *
+ * Logic:
+ *   1. Derive the ClaimListing PDA for this job
+ *   2. Fetch it; if status=Bought, the beneficiary ATA is the buyer's
+ *      USDC ATA. Otherwise it's the taker's ATA.
+ *   3. Invoke on-chain finalize_payment with:
+ *      - crank = our CRANK_KEYPAIR / DEPLOYER_KEYPAIR signer
+ *      - taker_token_account = beneficiary ATA from step 2
+ *      - claim_listing = the PDA (always passed; uninitialized if no
+ *        listing, Anchor still validates the address)
+ *
+ * Returns the tx signature. Throws on any on-chain error.
+ */
+export async function finalizeWithClaim(params: {
+  crankKeypair: Keypair;
+  poster: PublicKey;
+  taker: PublicKey;
+  specHash: Buffer;
+  escrowTokenAccount: PublicKey;
+}): Promise<{ sig: string; routedToBuyer: boolean; buyer: string | null }> {
+  const { crankKeypair, poster, taker, specHash, escrowTokenAccount } = params;
+
+  const program = getBotProgram(crankKeypair);
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+  const [reputationPda] = deriveReputationPda(taker);
+
+  // Discover who the beneficiary should be.
+  const listing = await fetchClaimListing(claimPda);
+  let beneficiaryWallet: PublicKey = taker;
+  let routedToBuyer = false;
+  let buyerStr: string | null = null;
+  if (listing && listing.status === "Bought" && listing.buyer) {
+    beneficiaryWallet = new PublicKey(listing.buyer);
+    routedToBuyer = true;
+    buyerStr = listing.buyer;
+  }
+
+  const beneficiaryAta = await getAssociatedTokenAddress(
+    USDC_MINT,
+    beneficiaryWallet,
+  );
+
+  const sig = (await (program.methods as { finalizePayment: () => unknown })
+    .finalizePayment()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .accounts({
+      crank: crankKeypair.publicKey,
+      jobEscrow: jobPda,
+      poster,
+      escrowTokenAccount,
+      takerTokenAccount: beneficiaryAta,
+      taker,
+      takerReputation: reputationPda,
+      claimListing: claimPda,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      systemProgram: SystemProgram.programId,
+    } as Record<string, PublicKey>)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .rpc()) as string;
+
+  return { sig, routedToBuyer, buyer: buyerStr };
+}
+
+/**
+ * Derive the escrow ATA owner ≡ the JobEscrow PDA. Since the on-chain
+ * escrow_token_account was created in `create_job` as a random keypair
+ * owned by the JobEscrow PDA, a caller that lost the escrowAta can
+ * reconstruct it by asking the SPL Token program for the single token
+ * account matching `(owner=jobPda, mint=tokenMint)`.
+ *
+ * This is expensive (RPC call) but works as a recovery path when the
+ * DB row is missing escrowAta (pre-schema-bump jobs).
+ */
+export async function findEscrowTokenAccount(params: {
+  jobPda: PublicKey;
+}): Promise<PublicKey | null> {
+  const conn = getConnection();
+  const { jobPda } = params;
+  const accounts = await conn.getTokenAccountsByOwner(jobPda, {
+    mint: USDC_MINT,
+  });
+  if (accounts.value.length === 0) return null;
+  // There's exactly one in the happy path. If multiple exist (shouldn't
+  // per create_job semantics), take the first non-empty one.
+  const nonEmpty = accounts.value.find(
+    (a) => BigInt(a.account.data.length) > 0n,
+  );
+  return nonEmpty?.pubkey ?? accounts.value[0].pubkey;
+}

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -14,6 +14,7 @@ datasource db {
 model Job {
   id               String      @id @default(cuid())
   pda              String?     @unique // on-chain JobEscrow PDA (base58)
+  escrowAta        String?     // SPL escrow token account (base58); random keypair in v1, not a PDA
   posterWallet     String
   takerWallet      String?
   amount           Float

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -178,6 +178,78 @@ Implement `DeliveryStorage` for IPFS, Arweave, S3, or any other backend.
 | `DELIVERY_URI_MAX_LEN` | `128` bytes | Hard on-chain cap |
 | `ARBITRATOR_COUNT` | `3` | 2-of-3 multisig in v1 |
 
+## Covenant Credit — BNPL for agents
+
+A taker who has delivered work may sell their pending payment claim to
+a lender at a discount. The lender pays the seller immediately and
+inherits the right to collect the full face value when
+`finalize_payment` fires. If the job ends up `FavorPoster` during the
+challenge window, the lender loses their principal — that risk is
+priced into the discount.
+
+### Listing a claim (seller side)
+
+```ts
+import BN from "bn.js";
+
+// Seller = taker of a Delivered, non-disputed job.
+// Price in USDC atomic units (6 decimals). Must be strictly less
+// than the job's face value — no rational buyer at par.
+const { txSig, claimPda } = await covenant.listClaim({
+  seller: takerKeypair,
+  jobPda,
+  price: new BN(9_700_000), // 9.7 USDC on a 10 USDC claim = ~3% discount
+});
+```
+
+### Buying a claim (lender side)
+
+```ts
+const { txSig } = await covenant.buyClaim({
+  buyer: lenderKeypair,
+  jobPda,
+  buyerTokenAccount,
+  sellerTokenAccount,
+});
+// Seller receives 9.7 USDC immediately. When finalize_payment fires,
+// the full 10 USDC face value goes to the buyer.
+```
+
+### Cancelling an unsold listing
+
+```ts
+await covenant.cancelClaim({
+  seller: takerKeypair,
+  jobPda,
+});
+// Account is closed, rent refunded to seller.
+// Only valid while status === "Listed".
+```
+
+### Reading claim state
+
+```ts
+const claim = await covenant.fetchClaim(jobPda);
+if (claim?.status === "Bought") {
+  console.log(`Sold to ${claim.buyer.toBase58()} for ${claim.price.toString()} atomic units`);
+}
+```
+
+### Why this is a Solana-native primitive
+
+At Ethereum mainnet gas prices, factoring a $10 claim over a 24-hour
+window would cost more in gas than the yield. Solana's sub-cent fees
++ sub-second finality make sub-$50 claim markets economically viable.
+
+## Examples
+
+See [`examples/`](./examples) for integrations with:
+
+- **MCP** — expose Covenant as an agent-payable tool server via the
+  Model Context Protocol
+- **LangChain** — drop Covenant payment into a LangChain agent graph
+  with a single tool node
+
 ## License
 
 Apache-2.0

--- a/sdk/examples/langchain-integration.ts
+++ b/sdk/examples/langchain-integration.ts
@@ -1,0 +1,202 @@
+/**
+ * Covenant × LangChain — payment rail as a LangChain Tool.
+ *
+ * Wraps Covenant's job lifecycle as LangChain StructuredTools so an
+ * agent graph can post paying jobs, and agents on the other side can
+ * accept + deliver + collect USDC autonomously.
+ *
+ * The demo shows BOTH sides:
+ *   - Poster agent posts a writing job with 5 USDC locked in escrow
+ *   - Taker agent accepts, delivers, lists the claim on Covenant Credit
+ *     at a 3% discount, and gets paid in sub-second wall time instead
+ *     of waiting 24h
+ *
+ * NOTE: This is illustrative. You'll want to swap the in-memory
+ * keypair loader with a secure wallet provider in production.
+ */
+
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import { getAssociatedTokenAddress } from "@solana/spl-token";
+import {
+  CovenantClient,
+  DEVNET_USDC_MINT,
+  hashSpec,
+  type JobSpec,
+} from "@wienerlabs/covenant-sdk";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import idl from "../dist/covenant-idl.json" with { type: "json" };
+
+function clientFor(keypair: Keypair): CovenantClient {
+  const conn = new Connection(
+    process.env.HELIUS_RPC_URL ?? "https://api.devnet.solana.com",
+    "confirmed",
+  );
+  const provider = new AnchorProvider(conn, new Wallet(keypair), {
+    commitment: "confirmed",
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return CovenantClient.fromProvider(provider, idl as any);
+}
+
+function loadKeypair(envVar: string): Keypair {
+  const raw = process.env[envVar];
+  if (!raw) throw new Error(`${envVar} not set`);
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(raw)));
+}
+
+// --- Tools ---------------------------------------------------------------
+
+export const covenantPostJobTool = new DynamicStructuredTool({
+  name: "covenant_post_job",
+  description:
+    "Create a paying job on Covenant. USDC is locked in a per-job PDA " +
+    "escrow on Solana and released to whoever delivers the work first. " +
+    "Returns the job PDA so the agent can track it.",
+  schema: z.object({
+    title: z.string(),
+    amountUsdc: z.number().positive(),
+    minWords: z.number().int().positive(),
+    deadlineHoursFromNow: z.number().positive(),
+  }),
+  func: async ({ title, amountUsdc, minWords, deadlineHoursFromNow }) => {
+    const poster = loadKeypair("POSTER_KEYPAIR");
+    const covenant = clientFor(poster);
+
+    const spec: JobSpec = {
+      type: "langchain.job.v1",
+      category: "text_writing",
+      language: "English",
+      minWords,
+      deadlineUnix:
+        Math.floor(Date.now() / 1000) + Math.round(deadlineHoursFromNow * 3600),
+      metadata: { title, source: "langchain-agent" },
+    };
+    const posterAta = await getAssociatedTokenAddress(
+      DEVNET_USDC_MINT,
+      poster.publicKey,
+    );
+
+    const { jobPda, txSig } = await covenant.createJob({
+      poster,
+      spec,
+      amount: new BN(Math.round(amountUsdc * 1_000_000)),
+      posterTokenAccount: posterAta,
+      tokenMint: DEVNET_USDC_MINT,
+    });
+
+    const specHash = hashSpec(spec);
+    return JSON.stringify({
+      jobPda: jobPda.toBase58(),
+      txSig,
+      specHash,
+    });
+  },
+});
+
+export const covenantSellClaimTool = new DynamicStructuredTool({
+  name: "covenant_sell_claim",
+  description:
+    "Covenant Credit: after the agent has DELIVERED work on a job, " +
+    "sell the pending payment claim at a discount to a lender and get " +
+    "paid immediately instead of waiting for the 24h challenge window " +
+    "to expire. Use this when the agent needs cash flow to accept the " +
+    "next job.",
+  schema: z.object({
+    jobPda: z.string(),
+    discountPct: z.number().min(0.5).max(20).default(3),
+  }),
+  func: async ({ jobPda, discountPct }) => {
+    const seller = loadKeypair("TAKER_KEYPAIR");
+    const covenant = clientFor(seller);
+
+    const jobKey = new PublicKey(jobPda);
+    const job = await covenant.fetchJob(jobKey);
+    const faceValue = job.amount.toNumber();
+    const price = new BN(Math.round(faceValue * (1 - discountPct / 100)));
+
+    const { txSig, claimPda } = await covenant.listClaim({
+      seller,
+      jobPda: jobKey,
+      price,
+    });
+
+    return JSON.stringify({
+      claimPda: claimPda.toBase58(),
+      txSig,
+      facedValueAtomic: faceValue,
+      priceAtomic: price.toString(),
+      discountPct,
+    });
+  },
+});
+
+export const covenantBuyClaimTool = new DynamicStructuredTool({
+  name: "covenant_buy_claim",
+  description:
+    "Covenant Credit: lender side. Buy a listed agent claim at its " +
+    "discounted price. On success the buyer receives the full face " +
+    "value when the job settles on chain — earning yield for bearing " +
+    "dispute risk during the challenge window.",
+  schema: z.object({
+    jobPda: z.string(),
+  }),
+  func: async ({ jobPda }) => {
+    const buyer = loadKeypair("LENDER_KEYPAIR");
+    const covenant = clientFor(buyer);
+
+    const jobKey = new PublicKey(jobPda);
+    const claim = await covenant.fetchClaim(jobKey);
+    if (!claim) throw new Error("no claim listing for this job");
+    if (claim.status !== "Listed") {
+      throw new Error(`claim is ${claim.status}, expected Listed`);
+    }
+
+    const buyerAta = await getAssociatedTokenAddress(
+      DEVNET_USDC_MINT,
+      buyer.publicKey,
+    );
+    const sellerAta = await getAssociatedTokenAddress(
+      DEVNET_USDC_MINT,
+      claim.seller,
+    );
+
+    const { txSig } = await covenant.buyClaim({
+      buyer,
+      jobPda: jobKey,
+      buyerTokenAccount: buyerAta,
+      sellerTokenAccount: sellerAta,
+    });
+
+    return JSON.stringify({
+      txSig,
+      paidAtomic: claim.price.toString(),
+      willReceiveAtomic: claim.faceValue.toString(),
+    });
+  },
+});
+
+/**
+ * All Covenant tools, ready to plug into an AgentExecutor.
+ *
+ * Example:
+ *
+ *   const agent = await createOpenAIToolsAgent({
+ *     llm: new ChatOpenAI({ model: "gpt-4o" }),
+ *     tools: covenantTools,
+ *     prompt: myPrompt,
+ *   });
+ *   const executor = new AgentExecutor({ agent, tools: covenantTools });
+ *   await executor.invoke({
+ *     input: "Post a $5 job for a 500-word product description, " +
+ *            "then once the work lands, sell my claim at 3% to lock in cash flow.",
+ *   });
+ */
+export const covenantTools = [
+  covenantPostJobTool,
+  covenantSellClaimTool,
+  covenantBuyClaimTool,
+];

--- a/sdk/examples/mcp-integration.ts
+++ b/sdk/examples/mcp-integration.ts
@@ -1,0 +1,159 @@
+/**
+ * Covenant × MCP — agent-payable tool server over Model Context Protocol.
+ *
+ * This example exposes two MCP tools:
+ *   - `post_job`   : clients (typically LLMs or agent frameworks) create
+ *                    a paying Covenant job with USDC locked in escrow.
+ *   - `finalize`   : once work has been delivered and the challenge
+ *                    period has elapsed, the crank releases the escrow
+ *                    (or routes it to the buyer if the claim was sold
+ *                    on Covenant Credit).
+ *
+ * Pair this with an MCP-speaking LLM agent to demo the end-to-end
+ * "agent earns money for a paid tool call" flow.
+ *
+ * NOTE: This is illustrative, not production code. It omits the MCP
+ * server boilerplate (transport, stdio wiring, etc.) and focuses on
+ * the Covenant surface.
+ */
+
+import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import {
+  CovenantClient,
+  DEVNET_USDC_MINT,
+  hashSpec,
+  type JobSpec,
+} from "@wienerlabs/covenant-sdk";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import idl from "../dist/covenant-idl.json" with { type: "json" };
+
+// --- MCP tool handlers ---------------------------------------------------
+
+export async function mcpPostJobTool(args: {
+  title: string;
+  amount: number; // USDC (human)
+  minWords: number;
+  deadlineHoursFromNow: number;
+}): Promise<{ jobPda: string; txSig: string; specHash: string }> {
+  const conn = new Connection(
+    process.env.HELIUS_RPC_URL ?? "https://api.devnet.solana.com",
+    "confirmed",
+  );
+  const poster = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(process.env.POSTER_KEYPAIR!)),
+  );
+  const provider = new AnchorProvider(conn, new Wallet(poster), {
+    commitment: "confirmed",
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const covenant = CovenantClient.fromProvider(provider, idl as any);
+
+  const spec: JobSpec = {
+    type: "mcp.prompt.v1",
+    category: "text_writing",
+    language: "English",
+    minWords: args.minWords,
+    deadlineUnix:
+      Math.floor(Date.now() / 1000) + args.deadlineHoursFromNow * 3600,
+    metadata: { title: args.title },
+  };
+  const specHashHex = hashSpec(spec);
+  const specHashBytes = Uint8Array.from(Buffer.from(specHashHex, "hex"));
+
+  // Derive poster's USDC ATA (assumed pre-funded).
+  const { getAssociatedTokenAddress } = await import("@solana/spl-token");
+  const posterAta = await getAssociatedTokenAddress(
+    DEVNET_USDC_MINT,
+    poster.publicKey,
+  );
+
+  const { jobPda, txSig, escrowTokenAccount } = await covenant.createJob({
+    poster,
+    spec,
+    amount: new BN(Math.round(args.amount * 1_000_000)), // USDC has 6 decimals
+    posterTokenAccount: posterAta,
+    tokenMint: DEVNET_USDC_MINT,
+  });
+
+  // In a real MCP server, stash escrowTokenAccount somewhere durable —
+  // you'll need it for finalize.
+  console.log("[mcp] created job", {
+    jobPda: jobPda.toBase58(),
+    escrow: escrowTokenAccount.toBase58(),
+  });
+
+  return {
+    jobPda: jobPda.toBase58(),
+    txSig,
+    specHash: specHashHex,
+  };
+}
+
+export async function mcpFinalizeTool(args: {
+  jobPda: string;
+  escrowTokenAccount: string;
+  takerTokenAccount: string;
+}): Promise<{ txSig: string; routedToBuyer: boolean }> {
+  const conn = new Connection(
+    process.env.HELIUS_RPC_URL ?? "https://api.devnet.solana.com",
+    "confirmed",
+  );
+  const crank = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(process.env.CRANK_KEYPAIR!)),
+  );
+  const provider = new AnchorProvider(conn, new Wallet(crank), {
+    commitment: "confirmed",
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const covenant = CovenantClient.fromProvider(provider, idl as any);
+
+  const jobPda = new PublicKey(args.jobPda);
+
+  // If the seller sold their claim via Covenant Credit, route payment
+  // to the buyer; otherwise to the taker. The SDK's fetchClaim handles
+  // the lookup.
+  const claim = await covenant.fetchClaim(jobPda);
+  const routedToBuyer =
+    claim !== null && claim.status === "Bought" && !claim.buyer.equals(PublicKey.default);
+
+  const { txSig } = await covenant.finalizePayment({
+    crank,
+    jobPda,
+    escrowTokenAccount: new PublicKey(args.escrowTokenAccount),
+    takerTokenAccount: new PublicKey(args.takerTokenAccount),
+  });
+
+  return { txSig, routedToBuyer };
+}
+
+// --- Minimal MCP server stub --------------------------------------------
+//
+// Replace with your MCP transport of choice. See the MCP spec at
+// https://modelcontextprotocol.io for the wire protocol.
+/*
+import { Server } from "@modelcontextprotocol/sdk/server";
+const server = new Server({ name: "covenant-payments", version: "0.1.0" });
+
+server.setTool("post_job", {
+  schema: {
+    type: "object",
+    properties: {
+      title: { type: "string" },
+      amount: { type: "number" },
+      minWords: { type: "number" },
+      deadlineHoursFromNow: { type: "number" },
+    },
+    required: ["title", "amount", "minWords", "deadlineHoursFromNow"],
+  },
+  handler: mcpPostJobTool,
+});
+
+server.setTool("finalize", {
+  schema: { ... },
+  handler: mcpFinalizeTool,
+});
+
+await server.connect(/* your transport here */);
+*/

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -16,7 +16,13 @@ import {
   DEFAULT_BOND_BPS,
   DEFAULT_MIN_BOND_ABSOLUTE,
 } from "./constants";
-import { deriveConfigPda, deriveJobPda, deriveReputationPda, deriveBondPda } from "./pda";
+import {
+  deriveConfigPda,
+  deriveJobPda,
+  deriveReputationPda,
+  deriveBondPda,
+  deriveClaimPda,
+} from "./pda";
 import { hashSpec } from "./spec";
 import { validateDeliveryUri } from "./delivery";
 import type {
@@ -27,6 +33,8 @@ import type {
   ProtocolConfigAccount,
   DisputeInfo,
   DisputeResolutionKind,
+  ClaimListingAccount,
+  ClaimStatus,
 } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -86,6 +94,14 @@ function decodeDispute(raw: RawAccount): DisputeInfo {
 function decodeDeliveryUri(bytes: Uint8Array | number[], len: number): string {
   const buf = Uint8Array.from(bytes).slice(0, len);
   return Buffer.from(buf).toString("utf8");
+}
+
+function parseClaimStatus(raw: RawAccount): ClaimStatus {
+  if ("listed" in raw) return "Listed";
+  if ("bought" in raw) return "Bought";
+  if ("cancelled" in raw) return "Cancelled";
+  if ("settled" in raw) return "Settled";
+  throw new Error(`Unknown claim status: ${JSON.stringify(raw)}`);
 }
 
 /**
@@ -418,6 +434,120 @@ export class CovenantClient {
       .rpc();
 
     return { txSig };
+  }
+
+  // ---- Covenant Credit ----
+
+  /**
+   * Derive the ClaimListing PDA for a job.
+   * seeds = [b"claim", job_escrow]
+   */
+  claimPda(jobPda: PublicKey): PublicKey {
+    return deriveClaimPda(jobPda, this.program.programId)[0];
+  }
+
+  /**
+   * List a pending payment claim at a discounted price. Only the taker
+   * of a Delivered, non-disputed job may list. Exactly one listing per
+   * job (PDA collision otherwise).
+   */
+  async listClaim(params: {
+    seller: Keypair;
+    jobPda: PublicKey;
+    price: BN;
+  }): Promise<{ txSig: TransactionSignature; claimPda: PublicKey }> {
+    const job = await this.fetchJob(params.jobPda);
+    const claimPda = this.claimPda(params.jobPda);
+
+    const txSig = await (this.program.methods as any)
+      .listClaim(params.price)
+      .accounts({
+        seller: params.seller.publicKey,
+        jobEscrow: params.jobPda,
+        poster: job.poster,
+        claimListing: claimPda,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([params.seller])
+      .rpc();
+
+    return { txSig, claimPda };
+  }
+
+  /**
+   * Buy a listed claim. The buyer pays `listing.price` USDC to the
+   * seller atomically and becomes the beneficiary of subsequent
+   * `finalize_payment` or `resolve_dispute` FavorTaker/Split proceeds.
+   */
+  async buyClaim(params: {
+    buyer: Keypair;
+    jobPda: PublicKey;
+    buyerTokenAccount: PublicKey;
+    sellerTokenAccount: PublicKey;
+  }): Promise<{ txSig: TransactionSignature }> {
+    const job = await this.fetchJob(params.jobPda);
+    const claimPda = this.claimPda(params.jobPda);
+
+    const txSig = await (this.program.methods as any)
+      .buyClaim()
+      .accounts({
+        buyer: params.buyer.publicKey,
+        jobEscrow: params.jobPda,
+        poster: job.poster,
+        claimListing: claimPda,
+        buyerTokenAccount: params.buyerTokenAccount,
+        sellerTokenAccount: params.sellerTokenAccount,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([params.buyer])
+      .rpc();
+
+    return { txSig };
+  }
+
+  /**
+   * Cancel an unsold claim listing. Refunds rent to the seller.
+   */
+  async cancelClaim(params: {
+    seller: Keypair;
+    jobPda: PublicKey;
+  }): Promise<{ txSig: TransactionSignature }> {
+    const claimPda = this.claimPda(params.jobPda);
+    const txSig = await (this.program.methods as any)
+      .cancelClaim()
+      .accounts({
+        seller: params.seller.publicKey,
+        claimListing: claimPda,
+      })
+      .signers([params.seller])
+      .rpc();
+    return { txSig };
+  }
+
+  /**
+   * Fetch + decode a ClaimListing account. Returns null if the PDA is
+   * uninitialized (no listing, or already cancelled + closed).
+   */
+  async fetchClaim(jobPda: PublicKey): Promise<ClaimListingAccount | null> {
+    const claimPda = this.claimPda(jobPda);
+    try {
+      const raw = (await (this.program.account as any)["claimListing"].fetch(
+        claimPda,
+      )) as RawAccount;
+      return {
+        job: raw.job,
+        seller: raw.seller,
+        buyer: raw.buyer,
+        price: new BN(raw.price),
+        faceValue: new BN(raw.faceValue),
+        listedAt: new BN(raw.listedAt),
+        boughtAt: new BN(raw.boughtAt),
+        status: parseClaimStatus(raw.status as RawAccount),
+        bump: Number(raw.bump),
+      };
+    } catch {
+      return null;
+    }
   }
 
   // ---- Account fetchers ----

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -42,4 +42,5 @@ export const PDA_SEEDS = {
   job: Buffer.from("job"),
   reputation: Buffer.from("reputation"),
   bond: Buffer.from("bond"),
+  claim: Buffer.from("claim"),
 } as const;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -22,6 +22,7 @@ export {
   deriveJobPda,
   deriveReputationPda,
   deriveBondPda,
+  deriveClaimPda,
 } from "./pda";
 export { parseLogLine, parseLogs } from "./events";
 export type { CovenantEvent } from "./events";
@@ -47,4 +48,6 @@ export type {
   DisputeInfo,
   DisputeResolutionKind,
   DeliveryCommitment,
+  ClaimListingAccount,
+  ClaimStatus,
 } from "./types";

--- a/sdk/src/pda.ts
+++ b/sdk/src/pda.ts
@@ -41,3 +41,14 @@ export function deriveBondPda(
     programId,
   );
 }
+
+/** Derive the ClaimListing PDA for a job (Covenant Credit). */
+export function deriveClaimPda(
+  job: PublicKey,
+  programId: PublicKey = COVENANT_PROGRAM_ID,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [PDA_SEEDS.claim, job.toBuffer()],
+    programId,
+  );
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -89,3 +89,29 @@ export interface DeliveryCommitment {
   /** Resolvable URI where the content lives. */
   deliveryUri: string;
 }
+
+// ---- Covenant Credit types ----
+
+/** Status of a ClaimListing on chain. */
+export type ClaimStatus = "Listed" | "Bought" | "Cancelled" | "Settled";
+
+/**
+ * On-chain ClaimListing account. Represents a taker's pending payment
+ * claim offered for sale to lenders.
+ */
+export interface ClaimListingAccount {
+  job: PublicKey;
+  seller: PublicKey;
+  /** `PublicKey.default` before purchase. */
+  buyer: PublicKey;
+  /** Price the buyer pays the seller (atomic token units, u64). */
+  price: BN;
+  /** Full escrow amount the buyer receives on finalize (atomic units). */
+  faceValue: BN;
+  /** Unix seconds when listed. */
+  listedAt: BN;
+  /** Unix seconds when bought. 0 until bought. */
+  boughtAt: BN;
+  status: ClaimStatus;
+  bump: number;
+}


### PR DESCRIPTION
## Ships the hackathon demo

After this merges (on top of #36 + #37), the 3-minute pitch flow is playable end-to-end AND comes with a real-time artifact for the Twitter post.

## Three parts

### 3a. Claim-aware finalize (**critical** — without this, Phase 2's demo ends with the wrong party paid)

- New helper \`finalizeWithClaim\` in \`lib/credit-server.ts\` — derives the ClaimListing PDA, picks the right beneficiary (taker or buyer), invokes on-chain \`finalize_payment\` with the mandatory \`claim_listing\` account
- Wired into \`/api/jobs/[id]/finalize\` and \`/api/cron/finalize\` (5-min cron)
- Three paths supported: agent synthetic (marker only), on-chain (finalizeWithClaim), legacy custodial fallback
- On success, mirrors the ClaimListing DB row → \`status=Settled\`, \`settledAt\`, \`settleTxHash\`
- Reputation credit always goes to the original taker regardless of who got the USDC
- Schema: \`Job.escrowAta\` added (run \`prisma db push\` after merge)

### 3b. Real-time visualizer — \`/credit/dashboard\`

- New endpoint \`/api/claims/stats\`: 7-day hourly series + APR distribution + totals
- New page with 5-tile hero + 4 SVG sparklines + 1 histogram
- **Pure SVG, zero charting dependencies** — loads instantly, no bloat
- Polls every 5s
- Linked from \`/credit\` hero as \"Live dashboard →\"

This is the **Twitter-shareable artifact** — judges (especially Anatoly, Lily Liu, Phantom/Metaplex) see activity in real time during the demo.

### 3c. SDK BNPL + integration examples

- \`CovenantClient\`: \`listClaim\`, \`buyClaim\`, \`cancelClaim\`, \`fetchClaim\`, \`claimPda\`
- Types: \`ClaimStatus\`, \`ClaimListingAccount\`
- PDA helper: \`deriveClaimPda\`
- README: full \"Covenant Credit\" section with code snippets + \"why Solana\" tagline
- **2 integration examples** (sdk/examples/):
  - \`mcp-integration.ts\` — Covenant as MCP tool server
  - \`langchain-integration.ts\` — three LangChain StructuredTools ready to drop into an AgentExecutor

Public Goods Award angle: this is a **complete, typed, documented, publishable** SDK. \`cd sdk && yarn build && yarn publish\` is one command away.

## Depends on

- PR #36 (on-chain program) — Base
- PR #37 (marketplace UI + API) — Direct parent; this PR is branched off it

## Battle Arena

Still untouched. Phase 3 lives entirely in \`/credit/dashboard\` and \`sdk/\`.

## Not in this PR (intentionally)

- **Lender pools** (reputation-threshold auto-buy): demo works fine with manual buyers; auto-pools add complexity but don't change the pitch. Ships as Phase 4 if needed.

## Verification checklist (for merger)

- [ ] \`anchor build && anchor deploy\` (PR #36)
- [ ] \`cd app && npx prisma generate && npx prisma db push\` (new \`Job.escrowAta\`)
- [ ] \`cd sdk && yarn build\` — confirm SDK compiles with BNPL exports
- [ ] Full loop smoke:
  1. Create job via \`/poster\` with USDC
  2. Accept + submit_work as a different wallet
  3. Open \`/credit\`, see \"Your pending payments\" → \"Sell claim →\"
  4. Pick 3% discount, sign tx → listing appears on marketplace
  5. Switch wallet (lender), click Buy claim → signature prompt
  6. Wait for challenge period, hit \"Finalize\" or wait for cron
  7. **Verify**: buyer's USDC balance rose by face value, seller's by list price, ClaimListing is Settled, Job is Finalized
- [ ] Open \`/credit/dashboard\`, confirm sparklines render and update every 5s
- [ ] \`cd sdk/examples && npx tsc --noEmit mcp-integration.ts langchain-integration.ts\` — confirm examples typecheck (needs SDK built first)

## Diff size

11 files modified, 3 new. ~1000 lines added.