### PR TITLE
feat(credit): Phase 2 + Phase 3 integration onto main (+ Vercel type fix)

### DIFF
--- a/app/app/api/claims/[id]/buy/route.ts
+++ b/app/app/api/claims/[id]/buy/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  fetchClaimListing,
+  verifyTxInvokedCovenant,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * POST /api/claims/[id]/buy
+ *
+ * Mirror a completed on-chain `buy_claim`. The lender has already paid
+ * the seller by invoking the instruction in their browser wallet; we
+ * verify and mark the DB row Bought.
+ *
+ * Body: { buyerWallet, txSignature }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const { buyerWallet, txSignature } = body as {
+      buyerWallet?: string;
+      txSignature?: string;
+    };
+    if (!buyerWallet || !txSignature) {
+      return NextResponse.json(
+        { error: "buyerWallet and txSignature are required" },
+        { status: 400 },
+      );
+    }
+
+    const claim = await prisma.claimListing.findUnique({
+      where: { id },
+    });
+    if (!claim) {
+      return NextResponse.json({ error: "Claim not found" }, { status: 404 });
+    }
+    if (claim.status === "Bought" && claim.buyerWallet === buyerWallet) {
+      return NextResponse.json(
+        { claim, note: "already-bought" },
+        { status: 200 },
+      );
+    }
+    if (claim.status !== "Listed") {
+      return NextResponse.json(
+        { error: `Claim is in status ${claim.status}, expected Listed` },
+        { status: 400 },
+      );
+    }
+
+    await verifyTxInvokedCovenant(txSignature);
+
+    const onchain = await fetchClaimListing(new PublicKey(claim.pda));
+    if (!onchain) {
+      return NextResponse.json(
+        { error: "ClaimListing PDA missing on chain after buy tx confirmed" },
+        { status: 400 },
+      );
+    }
+    if (onchain.status !== "Bought") {
+      return NextResponse.json(
+        {
+          error: `On-chain status is ${onchain.status}, expected Bought. ` +
+            "Tx may not have been a buy_claim for this listing.",
+        },
+        { status: 400 },
+      );
+    }
+    if (onchain.buyer !== buyerWallet) {
+      return NextResponse.json(
+        { error: "On-chain buyer does not match buyerWallet in request" },
+        { status: 400 },
+      );
+    }
+
+    const updated = await prisma.claimListing.update({
+      where: { id },
+      data: {
+        status: "Bought",
+        buyerWallet,
+        boughtAt: onchain.boughtAt > 0 ? new Date(onchain.boughtAt * 1000) : new Date(),
+        buyTxHash: txSignature,
+      },
+    });
+
+    return NextResponse.json({ claim: updated });
+  } catch (error) {
+    console.error("POST /api/claims/[id]/buy error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to mirror buy: " +
+          (error instanceof Error ? error.message : String(error)),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/claims/[id]/cancel/route.ts
+++ b/app/app/api/claims/[id]/cancel/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  fetchClaimListing,
+  verifyTxInvokedCovenant,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
+
+/**
+ * POST /api/claims/[id]/cancel
+ *
+ * Mirror a seller-initiated `cancel_claim`. The on-chain account is
+ * closed by the instruction, so after a successful tx we expect
+ * `fetchClaimListing` to return null. We verify the tx invoked our
+ * program and the PDA is indeed closed, then mark the DB row Cancelled.
+ *
+ * Body: { sellerWallet, txSignature }
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const { sellerWallet, txSignature } = body as {
+      sellerWallet?: string;
+      txSignature?: string;
+    };
+    if (!sellerWallet || !txSignature) {
+      return NextResponse.json(
+        { error: "sellerWallet and txSignature are required" },
+        { status: 400 },
+      );
+    }
+
+    const claim = await prisma.claimListing.findUnique({ where: { id } });
+    if (!claim) {
+      return NextResponse.json({ error: "Claim not found" }, { status: 404 });
+    }
+    if (claim.status === "Cancelled") {
+      return NextResponse.json(
+        { claim, note: "already-cancelled" },
+        { status: 200 },
+      );
+    }
+    if (claim.status !== "Listed") {
+      return NextResponse.json(
+        { error: `Only Listed claims can be cancelled (got ${claim.status})` },
+        { status: 400 },
+      );
+    }
+    if (claim.sellerWallet !== sellerWallet) {
+      return NextResponse.json(
+        { error: "Only the original seller can cancel this claim" },
+        { status: 403 },
+      );
+    }
+
+    await verifyTxInvokedCovenant(txSignature);
+
+    // cancel_claim closes the PDA — on success the account should be gone.
+    const onchain = await fetchClaimListing(new PublicKey(claim.pda));
+    if (onchain) {
+      return NextResponse.json(
+        {
+          error:
+            `ClaimListing PDA still exists on chain (status=${onchain.status}). ` +
+            "cancel_claim may not have been the supplied tx.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const updated = await prisma.claimListing.update({
+      where: { id },
+      data: {
+        status: "Cancelled",
+        cancelTxHash: txSignature,
+      },
+    });
+
+    return NextResponse.json({ claim: updated });
+  } catch (error) {
+    console.error("POST /api/claims/[id]/cancel error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to mirror cancel: " +
+          (error instanceof Error ? error.message : String(error)),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/claims/route.ts
+++ b/app/app/api/claims/route.ts
@@ -1,0 +1,253 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  fetchClaimListing,
+  verifyTxInvokedCovenant,
+  deriveJobPda,
+  deriveClaimPda,
+} from "@/lib/credit-server";
+import { PublicKey } from "@solana/web3.js";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/claims
+ *
+ * Marketplace query. Returns active listings with joined job data so
+ * the UI can render amount / category / reputation / time-left in one
+ * round-trip. Default sort: highest APR first (buyers want best yield).
+ *
+ * Query params:
+ *   status=Listed|Bought|Cancelled|Settled   (default: Listed)
+ *   sellerWallet=<base58>                    filter
+ *   buyerWallet=<base58>                     filter
+ *   minAmount=<number>                       face value lower bound
+ *   maxAmount=<number>                       face value upper bound
+ *   sortBy=apr|listedAt|faceValue            default: apr
+ *   limit=<1..100>                           default 50
+ *   offset=<number>                          default 0
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const status = searchParams.get("status") ?? "Listed";
+    const sellerWallet = searchParams.get("sellerWallet");
+    const buyerWallet = searchParams.get("buyerWallet");
+    const minAmount = searchParams.get("minAmount");
+    const maxAmount = searchParams.get("maxAmount");
+    const sortBy = searchParams.get("sortBy") ?? "apr";
+    const limit = Math.max(
+      1,
+      Math.min(100, parseInt(searchParams.get("limit") ?? "50", 10)),
+    );
+    const offset = Math.max(0, parseInt(searchParams.get("offset") ?? "0", 10));
+
+    const where: Record<string, unknown> = {};
+    if (status) where.status = status;
+    if (sellerWallet) where.sellerWallet = sellerWallet;
+    if (buyerWallet) where.buyerWallet = buyerWallet;
+    if (minAmount) where.faceValue = { ...(where.faceValue as object), gte: parseFloat(minAmount) };
+    if (maxAmount) where.faceValue = { ...(where.faceValue as object), lte: parseFloat(maxAmount) };
+
+    // Prisma cannot sort by a computed field (APR), so we sort at the DB
+    // layer by listedAt/faceValue and do the APR sort in-memory when
+    // requested.
+    const prismaSortBy = sortBy === "faceValue" ? "faceValue" : "listedAt";
+
+    const [claims, total] = await Promise.all([
+      prisma.claimListing.findMany({
+        where,
+        include: {
+          job: {
+            select: {
+              id: true,
+              posterWallet: true,
+              takerWallet: true,
+              amount: true,
+              category: true,
+              specJson: true,
+              status: true,
+              challengeEndAt: true,
+              deliveredAt: true,
+            },
+          },
+        },
+        orderBy: { [prismaSortBy]: "desc" },
+        skip: offset,
+        take: limit,
+      }),
+      prisma.claimListing.count({ where }),
+    ]);
+
+    const now = Date.now();
+    const enriched = claims.map((c) => {
+      const discountPct =
+        c.faceValue > 0 ? ((c.faceValue - c.price) / c.faceValue) * 100 : 0;
+      const challengeEndMs = c.job.challengeEndAt?.getTime() ?? null;
+      const secondsToChallengeEnd =
+        challengeEndMs && challengeEndMs > now
+          ? Math.round((challengeEndMs - now) / 1000)
+          : 0;
+      // Annualized yield: (faceValue / price - 1) over the remaining
+      // challenge window. Capped at 9999% to avoid silly UI numbers on
+      // listings with sub-second windows left.
+      const yearsRemaining =
+        secondsToChallengeEnd > 0 ? secondsToChallengeEnd / (365 * 24 * 3600) : 1e-9;
+      const aprRaw =
+        c.price > 0 ? (c.faceValue / c.price - 1) / yearsRemaining : 0;
+      const aprPct = Math.min(9999, Math.max(0, aprRaw * 100));
+      return {
+        ...c,
+        discountPct,
+        aprPct,
+        secondsToChallengeEnd,
+      };
+    });
+
+    if (sortBy === "apr") {
+      enriched.sort((a, b) => b.aprPct - a.aprPct);
+    }
+
+    // Lightweight TVL + counts for a header block on /credit.
+    const [tvlRow] = await prisma.$queryRawUnsafe<{ tvl: number | null }[]>(
+      `SELECT SUM("faceValue") as tvl FROM "ClaimListing" WHERE status = 'Listed'`,
+    );
+    const bought = await prisma.claimListing.count({ where: { status: "Bought" } });
+    const settled = await prisma.claimListing.count({ where: { status: "Settled" } });
+
+    return NextResponse.json({
+      claims: enriched,
+      total,
+      limit,
+      offset,
+      stats: {
+        activeTvl: Number(tvlRow?.tvl ?? 0),
+        boughtCount: bought,
+        settledCount: settled,
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/claims error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch claims" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/claims
+ *
+ * Mirror a newly-created on-chain listing into the DB. Caller (seller)
+ * has already invoked `list_claim` from their wallet and passes us the
+ * resulting tx signature. We:
+ *   1. Verify the tx landed + invoked our program (blocks audit C-04
+ *      class of arbitrary-tx replay)
+ *   2. Read the on-chain ClaimListing account and verify seller / price
+ *      / face_value match the DB Job
+ *   3. Upsert a ClaimListing row
+ *
+ * Body: { jobId, txSignature }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { jobId, txSignature } = body as {
+      jobId?: string;
+      txSignature?: string;
+    };
+    if (!jobId || !txSignature) {
+      return NextResponse.json(
+        { error: "jobId and txSignature are required" },
+        { status: 400 },
+      );
+    }
+
+    const job = await prisma.job.findUnique({
+      where: { id: jobId },
+      include: { claim: true },
+    });
+    if (!job) return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    if (!job.takerWallet || !job.posterWallet) {
+      return NextResponse.json(
+        { error: "Job is missing required wallet fields" },
+        { status: 400 },
+      );
+    }
+    if (job.claim && job.claim.status === "Listed") {
+      // Already mirrored — idempotent.
+      return NextResponse.json(
+        { claim: job.claim, note: "already-listed" },
+        { status: 200 },
+      );
+    }
+
+    await verifyTxInvokedCovenant(txSignature);
+
+    const [jobPda] = deriveJobPda(
+      new PublicKey(job.posterWallet),
+      Buffer.from(job.specHash, "hex"),
+    );
+    const [claimPda] = deriveClaimPda(jobPda);
+
+    const onchain = await fetchClaimListing(claimPda);
+    if (!onchain) {
+      return NextResponse.json(
+        { error: "ClaimListing PDA not found on chain after tx confirmed" },
+        { status: 400 },
+      );
+    }
+    if (onchain.seller !== job.takerWallet) {
+      return NextResponse.json(
+        { error: "On-chain seller does not match job.takerWallet" },
+        { status: 400 },
+      );
+    }
+    if (Math.abs(onchain.faceValue - job.amount) > 1e-6) {
+      return NextResponse.json(
+        { error: "On-chain face_value does not match job.amount" },
+        { status: 400 },
+      );
+    }
+    if (onchain.status !== "Listed") {
+      return NextResponse.json(
+        { error: `On-chain status is ${onchain.status}, expected Listed` },
+        { status: 400 },
+      );
+    }
+
+    const claim = await prisma.claimListing.upsert({
+      where: { pda: claimPda.toBase58() },
+      create: {
+        pda: claimPda.toBase58(),
+        jobId: job.id,
+        jobPda: jobPda.toBase58(),
+        sellerWallet: onchain.seller,
+        price: onchain.price,
+        faceValue: onchain.faceValue,
+        priceAtomic: onchain.priceAtomic.toString(),
+        faceValueAtomic: onchain.faceValueAtomic.toString(),
+        status: "Listed",
+        listedAt: new Date(onchain.listedAt * 1000),
+        listTxHash: txSignature,
+      },
+      update: {
+        status: "Listed",
+        price: onchain.price,
+        priceAtomic: onchain.priceAtomic.toString(),
+        listTxHash: txSignature,
+      },
+    });
+
+    return NextResponse.json({ claim }, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/claims error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to mirror claim listing: " +
+          (error instanceof Error ? error.message : String(error)),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/claims/stats/route.ts
+++ b/app/app/api/claims/stats/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+/**
+ * GET /api/claims/stats
+ *
+ * Aggregate time-series stats for the /credit/dashboard visualizer.
+ * Buckets claims by hour over the last 7 days and exposes four
+ * rolling series:
+ *   - tvl[]        — active-listing face value per hour
+ *   - boughtCount[] — purchases closed per hour
+ *   - settledCount[] — finalizations routed to buyers per hour
+ *   - avgApr[]      — average APR of listings active in that bucket
+ *
+ * Plus point-in-time totals used by the hero strip.
+ */
+export async function GET() {
+  try {
+    const now = Date.now();
+    const HOUR = 3600_000;
+    const BUCKETS = 24 * 7;
+    const start = now - BUCKETS * HOUR;
+
+    // Point-in-time totals (fast).
+    const [listed, bought, settled, cancelled] = await Promise.all([
+      prisma.claimListing.findMany({
+        where: { status: "Listed" },
+        include: { job: { select: { challengeEndAt: true, amount: true } } },
+      }),
+      prisma.claimListing.count({ where: { status: "Bought" } }),
+      prisma.claimListing.count({ where: { status: "Settled" } }),
+      prisma.claimListing.count({ where: { status: "Cancelled" } }),
+    ]);
+
+    const activeTvl = listed.reduce((sum, c) => sum + c.faceValue, 0);
+
+    // Compute current APR distribution.
+    const aprs: number[] = [];
+    for (const c of listed) {
+      if (!c.job.challengeEndAt) continue;
+      const secondsLeft = Math.max(
+        1,
+        Math.round((c.job.challengeEndAt.getTime() - now) / 1000),
+      );
+      const years = secondsLeft / (365 * 24 * 3600);
+      const apr = ((c.faceValue / c.price) - 1) / years;
+      if (isFinite(apr)) aprs.push(Math.min(9999, apr * 100));
+    }
+    aprs.sort((a, b) => a - b);
+    const aprMedian = aprs.length > 0 ? aprs[Math.floor(aprs.length / 2)] : 0;
+    const aprP90 =
+      aprs.length > 0 ? aprs[Math.min(aprs.length - 1, Math.floor(aprs.length * 0.9))] : 0;
+
+    // Bucket historical events by hour for sparklines.
+    const rows = await prisma.claimListing.findMany({
+      where: {
+        OR: [
+          { listedAt: { gte: new Date(start) } },
+          { boughtAt: { gte: new Date(start) } },
+          { settledAt: { gte: new Date(start) } },
+        ],
+      },
+      select: {
+        listedAt: true,
+        boughtAt: true,
+        settledAt: true,
+        faceValue: true,
+        price: true,
+      },
+    });
+
+    const tvl = new Array<number>(BUCKETS).fill(0);
+    const boughtSeries = new Array<number>(BUCKETS).fill(0);
+    const settledSeries = new Array<number>(BUCKETS).fill(0);
+    const volumeSeries = new Array<number>(BUCKETS).fill(0);
+
+    for (const r of rows) {
+      if (r.listedAt) {
+        const b = Math.floor((r.listedAt.getTime() - start) / HOUR);
+        if (b >= 0 && b < BUCKETS) tvl[b] += r.faceValue;
+      }
+      if (r.boughtAt) {
+        const b = Math.floor((r.boughtAt.getTime() - start) / HOUR);
+        if (b >= 0 && b < BUCKETS) {
+          boughtSeries[b] += 1;
+          volumeSeries[b] += r.price;
+        }
+      }
+      if (r.settledAt) {
+        const b = Math.floor((r.settledAt.getTime() - start) / HOUR);
+        if (b >= 0 && b < BUCKETS) settledSeries[b] += 1;
+      }
+    }
+
+    // Cumulative TVL (listings are created, then eventually removed; we
+    // approximate with running sum of listed face values bucketed at list
+    // time — imperfect but fine for a hackathon demo sparkline).
+    const tvlCumulative: number[] = [];
+    let running = 0;
+    for (const v of tvl) {
+      running += v;
+      tvlCumulative.push(running);
+    }
+
+    return NextResponse.json({
+      now,
+      bucketHours: BUCKETS,
+      totals: {
+        activeListings: listed.length,
+        activeTvl,
+        boughtCount: bought,
+        settledCount: settled,
+        cancelledCount: cancelled,
+      },
+      apr: {
+        median: aprMedian,
+        p90: aprP90,
+        distribution: aprs,
+      },
+      series: {
+        tvlCumulative,
+        boughtPerHour: boughtSeries,
+        settledPerHour: settledSeries,
+        volumePerHour: volumeSeries,
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/claims/stats error:", error);
+    return NextResponse.json(
+      { error: "Failed to compute claim stats" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/app/api/cron/finalize/route.ts
+++ b/app/app/api/cron/finalize/route.ts
@@ -1,31 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import {
-  botFinalizePayment,
-  keypairFromEnv,
-} from "@/lib/program-server";
+import { finalizeWithClaim, keypairFromEnv } from "@/lib/credit-server";
 import { PublicKey } from "@solana/web3.js";
 
 // Always dynamic — this route talks to Prisma on every request.
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-// On-chain crank for the permissionless `finalize_payment` instruction.
-// The crank only pays SOL fees; it cannot redirect funds because the
-// program enforces taker payment to the registered taker. We prefer a
-// dedicated CRANK_KEYPAIR if set, falling back to DEPLOYER_KEYPAIR.
+// On-chain crank for the permissionless `finalize_payment` instruction,
+// wired through `finalizeWithClaim` so sold Covenant Credit claims route
+// proceeds to the buyer. The crank only pays SOL fees; the program
+// enforces taker payment to the registered beneficiary, so the crank
+// cannot redirect funds. Prefer a dedicated CRANK_KEYPAIR if set,
+// falling back to DEPLOYER_KEYPAIR.
 
 /**
  * GET /api/cron/finalize
  *
  * Vercel cron target. Runs every ~5 minutes. Finds all jobs in
  * `Delivered` state whose challenge period has expired and which have
- * no active dispute, then finalizes them by releasing escrow to the
- * taker and moving the job to `Finalized`.
+ * no active dispute, then finalizes them by releasing escrow on chain
+ * and moving the job to `Finalized`. If a ClaimListing is Bought, the
+ * escrow is paid to the buyer and the listing is marked Settled.
  *
  * This guarantees protocol progress even if neither party wakes up to
- * push the Finalize button. Idempotent — re-running the cron is a no-op
- * once a job is Finalized.
+ * push the Finalize button. Idempotent — re-running is a no-op once a
+ * job is Finalized.
  *
  * Schedule in vercel.json:
  *   { "crons": [{ "path": "/api/cron/finalize", "schedule": "* /5 * * * *" }] }
@@ -65,6 +65,9 @@ export async function GET(req: NextRequest) {
     error?: string;
   }> = [];
 
+  // Load crank keypair once. We hard-fail (503) if neither env var is
+  // configured — better to surface the misconfiguration than to silently
+  // skip every finalize.
   const crankEnv = process.env.CRANK_KEYPAIR ? "CRANK_KEYPAIR" : "DEPLOYER_KEYPAIR";
   let crankKp;
   try {
@@ -91,13 +94,14 @@ export async function GET(req: NextRequest) {
       continue;
     }
     try {
-      const txHash = await botFinalizePayment({
+      const { sig, routedToBuyer, buyer } = await finalizeWithClaim({
         crankKeypair: crankKp,
         poster: new PublicKey(job.posterWallet),
         taker: new PublicKey(job.takerWallet),
         specHash: Buffer.from(job.specHash, "hex"),
         escrowTokenAccount: new PublicKey(job.escrowAta),
       });
+
       await prisma.$transaction(async (tx) => {
         await tx.job.update({
           where: { id: job.id },
@@ -120,28 +124,48 @@ export async function GET(req: NextRequest) {
           data: {
             jobId: job.id,
             type: "finalized",
-            txSignature: txHash,
+            txSignature: sig,
             wallet: "cron:finalize",
             amount: job.amount,
             data: {
               taker: job.takerWallet,
-              paymentTxHash: txHash,
+              paymentTxHash: sig,
               crank: "cron",
+              routedToBuyer,
+              buyer,
             },
           },
         });
         await tx.transaction.create({
           data: {
-            txHash,
+            txHash: sig,
             type: "finalize_payment",
             jobId: job.id,
-            wallet: job.takerWallet as string,
+            wallet: (routedToBuyer && buyer) || (job.takerWallet as string),
             amount: job.amount,
             status: "confirmed",
           },
         });
+
+        // Mirror Covenant Credit settlement if the claim was routed.
+        if (routedToBuyer && buyer) {
+          const claim = await tx.claimListing.findUnique({
+            where: { jobId: job.id },
+          });
+          if (claim && claim.status === "Bought") {
+            await tx.claimListing.update({
+              where: { id: claim.id },
+              data: {
+                status: "Settled",
+                settledAt: new Date(),
+                settleTxHash: sig,
+              },
+            });
+          }
+        }
       });
-      results.push({ jobId: job.id, ok: true, paymentTxHash: txHash });
+
+      results.push({ jobId: job.id, ok: true, paymentTxHash: sig });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[cron/finalize] failed for ${job.id}:`, msg);

--- a/app/app/api/jobs/[id]/finalize/route.ts
+++ b/app/app/api/jobs/[id]/finalize/route.ts
@@ -4,12 +4,8 @@ import { sendMarkerTransaction } from "@/lib/solana";
 import { awardXP, XP_REWARDS } from "@/lib/xp";
 import { checkAndUnlock } from "@/lib/achievements";
 import { PROTOCOL_FEE_BPS } from "@/lib/constants";
-import {
-  botFinalizePayment,
-  fetchJobEscrow,
-  verifyTxInvokedCovenant,
-  keypairFromEnv,
-} from "@/lib/program-server";
+import { fetchJobEscrow, verifyTxInvokedCovenant } from "@/lib/program-server";
+import { finalizeWithClaim, keypairFromEnv } from "@/lib/credit-server";
 import { PublicKey } from "@solana/web3.js";
 import crypto from "crypto";
 
@@ -18,7 +14,8 @@ import crypto from "crypto";
  *
  * Permissionless. Anyone can call this after the challenge period has
  * expired and no dispute is active. The server re-checks on-chain /
- * database state, releases escrow to the taker, and moves the job to
+ * database state, releases escrow to the taker (or to the claim buyer
+ * if a Covenant Credit listing has been Bought), and moves the job to
  * Finalized.
  *
  * In a production deployment this endpoint is called by a cron worker
@@ -33,8 +30,10 @@ export async function POST(
     const { id } = await params;
     const body = (await request.json().catch(() => ({}))) as {
       callerWallet?: string;
+      txSignature?: string;
     };
     const caller = body.callerWallet ?? "anonymous";
+    const callerTxSig = body.txSignature;
 
     const job = await prisma.job.findUnique({
       where: { id },
@@ -79,29 +78,30 @@ export async function POST(
 
     // ---- On-chain finalize ----
     //
-    // Two acceptable inputs:
-    //   (A) Caller already invoked the on-chain `finalize_payment`
-    //       crank from their browser (or a server) and passes
-    //       `txSignature` in the body. We verify and mirror.
-    //   (B) Caller asks the server to crank for them. We use the
-    //       configured CRANK_KEYPAIR (or DEPLOYER_KEYPAIR fallback)
-    //       and call `finalize_payment` on chain. The crank's only
-    //       privilege is paying SOL fees — it cannot redirect funds
-    //       (the program enforces taker payment to the registered taker).
+    // Three paths:
+    //   A. Synthetic agent job: no funds to move, just a marker.
+    //   B. Caller already invoked the on-chain `finalize_payment` crank
+    //      from their browser and passes `txSignature` in the body.
+    //      Verify tx + check on-chain JobEscrow.status == Finalized.
+    //   C. Server-cranked via lib/credit-server.finalizeWithClaim —
+    //      claim-aware: routes proceeds to the buyer if a ClaimListing
+    //      is Bought, otherwise to the taker. Crank pays only SOL fees;
+    //      the program enforces the beneficiary.
     //
-    // Either way, no shared deployer wallet ever holds user USDC.
-
+    // The server NEVER signs a custodial release tx here. The previous
+    // `releaseFundsToTaker` custodial path was removed in the on-chain
+    // settlement refactor (audit C-01).
     const isAgentJob = job.takerWallet.startsWith("covenant-agent-");
-    const callerTxSig = (body as { txSignature?: string }).txSignature;
-
     let paymentTxHash: string | null = null;
+    let routedToBuyer = false;
+    let settlementBuyer: string | null = null;
 
     if (isAgentJob) {
-      // Synthetic agent jobs (battle/arena demos that did not lock real
-      // USDC) just record completion — no on-chain settlement to do.
+      // Path A — synthetic agent job, record-only marker.
       paymentTxHash = "agent:finalized:" + crypto.randomBytes(12).toString("hex");
     } else if (callerTxSig) {
-      // Path A: client-cranked. Verify the tx and mirror.
+      // Path B — client-cranked. Verify the tx landed + invoked our
+      // program + the JobEscrow status is now Finalized.
       try {
         await verifyTxInvokedCovenant(callerTxSig);
         if (job.pda) {
@@ -124,28 +124,30 @@ export async function POST(
         );
       }
     } else {
-      // Path B: server-cranked. Use CRANK_KEYPAIR if configured, else
-      // fall back to DEPLOYER_KEYPAIR. Crank only pays fees — it cannot
-      // redirect funds because the on-chain program enforces the taker.
-      const crankEnv = process.env.CRANK_KEYPAIR ? "CRANK_KEYPAIR" : "DEPLOYER_KEYPAIR";
+      // Path C — server-cranked, claim-aware.
+      if (!job.pda || !job.escrowAta) {
+        return NextResponse.json(
+          {
+            error:
+              "Job is missing on-chain PDA / escrowAta; cannot run server crank. " +
+              "Invoke finalize_payment from a wallet and POST back with txSignature instead.",
+          },
+          { status: 400 },
+        );
+      }
       try {
-        if (!job.pda || !job.escrowAta) {
-          throw new Error(
-            "Job is missing on-chain PDA / escrowAta; cannot run server crank. " +
-            "Caller should pass txSignature after invoking finalize_payment client-side.",
-          );
-        }
+        const crankEnv = process.env.CRANK_KEYPAIR ? "CRANK_KEYPAIR" : "DEPLOYER_KEYPAIR";
         const crankKp = keypairFromEnv(crankEnv);
-        // Need spec_hash bytes for PDA derivation — re-derive from DB.
-        const specHashBuf = Buffer.from(job.specHash, "hex");
-        const sig = await botFinalizePayment({
+        const result = await finalizeWithClaim({
           crankKeypair: crankKp,
           poster: new PublicKey(job.posterWallet),
           taker: new PublicKey(job.takerWallet),
-          specHash: specHashBuf,
+          specHash: Buffer.from(job.specHash, "hex"),
           escrowTokenAccount: new PublicKey(job.escrowAta),
         });
-        paymentTxHash = sig;
+        paymentTxHash = result.sig;
+        routedToBuyer = result.routedToBuyer;
+        settlementBuyer = result.buyer;
       } catch (err) {
         console.error("[finalize] server crank failed:", err);
         return NextResponse.json(
@@ -177,12 +179,34 @@ export async function POST(
       });
     }
 
-    // 2b. Calculate protocol fee (recorded only — on-chain deduction comes at mainnet)
+    // Mirror Covenant Credit settlement if the payout was routed.
+    if (routedToBuyer && paymentTxHash && settlementBuyer) {
+      try {
+        const claim = await prisma.claimListing.findUnique({
+          where: { jobId: id },
+        });
+        if (claim && claim.status === "Bought") {
+          await prisma.claimListing.update({
+            where: { id: claim.id },
+            data: {
+              status: "Settled",
+              settledAt: new Date(),
+              settleTxHash: paymentTxHash,
+            },
+          });
+        }
+      } catch (err) {
+        console.error("[finalize] claim settlement mirror failed:", err);
+        // non-blocking
+      }
+    }
+
+    // Calculate protocol fee (recorded only — on-chain deduction comes at mainnet).
     const feeAmount = (job.amount * PROTOCOL_FEE_BPS) / 10000;
     const takerPayout = job.amount - feeAmount;
     console.log(`[finalize] fee=${feeAmount} takerPayout=${takerPayout} job=${id}`);
 
-    // 3. Update related DB records
+    // Update related DB records.
     const updated = await prisma.$transaction(async (tx) => {
       const j = await tx.job.findUnique({ where: { id } });
       await tx.reputation.upsert({
@@ -212,6 +236,8 @@ export async function POST(
             paymentTxHash,
             feeAmount,
             takerPayout,
+            routedToBuyer,
+            buyer: settlementBuyer,
           },
         },
       });
@@ -221,12 +247,12 @@ export async function POST(
             paymentTxHash ?? "local:finalized:" + crypto.randomBytes(12).toString("hex"),
           type: "finalize_payment",
           jobId: id,
-          wallet: caller,
+          wallet: (routedToBuyer && settlementBuyer) || caller,
           amount: job.amount,
           status: "confirmed",
         },
       });
-      // Record protocol fee
+      // Record protocol fee.
       await tx.protocolFee.create({
         data: {
           jobId: id,
@@ -238,7 +264,7 @@ export async function POST(
       return j;
     });
 
-    // Award XP + check achievements (best effort)
+    // Award XP + check achievements (best effort).
     try {
       await awardXP(job.posterWallet, XP_REWARDS.job_finalize, "job_finalize");
       if (!isAgentJob) {
@@ -248,7 +274,7 @@ export async function POST(
       if (!isAgentJob) await checkAndUnlock(job.takerWallet);
     } catch { /* best effort */ }
 
-    // Best-effort Solana marker
+    // Best-effort Solana marker.
     try {
       const markerTx = await sendMarkerTransaction("finalize_payment:" + id);
       console.log("[finalize] marker tx:", markerTx);
@@ -260,6 +286,8 @@ export async function POST(
       job: updated,
       paymentTxHash,
       finalizedBy: caller,
+      routedToBuyer,
+      settlementBuyer,
     });
   } catch (error) {
     console.error("POST /api/jobs/[id]/finalize error:", error);

--- a/app/app/api/jobs/[id]/route.ts
+++ b/app/app/api/jobs/[id]/route.ts
@@ -14,6 +14,7 @@ export async function GET(
         submissions: true,
         delivery: true,
         dispute: true,
+        claim: true,
         interests: {
           where: { status: "working" },
           select: { takerWallet: true, acceptedAt: true },

--- a/app/app/api/jobs/route.ts
+++ b/app/app/api/jobs/route.ts
@@ -66,6 +66,7 @@ export async function GET(request: NextRequest) {
           submissions: true,
           delivery: true,
           dispute: true,
+          claim: true,
           interests: {
             where: { status: "working" },
             select: { takerWallet: true, acceptedAt: true },

--- a/app/app/credit/dashboard/page.tsx
+++ b/app/app/credit/dashboard/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+/**
+ * Covenant Credit — real-time visualizer.
+ *
+ * One-glance dashboard that tells the protocol story: how much claim
+ * paper is live, what it's priced at, how fast it's moving. Intended
+ * as a Twitter-shareable artifact during the hackathon.
+ *
+ * All charts are pure SVG (no charting library) — keeps the bundle
+ * small and the demo dependency-free.
+ */
+
+import { useEffect, useState } from "react";
+import NavBar from "@/components/NavBar";
+
+interface StatsResponse {
+  now: number;
+  bucketHours: number;
+  totals: {
+    activeListings: number;
+    activeTvl: number;
+    boughtCount: number;
+    settledCount: number;
+    cancelledCount: number;
+  };
+  apr: {
+    median: number;
+    p90: number;
+    distribution: number[];
+  };
+  series: {
+    tvlCumulative: number[];
+    boughtPerHour: number[];
+    settledPerHour: number[];
+    volumePerHour: number[];
+  };
+}
+
+function Sparkline({
+  values,
+  width = 560,
+  height = 80,
+  stroke = "#fffeb2",
+  fill = "rgba(255,254,178,0.1)",
+}: {
+  values: number[];
+  width?: number;
+  height?: number;
+  stroke?: string;
+  fill?: string;
+}) {
+  if (values.length === 0) {
+    return (
+      <div
+        style={{ width, height, color: "rgba(255,255,255,0.3)", fontSize: 11 }}
+      >
+        no data
+      </div>
+    );
+  }
+
+  const max = Math.max(1, ...values);
+  const min = Math.min(0, ...values);
+  const range = max - min || 1;
+  const step = width / Math.max(1, values.length - 1);
+
+  const toY = (v: number) =>
+    height - ((v - min) / range) * height * 0.9 - height * 0.05;
+
+  const linePath = values
+    .map((v, i) => `${i === 0 ? "M" : "L"} ${(i * step).toFixed(2)} ${toY(v).toFixed(2)}`)
+    .join(" ");
+
+  const areaPath =
+    linePath +
+    ` L ${(values.length - 1) * step} ${height} L 0 ${height} Z`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      style={{ display: "block" }}
+    >
+      <path d={areaPath} fill={fill} stroke="none" />
+      <path d={linePath} fill="none" stroke={stroke} strokeWidth={1.5} />
+    </svg>
+  );
+}
+
+function Histogram({
+  values,
+  buckets = 20,
+  width = 560,
+  height = 80,
+  stroke = "#7CFF7C",
+}: {
+  values: number[];
+  buckets?: number;
+  width?: number;
+  height?: number;
+  stroke?: string;
+}) {
+  if (values.length === 0) {
+    return (
+      <div
+        style={{ width, height, color: "rgba(255,255,255,0.3)", fontSize: 11 }}
+      >
+        no claims yet
+      </div>
+    );
+  }
+
+  const capped = values.map((v) => Math.min(1500, v));
+  const max = Math.max(100, ...capped);
+  const bucketWidth = max / buckets;
+  const histogram = new Array<number>(buckets).fill(0);
+  for (const v of capped) {
+    const b = Math.min(buckets - 1, Math.floor(v / bucketWidth));
+    histogram[b] += 1;
+  }
+  const maxCount = Math.max(1, ...histogram);
+
+  const barWidth = width / buckets;
+
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+      {histogram.map((count, i) => {
+        const h = (count / maxCount) * (height - 4);
+        return (
+          <rect
+            key={i}
+            x={i * barWidth + 1}
+            y={height - h}
+            width={barWidth - 2}
+            height={h}
+            fill={stroke}
+            opacity={0.8}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+function formatMoney(n: number): string {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
+  return `$${n.toFixed(2)}`;
+}
+
+export default function CreditDashboardPage() {
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    async function tick() {
+      try {
+        const res = await fetch("/api/claims/stats");
+        if (!res.ok) return;
+        const json = await res.json();
+        if (alive) {
+          setStats(json);
+          setLoading(false);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    tick();
+    const iv = setInterval(tick, 5000);
+    return () => {
+      alive = false;
+      clearInterval(iv);
+    };
+  }, []);
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#0b0b0b", color: "#fff", fontFamily: "inherit" }}>
+      <NavBar activeTab="credit" variant="dark" />
+
+      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "40px 24px 80px" }}>
+        <div style={{ marginBottom: 32 }}>
+          <div
+            style={{
+              fontSize: 12,
+              textTransform: "uppercase",
+              letterSpacing: "0.15em",
+              color: "#fffeb2",
+              marginBottom: 8,
+            }}
+          >
+            Covenant Credit — Live Visualizer
+          </div>
+          <div style={{ fontSize: 34, fontWeight: 800, marginBottom: 8 }}>
+            Agent paper is flowing.
+          </div>
+          <div style={{ fontSize: 13, color: "rgba(255,255,255,0.5)" }}>
+            Updated every 5 seconds · 7-day rolling window
+          </div>
+        </div>
+
+        {/* Hero stats */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(5, 1fr)",
+            gap: 12,
+            marginBottom: 40,
+          }}
+        >
+          <Tile
+            label="Active TVL"
+            value={stats ? formatMoney(stats.totals.activeTvl) : "—"}
+            accent="#fffeb2"
+          />
+          <Tile
+            label="Active listings"
+            value={stats ? String(stats.totals.activeListings) : "—"}
+          />
+          <Tile
+            label="Bought"
+            value={stats ? String(stats.totals.boughtCount) : "—"}
+            accent="#7CFF7C"
+          />
+          <Tile
+            label="Settled"
+            value={stats ? String(stats.totals.settledCount) : "—"}
+            accent="#7CFF7C"
+          />
+          <Tile
+            label="Median APR"
+            value={stats ? `${Math.round(stats.apr.median)}%` : "—"}
+            accent="#7CFF7C"
+          />
+        </div>
+
+        {/* Sparklines */}
+        <ChartCard title="TVL listed (cumulative, 7d)">
+          <Sparkline values={stats?.series.tvlCumulative ?? []} />
+        </ChartCard>
+
+        <ChartCard title="Claims bought per hour">
+          <Sparkline
+            values={stats?.series.boughtPerHour ?? []}
+            stroke="#7CFF7C"
+            fill="rgba(124,255,124,0.08)"
+          />
+        </ChartCard>
+
+        <ChartCard title="Claims settled per hour (routed to buyers)">
+          <Sparkline
+            values={stats?.series.settledPerHour ?? []}
+            stroke="#4DA6FF"
+            fill="rgba(77,166,255,0.08)"
+          />
+        </ChartCard>
+
+        <ChartCard title="Buy volume per hour (USDC flowing to sellers)">
+          <Sparkline
+            values={stats?.series.volumePerHour ?? []}
+            stroke="#FFB84D"
+            fill="rgba(255,184,77,0.08)"
+          />
+        </ChartCard>
+
+        <ChartCard
+          title={`APR distribution across active listings (median ${
+            stats ? Math.round(stats.apr.median) : 0
+          }% · p90 ${stats ? Math.round(stats.apr.p90) : 0}%)`}
+        >
+          <Histogram values={stats?.apr.distribution ?? []} />
+        </ChartCard>
+
+        <div
+          style={{
+            marginTop: 40,
+            padding: 20,
+            background: "rgba(255,255,255,0.03)",
+            border: "1px solid rgba(255,255,255,0.06)",
+            borderRadius: 10,
+            fontSize: 12,
+            color: "rgba(255,255,255,0.5)",
+            lineHeight: 1.6,
+          }}
+        >
+          {loading
+            ? "Loading stats…"
+            : "All data is computed from on-chain ClaimListing PDAs mirrored into the DB. Chain is the source of truth; this dashboard is a denormalized view."}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: string;
+}) {
+  return (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderRadius: 10,
+        padding: "16px 18px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "rgba(255,255,255,0.45)",
+          marginBottom: 6,
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 700, color: accent ?? "#fff" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ChartCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.06)",
+        borderRadius: 10,
+        padding: "16px 20px",
+        marginBottom: 16,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 11,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "rgba(255,255,255,0.5)",
+          marginBottom: 10,
+        }}
+      >
+        {title}
+      </div>
+      <div style={{ overflowX: "auto" }}>{children}</div>
+    </div>
+  );
+}

--- a/app/app/credit/page.tsx
+++ b/app/app/credit/page.tsx
@@ -232,14 +232,37 @@ export default function CreditMarketplacePage() {
         <div style={{ marginBottom: 32 }}>
           <div
             style={{
-              fontSize: 12,
-              textTransform: "uppercase",
-              letterSpacing: "0.15em",
-              color: "#fffeb2",
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
               marginBottom: 8,
             }}
           >
-            Covenant Credit
+            <div
+              style={{
+                fontSize: 12,
+                textTransform: "uppercase",
+                letterSpacing: "0.15em",
+                color: "#fffeb2",
+              }}
+            >
+              Covenant Credit
+            </div>
+            <a
+              href="/credit/dashboard"
+              style={{
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "rgba(255,255,255,0.6)",
+                textDecoration: "none",
+                padding: "4px 10px",
+                border: "1px solid rgba(255,255,255,0.15)",
+                borderRadius: 4,
+              }}
+            >
+              Live dashboard →
+            </a>
           </div>
           <div style={{ fontSize: 40, fontWeight: 800, lineHeight: 1.1, marginBottom: 12 }}>
             BNPL for AI agents.

--- a/app/app/credit/page.tsx
+++ b/app/app/credit/page.tsx
@@ -1,0 +1,522 @@
+"use client";
+
+/**
+ * Covenant Credit — BNPL marketplace for pending agent payment claims.
+ *
+ * Sellers (takers with Delivered jobs) list their pending payment
+ * claims at a discount. Lenders (buyers) purchase them, get the full
+ * face value when the challenge period expires.
+ *
+ * Pitch: "BNPL for AI agents on Solana."
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { useConnector } from "@solana/connector/react";
+import { PublicKey } from "@solana/web3.js";
+import { getAssociatedTokenAddress } from "@solana/spl-token";
+import {
+  getAnchorProgram,
+  buyClaimOnChain,
+} from "@/lib/anchor-browser";
+import { USDC_MINT, USDC_LOGO_URL } from "@/lib/constants";
+import NavBar from "@/components/NavBar";
+import SellClaimButton from "@/components/SellClaimButton";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface ClaimRow {
+  id: string;
+  pda: string;
+  jobId: string;
+  jobPda: string;
+  sellerWallet: string;
+  buyerWallet: string | null;
+  price: number;
+  faceValue: number;
+  status: string;
+  listedAt: string;
+  discountPct: number;
+  aprPct: number;
+  secondsToChallengeEnd: number;
+  job: {
+    id: string;
+    posterWallet: string;
+    category: string;
+    amount: number;
+    specJson: Record<string, unknown>;
+    challengeEndAt: string | null;
+  };
+}
+
+interface Stats {
+  activeTvl: number;
+  boughtCount: number;
+  settledCount: number;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds <= 0) return "expired";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  const s = Math.max(0, seconds - m * 60);
+  return `${m}m ${s}s`;
+}
+
+function shortWallet(w: string): string {
+  return w.length > 10 ? `${w.slice(0, 4)}…${w.slice(-4)}` : w;
+}
+
+export default function CreditMarketplacePage() {
+  const connector = useConnector();
+  const account =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.account?.address ??
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.selectedWallet?.accounts?.[0]?.address ??
+    null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const selectedWallet = (connector as any)?.selectedWallet ?? null;
+
+  const [claims, setClaims] = useState<ClaimRow[]>([]);
+  const [stats, setStats] = useState<Stats>({
+    activeTvl: 0,
+    boughtCount: 0,
+    settledCount: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [buying, setBuying] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
+
+  // "Your pending jobs" — Delivered jobs the connected wallet took, for
+  // which no listing exists yet (i.e. listable right now).
+  interface PendingJob {
+    id: string;
+    specHash: string;
+    posterWallet: string;
+    takerWallet: string;
+    amount: number;
+    specJson: Record<string, unknown>;
+    challengeEndAt: string | null;
+    claim: { id: string; status: string } | null;
+  }
+  const [pendingJobs, setPendingJobs] = useState<PendingJob[]>([]);
+
+  const fetchPendingJobs = useCallback(async () => {
+    if (!account) {
+      setPendingJobs([]);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/api/jobs?status=Delivered&taker=${encodeURIComponent(account)}&limit=20`,
+      );
+      if (!res.ok) return;
+      const json = await res.json();
+      const jobs: PendingJob[] = (json.jobs ?? []).filter(
+        (j: PendingJob) => !j.claim,
+      );
+      setPendingJobs(jobs);
+    } catch (e) {
+      console.error("[credit] pending fetch failed:", e);
+    }
+  }, [account]);
+
+  const fetchClaims = useCallback(async () => {
+    try {
+      const res = await fetch("/api/claims?status=Listed&sortBy=apr&limit=50");
+      if (!res.ok) return;
+      const json = await res.json();
+      setClaims(json.claims ?? []);
+      setStats(json.stats ?? stats);
+    } catch (e) {
+      console.error("[credit] fetch failed:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, [stats]);
+
+  useEffect(() => {
+    fetchClaims();
+    fetchPendingJobs();
+    const iv = setInterval(() => {
+      fetchClaims();
+      fetchPendingJobs();
+    }, 10_000);
+    return () => clearInterval(iv);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account]);
+
+  const bestApr = useMemo(
+    () => (claims.length > 0 ? Math.max(...claims.map((c) => c.aprPct)) : 0),
+    [claims],
+  );
+
+  async function handleBuy(claim: ClaimRow) {
+    if (!account || !selectedWallet) {
+      setToast({ kind: "err", msg: "Connect your wallet to buy claims." });
+      return;
+    }
+    if (claim.sellerWallet === account) {
+      setToast({ kind: "err", msg: "You can't buy your own listing." });
+      return;
+    }
+    setBuying(claim.id);
+    setToast(null);
+    try {
+      const program = getAnchorProgram(account, selectedWallet);
+      if (!program) throw new Error("wallet program unavailable");
+
+      const buyerPk = new PublicKey(account);
+      const sellerPk = new PublicKey(claim.sellerWallet);
+      const posterPk = new PublicKey(claim.job.posterWallet);
+
+      // Derive ATAs from the USDC mint + wallet pubkeys.
+      const [buyerAta, sellerAta] = await Promise.all([
+        getAssociatedTokenAddress(USDC_MINT, buyerPk),
+        getAssociatedTokenAddress(USDC_MINT, sellerPk),
+      ]);
+
+      // Fetch the Job to get the 32-byte specHash.
+      const jobRes = await fetch(`/api/jobs/${claim.jobId}`);
+      if (!jobRes.ok) throw new Error("job lookup failed");
+      const jobJson = await jobRes.json();
+      const specHashHex: string = jobJson.specHash ?? jobJson.job?.specHash;
+      if (!specHashHex) throw new Error("job missing specHash");
+      const specHash = Uint8Array.from(Buffer.from(specHashHex, "hex"));
+
+      const { sig } = await buyClaimOnChain({
+        program,
+        buyer: buyerPk,
+        poster: posterPk,
+        specHash,
+        buyerTokenAccount: buyerAta,
+        sellerTokenAccount: sellerAta,
+      });
+
+      const mirrorRes = await fetch(`/api/claims/${claim.id}/buy`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ buyerWallet: account, txSignature: sig }),
+      });
+      if (!mirrorRes.ok) {
+        const txt = await mirrorRes.text();
+        throw new Error(`mirror failed: ${txt}`);
+      }
+
+      setToast({
+        kind: "ok",
+        msg:
+          `Bought ${claim.faceValue.toFixed(2)} USDC claim for ` +
+          `${claim.price.toFixed(2)} USDC. Settlement in ` +
+          `${formatDuration(claim.secondsToChallengeEnd)}.`,
+      });
+      await fetchClaims();
+    } catch (e) {
+      console.error("[credit] buy failed:", e);
+      setToast({
+        kind: "err",
+        msg: "Buy failed: " + (e instanceof Error ? e.message : String(e)),
+      });
+    } finally {
+      setBuying(null);
+    }
+  }
+
+  return (
+    <div style={{ minHeight: "100vh", background: "#0b0b0b", color: "#fff", fontFamily: "inherit" }}>
+      <NavBar activeTab="credit" variant="dark" />
+
+      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "40px 24px 80px" }}>
+        {/* Hero */}
+        <div style={{ marginBottom: 32 }}>
+          <div
+            style={{
+              fontSize: 12,
+              textTransform: "uppercase",
+              letterSpacing: "0.15em",
+              color: "#fffeb2",
+              marginBottom: 8,
+            }}
+          >
+            Covenant Credit
+          </div>
+          <div style={{ fontSize: 40, fontWeight: 800, lineHeight: 1.1, marginBottom: 12 }}>
+            BNPL for AI agents.
+          </div>
+          <div style={{ fontSize: 14, color: "rgba(255,255,255,0.6)", maxWidth: 720, lineHeight: 1.5 }}>
+            Agents with Delivered jobs can sell their pending payment claims at a discount.
+            Lenders earn yield for bearing dispute risk during the 24h challenge window.
+            Only makes economic sense on Solana — try this on Ethereum and you&apos;d lose money to gas.
+          </div>
+        </div>
+
+        {/* Stats strip */}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 32 }}>
+          <StatCard label="Active TVL" value={`$${stats.activeTvl.toFixed(2)}`} accent="#fffeb2" />
+          <StatCard label="Listed" value={String(claims.length)} />
+          <StatCard label="Bought" value={String(stats.boughtCount)} />
+          <StatCard label="Best APR" value={`${bestApr.toFixed(0)}%`} accent="#7CFF7C" />
+        </div>
+
+        {/* Your pending jobs (Delivered, no listing yet) */}
+        {account && pendingJobs.length > 0 && (
+          <div
+            style={{
+              marginBottom: 32,
+              padding: 20,
+              background: "rgba(255,254,178,0.05)",
+              border: "1px solid rgba(255,254,178,0.25)",
+              borderRadius: 12,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "#fffeb2",
+                marginBottom: 12,
+                fontWeight: 700,
+              }}
+            >
+              Your pending payments — sell any of these instantly
+            </div>
+            {pendingJobs.map((j) => (
+              <div
+                key={j.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 16,
+                  padding: "12px 0",
+                  borderTop: "1px solid rgba(255,255,255,0.06)",
+                  fontSize: 13,
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 600 }}>
+                    {((j.specJson as { title?: string } | undefined)?.title) ??
+                      `Job ${j.id.slice(0, 6)}`}
+                  </div>
+                  <div style={{ fontSize: 11, color: "rgba(255,255,255,0.5)", marginTop: 2 }}>
+                    {j.amount.toFixed(2)} USDC — settles in{" "}
+                    {j.challengeEndAt
+                      ? formatDuration(
+                          Math.round(
+                            (new Date(j.challengeEndAt).getTime() - Date.now()) /
+                              1000,
+                          ),
+                        )
+                      : "—"}
+                  </div>
+                </div>
+                <SellClaimButton
+                  jobId={j.id}
+                  posterWallet={j.posterWallet}
+                  takerWallet={j.takerWallet}
+                  specHashHex={j.specHash}
+                  faceValue={j.amount}
+                  onListed={() => {
+                    fetchClaims();
+                    fetchPendingJobs();
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Toast */}
+        {toast && (
+          <div
+            style={{
+              marginBottom: 20,
+              padding: "12px 16px",
+              borderRadius: 8,
+              fontSize: 13,
+              color: toast.kind === "ok" ? "#7CFF7C" : "#FF425E",
+              background: toast.kind === "ok" ? "rgba(124,255,124,0.1)" : "rgba(255,66,94,0.1)",
+              border: `1px solid ${toast.kind === "ok" ? "#7CFF7C40" : "#FF425E40"}`,
+            }}
+          >
+            {toast.msg}
+          </div>
+        )}
+
+        {/* Table */}
+        <div
+          style={{
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.08)",
+            borderRadius: 12,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(160px,1.2fr) 100px 100px 90px 90px 140px 140px 120px",
+              padding: "14px 20px",
+              background: "rgba(255,255,255,0.03)",
+              borderBottom: "1px solid rgba(255,255,255,0.08)",
+              fontSize: 11,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "rgba(255,255,255,0.5)",
+            }}
+          >
+            <div>Job</div>
+            <div>Category</div>
+            <div>Face value</div>
+            <div>Price</div>
+            <div>Discount</div>
+            <div>APR (annual)</div>
+            <div>Settles in</div>
+            <div />
+          </div>
+
+          {loading ? (
+            <div style={{ padding: 40, textAlign: "center", color: "rgba(255,255,255,0.4)" }}>
+              Loading claims…
+            </div>
+          ) : claims.length === 0 ? (
+            <div style={{ padding: 40, textAlign: "center", color: "rgba(255,255,255,0.4)" }}>
+              No active listings. An agent needs to deliver a job and sell the claim first.
+            </div>
+          ) : (
+            claims.map((c) => (
+              <div
+                key={c.id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "minmax(160px,1.2fr) 100px 100px 90px 90px 140px 140px 120px",
+                  padding: "14px 20px",
+                  borderBottom: "1px solid rgba(255,255,255,0.06)",
+                  alignItems: "center",
+                  fontSize: 13,
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 600, marginBottom: 2 }}>
+                    {((c.job.specJson as { title?: string } | undefined)?.title as string) ??
+                      `Job ${c.jobId.slice(0, 6)}`}
+                  </div>
+                  <div style={{ fontSize: 11, color: "rgba(255,255,255,0.4)" }}>
+                    seller {shortWallet(c.sellerWallet)}
+                  </div>
+                </div>
+                <div style={{ fontSize: 12, color: "rgba(255,255,255,0.6)" }}>{c.job.category}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={USDC_LOGO_URL} alt="USDC" width={14} height={14} style={{ borderRadius: "50%" }} />
+                  <span>{c.faceValue.toFixed(2)}</span>
+                </div>
+                <div style={{ color: "#fffeb2" }}>{c.price.toFixed(2)}</div>
+                <div style={{ color: "#7CFF7C" }}>{c.discountPct.toFixed(1)}%</div>
+                <div style={{ color: "#7CFF7C", fontWeight: 700 }}>
+                  {c.aprPct >= 1000 ? `${Math.round(c.aprPct)}%` : `${c.aprPct.toFixed(0)}%`}
+                </div>
+                <div
+                  style={{
+                    color:
+                      c.secondsToChallengeEnd > 3600
+                        ? "rgba(255,255,255,0.5)"
+                        : "#FFB84D",
+                  }}
+                >
+                  {formatDuration(c.secondsToChallengeEnd)}
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <button
+                    onClick={() => handleBuy(c)}
+                    disabled={
+                      buying !== null ||
+                      !account ||
+                      c.sellerWallet === account ||
+                      c.secondsToChallengeEnd <= 0
+                    }
+                    style={{
+                      padding: "6px 14px",
+                      fontFamily: "inherit",
+                      fontSize: 11,
+                      fontWeight: 700,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      color: "#000",
+                      background:
+                        buying !== null ||
+                        !account ||
+                        c.sellerWallet === account ||
+                        c.secondsToChallengeEnd <= 0
+                          ? "rgba(255,254,178,0.3)"
+                          : "#fffeb2",
+                      border: "none",
+                      borderRadius: 6,
+                      cursor:
+                        buying !== null ||
+                        !account ||
+                        c.sellerWallet === account ||
+                        c.secondsToChallengeEnd <= 0
+                          ? "not-allowed"
+                          : "pointer",
+                    }}
+                  >
+                    {buying === c.id ? "Buying…" : "Buy claim"}
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer explainer */}
+        <div
+          style={{
+            marginTop: 40,
+            padding: 20,
+            background: "rgba(255,255,255,0.03)",
+            border: "1px solid rgba(255,255,255,0.06)",
+            borderRadius: 10,
+            fontSize: 12,
+            color: "rgba(255,255,255,0.5)",
+            lineHeight: 1.6,
+          }}
+        >
+          <b style={{ color: "#fffeb2" }}>How it works.</b>{" "}
+          A taker with a Delivered job lists their claim at a discounted price — they prefer
+          cash now over waiting for the challenge window to expire. You buy the claim by paying
+          the seller directly; when finalize_payment fires on chain, you receive the full face
+          value instead of the seller. If a dispute resolves FavorPoster during the challenge
+          window you lose your principal — that risk is priced into every discount.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  return (
+    <div
+      style={{
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderRadius: 10,
+        padding: "16px 18px",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "rgba(255,255,255,0.45)",
+          marginBottom: 6,
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ fontSize: 22, fontWeight: 700, color: accent ?? "#fff" }}>{value}</div>
+    </div>
+  );
+}

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -58,7 +58,7 @@ function prefetchBackground(href: string): void {
   img.src = href;
 }
 
-type Tab = "home" | "agents" | "create" | "poster" | "taker" | "dashboard" | "battle" | "arena" | "autonomous" | "leaderboard" | "architecture" | "events" | "admin" | "onchain" | "disputes" | "faucet" | "api-docs" | "protocol" | "developers" | "integrate" | "profile";
+type Tab = "home" | "agents" | "create" | "poster" | "taker" | "dashboard" | "battle" | "arena" | "autonomous" | "leaderboard" | "architecture" | "events" | "admin" | "onchain" | "disputes" | "faucet" | "api-docs" | "protocol" | "developers" | "integrate" | "profile" | "credit";
 
 interface NavBarProps {
   activeTab: Tab;
@@ -74,6 +74,7 @@ const PRIMARY_TABS: { id: Tab; label: string; href: string }[] = [
   { id: "dashboard", label: "Dashboard", href: "/dashboard" },
   { id: "battle", label: "Battle", href: "/battle" },
   { id: "arena", label: "Arena", href: "/arena" },
+  { id: "credit", label: "Credit", href: "/credit" },
 ];
 
 const MORE_TABS: { id: Tab; label: string; href: string }[] = [

--- a/app/components/SellClaimButton.tsx
+++ b/app/components/SellClaimButton.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+/**
+ * SellClaimButton — lets the taker list their pending payment claim on
+ * Covenant Credit. Appears only for jobs the caller actually took and
+ * that are currently in `Delivered` state with no active dispute.
+ *
+ * UX: click → modal with price slider (default 97% = 3% discount) →
+ * preview yield → confirm → sign list_claim in wallet → POST to
+ * /api/claims to mirror the on-chain state into the DB.
+ */
+
+import { useState } from "react";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { useConnector } from "@solana/connector/react";
+import { BN } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { getAnchorProgram, listClaimOnChain } from "@/lib/anchor-browser";
+import { USDC_DECIMALS } from "@/lib/constants";
+
+interface SellClaimButtonProps {
+  jobId: string;
+  posterWallet: string;
+  takerWallet: string;
+  specHashHex: string;
+  faceValue: number;
+  /** True if a ClaimListing already exists for this job. */
+  alreadyListed?: boolean;
+  onListed?: () => void;
+}
+
+function toAtomic(amount: number): BN {
+  return new BN(Math.round(amount * 10 ** USDC_DECIMALS));
+}
+
+export default function SellClaimButton(props: SellClaimButtonProps) {
+  const connector = useConnector();
+  const account =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.account?.address ??
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (connector as any)?.selectedWallet?.accounts?.[0]?.address ??
+    null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const selectedWallet = (connector as any)?.selectedWallet ?? null;
+
+  const [open, setOpen] = useState(false);
+  const [discountPct, setDiscountPct] = useState(3); // default 3% discount
+  const [listing, setListing] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const isTaker = account === props.takerWallet;
+  if (!isTaker || props.alreadyListed) return null;
+
+  const price = Math.max(0.000001, props.faceValue * (1 - discountPct / 100));
+  const earnedNow = price;
+  const lenderYield = props.faceValue - price;
+
+  async function handleConfirm() {
+    if (!account || !selectedWallet) {
+      setErr("Connect your wallet first.");
+      return;
+    }
+    setListing(true);
+    setErr(null);
+    try {
+      const program = getAnchorProgram(account, selectedWallet);
+      if (!program) throw new Error("wallet program unavailable");
+
+      const specHash = Uint8Array.from(Buffer.from(props.specHashHex, "hex"));
+      const priceBn = toAtomic(price);
+      const sellerPk = new PublicKey(account);
+      const posterPk = new PublicKey(props.posterWallet);
+
+      const { sig } = await listClaimOnChain({
+        program,
+        seller: sellerPk,
+        poster: posterPk,
+        specHash,
+        price: priceBn,
+      });
+
+      const mirrorRes = await fetch("/api/claims", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId: props.jobId, txSignature: sig }),
+      });
+      if (!mirrorRes.ok) {
+        const txt = await mirrorRes.text();
+        throw new Error(`mirror failed: ${txt}`);
+      }
+
+      setOpen(false);
+      props.onListed?.();
+    } catch (e) {
+      console.error("[sell-claim] failed:", e);
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setListing(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        style={{
+          padding: "10px 18px",
+          fontFamily: "inherit",
+          fontSize: 12,
+          fontWeight: 700,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "#000",
+          background: "#fffeb2",
+          border: "none",
+          borderRadius: 6,
+          cursor: "pointer",
+        }}
+      >
+        Sell claim →
+      </button>
+
+      {open && (
+        <div
+          onClick={() => !listing && setOpen(false)}
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.7)",
+            backdropFilter: "blur(6px)",
+            zIndex: 100,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: "100%",
+              maxWidth: 440,
+              background: "#111",
+              border: "1px solid rgba(255,255,255,0.1)",
+              borderRadius: 12,
+              padding: 28,
+              color: "#fff",
+              fontFamily: "inherit",
+            }}
+          >
+            <div style={{ fontSize: 20, fontWeight: 700, marginBottom: 6 }}>
+              Sell your pending claim
+            </div>
+            <div style={{ fontSize: 13, color: "rgba(255,255,255,0.5)", marginBottom: 20, lineHeight: 1.5 }}>
+              Skip the 24h challenge window. Get paid in USDC now, the lender
+              collects the full face value when finalize_payment fires.
+            </div>
+
+            {/* Discount slider */}
+            <div style={{ marginBottom: 16 }}>
+              <div
+                style={{
+                  fontSize: 11,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "rgba(255,255,255,0.5)",
+                  marginBottom: 6,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>Discount</span>
+                <span style={{ color: "#7CFF7C" }}>{discountPct.toFixed(1)}%</span>
+              </div>
+              <input
+                type="range"
+                min={0.5}
+                max={20}
+                step={0.5}
+                value={discountPct}
+                onChange={(e) => setDiscountPct(parseFloat(e.target.value))}
+                disabled={listing}
+                style={{ width: "100%", accentColor: "#fffeb2" }}
+              />
+              <div
+                style={{
+                  fontSize: 10,
+                  color: "rgba(255,255,255,0.4)",
+                  marginTop: 4,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span>0.5% (tight)</span>
+                <span>20% (fast sale)</span>
+              </div>
+            </div>
+
+            {/* Preview */}
+            <div
+              style={{
+                background: "rgba(255,254,178,0.05)",
+                border: "1px solid rgba(255,254,178,0.2)",
+                borderRadius: 8,
+                padding: 16,
+                marginBottom: 16,
+                fontSize: 13,
+              }}
+            >
+              <Row label="Face value" value={`$${props.faceValue.toFixed(2)}`} />
+              <Row
+                label="You receive now"
+                value={`$${earnedNow.toFixed(2)}`}
+                accent="#fffeb2"
+                strong
+              />
+              <Row label="Lender earns" value={`$${lenderYield.toFixed(2)}`} accent="#7CFF7C" />
+            </div>
+
+            {err && (
+              <div
+                style={{
+                  padding: 10,
+                  borderRadius: 6,
+                  fontSize: 12,
+                  background: "rgba(255,66,94,0.1)",
+                  border: "1px solid rgba(255,66,94,0.3)",
+                  color: "#FF425E",
+                  marginBottom: 12,
+                }}
+              >
+                {err}
+              </div>
+            )}
+
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                onClick={() => !listing && setOpen(false)}
+                disabled={listing}
+                style={{
+                  flex: 1,
+                  padding: "12px",
+                  fontFamily: "inherit",
+                  fontSize: 12,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "rgba(255,255,255,0.7)",
+                  background: "transparent",
+                  border: "1px solid rgba(255,255,255,0.2)",
+                  borderRadius: 6,
+                  cursor: listing ? "not-allowed" : "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={listing}
+                style={{
+                  flex: 2,
+                  padding: "12px",
+                  fontFamily: "inherit",
+                  fontSize: 12,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                  color: "#000",
+                  background: listing ? "rgba(255,254,178,0.4)" : "#fffeb2",
+                  border: "none",
+                  borderRadius: 6,
+                  cursor: listing ? "not-allowed" : "pointer",
+                }}
+              >
+                {listing ? "Listing…" : "Sign & list"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function Row({
+  label,
+  value,
+  accent,
+  strong,
+}: {
+  label: string;
+  value: string;
+  accent?: string;
+  strong?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        padding: "4px 0",
+        fontSize: 13,
+      }}
+    >
+      <span style={{ color: "rgba(255,255,255,0.6)" }}>{label}</span>
+      <span
+        style={{
+          color: accent ?? "#fff",
+          fontWeight: strong ? 700 : 500,
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/app/lib/anchor-browser.ts
+++ b/app/lib/anchor-browser.ts
@@ -542,3 +542,151 @@ export async function finalizePaymentOnChain(params: {
   );
   return sig;
 }
+
+// ---- Covenant Credit helpers ----
+
+export function deriveClaimPda(jobPda: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("claim"), jobPda.toBuffer()],
+    PROGRAM_ID,
+  );
+}
+
+/**
+ * Build + sign the on-chain `list_claim` instruction.
+ *
+ * Taker (seller) must have a Delivered job with no active dispute.
+ * Price must be strictly less than the job's face value — there's no
+ * rational buyer at par.
+ */
+export async function listClaimOnChain(params: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  program: Program<any>;
+  seller: PublicKey;
+  poster: PublicKey;
+  specHash: Uint8Array;
+  price: BN;
+}): Promise<{ sig: string; claimPda: PublicKey }> {
+  const { program, seller, poster, specHash, price } = params;
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  const tx = await (program.methods as any)
+    .listClaim(price)
+    .accounts({
+      seller,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      systemProgram: SystemProgram.programId,
+    })
+    .transaction();
+
+  const connection = program.provider.connection;
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = seller;
+
+  const signedTx = await ((program.provider as any).wallet as any).signTransaction(tx);
+  const sig = await connection.sendRawTransaction(signedTx.serialize(), {
+    skipPreflight: false,
+  });
+  await connection.confirmTransaction(
+    { signature: sig, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+  return { sig, claimPda };
+}
+
+/**
+ * Build + sign the on-chain `buy_claim` instruction.
+ *
+ * Buyer pays `claim_listing.price` USDC to the seller atomically and
+ * inherits the right to collect `face_value` when finalize/resolve
+ * fires. Rejects if buyer == seller.
+ */
+export async function buyClaimOnChain(params: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  program: Program<any>;
+  buyer: PublicKey;
+  poster: PublicKey;
+  specHash: Uint8Array;
+  buyerTokenAccount: PublicKey;
+  sellerTokenAccount: PublicKey;
+}): Promise<{ sig: string; claimPda: PublicKey }> {
+  const { program, buyer, poster, specHash, buyerTokenAccount, sellerTokenAccount } = params;
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  const tx = await (program.methods as any)
+    .buyClaim()
+    .accounts({
+      buyer,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      buyerTokenAccount,
+      sellerTokenAccount,
+      tokenProgram: TOKEN_PROGRAM_ID,
+    })
+    .transaction();
+
+  const connection = program.provider.connection;
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = buyer;
+
+  const signedTx = await ((program.provider as any).wallet as any).signTransaction(tx);
+  const sig = await connection.sendRawTransaction(signedTx.serialize(), {
+    skipPreflight: false,
+  });
+  await connection.confirmTransaction(
+    { signature: sig, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+  return { sig, claimPda };
+}
+
+/**
+ * Build + sign the on-chain `cancel_claim` instruction.
+ *
+ * Only the original seller may cancel, and only while the listing is
+ * still in `Listed` state. Account is closed and rent refunded.
+ */
+export async function cancelClaimOnChain(params: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  program: Program<any>;
+  seller: PublicKey;
+  claimPda: PublicKey;
+}): Promise<string> {
+  const { program, seller, claimPda } = params;
+
+  const tx = await (program.methods as any)
+    .cancelClaim()
+    .accounts({
+      seller,
+      claimListing: claimPda,
+    })
+    .transaction();
+
+  const connection = program.provider.connection;
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  tx.recentBlockhash = blockhash;
+  tx.lastValidBlockHeight = lastValidBlockHeight;
+  tx.feePayer = seller;
+
+  const signedTx = await ((program.provider as any).wallet as any).signTransaction(tx);
+  const sig = await connection.sendRawTransaction(signedTx.serialize(), {
+    skipPreflight: false,
+  });
+  await connection.confirmTransaction(
+    { signature: sig, blockhash, lastValidBlockHeight },
+    "confirmed",
+  );
+  return sig;
+}

--- a/app/lib/credit-server.ts
+++ b/app/lib/credit-server.ts
@@ -278,3 +278,109 @@ export async function botBuyClaim(params: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .rpc()) as string;
 }
+
+// ---- Claim-aware finalize crank ----
+
+/**
+ * Derive the expected `reputation` PDA for a taker.
+ */
+export function deriveReputationPda(wallet: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("reputation"), wallet.toBuffer()],
+    PROGRAM_ID,
+  );
+}
+
+/**
+ * Permissionless finalize crank that correctly routes payment when a
+ * claim has been sold.
+ *
+ * Logic:
+ *   1. Derive the ClaimListing PDA for this job
+ *   2. Fetch it; if status=Bought, the beneficiary ATA is the buyer's
+ *      USDC ATA. Otherwise it's the taker's ATA.
+ *   3. Invoke on-chain finalize_payment with:
+ *      - crank = our CRANK_KEYPAIR / DEPLOYER_KEYPAIR signer
+ *      - taker_token_account = beneficiary ATA from step 2
+ *      - claim_listing = the PDA (always passed; uninitialized if no
+ *        listing, Anchor still validates the address)
+ *
+ * Returns the tx signature. Throws on any on-chain error.
+ */
+export async function finalizeWithClaim(params: {
+  crankKeypair: Keypair;
+  poster: PublicKey;
+  taker: PublicKey;
+  specHash: Buffer;
+  escrowTokenAccount: PublicKey;
+}): Promise<{ sig: string; routedToBuyer: boolean; buyer: string | null }> {
+  const { crankKeypair, poster, taker, specHash, escrowTokenAccount } = params;
+
+  const program = getBotProgram(crankKeypair);
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+  const [reputationPda] = deriveReputationPda(taker);
+
+  // Discover who the beneficiary should be.
+  const listing = await fetchClaimListing(claimPda);
+  let beneficiaryWallet: PublicKey = taker;
+  let routedToBuyer = false;
+  let buyerStr: string | null = null;
+  if (listing && listing.status === "Bought" && listing.buyer) {
+    beneficiaryWallet = new PublicKey(listing.buyer);
+    routedToBuyer = true;
+    buyerStr = listing.buyer;
+  }
+
+  const beneficiaryAta = await getAssociatedTokenAddress(
+    USDC_MINT,
+    beneficiaryWallet,
+  );
+
+  const sig = (await (program.methods as { finalizePayment: () => unknown })
+    .finalizePayment()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .accounts({
+      crank: crankKeypair.publicKey,
+      jobEscrow: jobPda,
+      poster,
+      escrowTokenAccount,
+      takerTokenAccount: beneficiaryAta,
+      taker,
+      takerReputation: reputationPda,
+      claimListing: claimPda,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      systemProgram: SystemProgram.programId,
+    } as Record<string, PublicKey>)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .rpc()) as string;
+
+  return { sig, routedToBuyer, buyer: buyerStr };
+}
+
+/**
+ * Derive the escrow ATA owner ≡ the JobEscrow PDA. Since the on-chain
+ * escrow_token_account was created in `create_job` as a random keypair
+ * owned by the JobEscrow PDA, a caller that lost the escrowAta can
+ * reconstruct it by asking the SPL Token program for the single token
+ * account matching `(owner=jobPda, mint=tokenMint)`.
+ *
+ * This is expensive (RPC call) but works as a recovery path when the
+ * DB row is missing escrowAta (pre-schema-bump jobs).
+ */
+export async function findEscrowTokenAccount(params: {
+  jobPda: PublicKey;
+}): Promise<PublicKey | null> {
+  const conn = getConnection();
+  const { jobPda } = params;
+  const accounts = await conn.getTokenAccountsByOwner(jobPda, {
+    mint: USDC_MINT,
+  });
+  if (accounts.value.length === 0) return null;
+  // There's exactly one in the happy path. If multiple exist (shouldn't
+  // per create_job semantics), take the first non-empty one.
+  const nonEmpty = accounts.value.find(
+    (a) => BigInt(a.account.data.length) > 0n,
+  );
+  return nonEmpty?.pubkey ?? accounts.value[0].pubkey;
+}

--- a/app/lib/credit-server.ts
+++ b/app/lib/credit-server.ts
@@ -1,0 +1,280 @@
+/**
+ * @file credit-server.ts — server-side helpers for Covenant Credit.
+ *
+ * Reads and (bot-only) writes the on-chain ClaimListing state introduced
+ * in PR #36. Used by the `/api/claims*` API routes and by cron tasks
+ * that scan for claim-related events.
+ *
+ * Human users never go through here — they invoke list_claim /
+ * buy_claim / cancel_claim via the browser (see `lib/anchor-browser.ts`
+ * extensions). The server's role is strictly:
+ *   1. Verify a user-signed claim tx invoked our program
+ *   2. Read the on-chain account back
+ *   3. Mirror to the DB
+ *
+ * Bot helpers (botListClaim, botBuyClaim) exist for arena/battle/
+ * autonomous demos where the server holds the bot's own keypair.
+ */
+
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+} from "@solana/web3.js";
+import { TOKEN_PROGRAM_ID, getAssociatedTokenAddress } from "@solana/spl-token";
+import { AnchorProvider, BN, Program, type Idl } from "@coral-xyz/anchor";
+import idl from "./covenant-idl.json";
+import {
+  PROGRAM_ID,
+  USDC_MINT,
+  USDC_DECIMALS,
+  DEVNET_ENDPOINT,
+} from "./constants";
+
+// ---- Connection + program ----
+
+export function getConnection(): Connection {
+  const rpc =
+    process.env.HELIUS_RPC_URL ||
+    process.env.NEXT_PUBLIC_RPC_URL ||
+    DEVNET_ENDPOINT;
+  return new Connection(rpc, "confirmed");
+}
+
+class NodeWallet {
+  constructor(public readonly payer: Keypair) {}
+  get publicKey() {
+    return this.payer.publicKey;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async signTransaction<T>(tx: T): Promise<T> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tx as any).partialSign(this.payer);
+    return tx;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async signAllTransactions<T>(txs: T[]): Promise<T[]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    txs.forEach((tx) => (tx as any).partialSign(this.payer));
+    return txs;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getBotProgram(botKeypair: Keypair): Program<any> {
+  const connection = getConnection();
+  const wallet = new NodeWallet(botKeypair);
+  const provider = new AnchorProvider(connection, wallet, {
+    commitment: "confirmed",
+  });
+  return new Program(idl as Idl, provider);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getReadOnlyProgram(): Program<any> {
+  return getBotProgram(Keypair.generate());
+}
+
+export function keypairFromEnv(envVar: string): Keypair {
+  const raw = process.env[envVar];
+  if (!raw) throw new Error(`${envVar} not set`);
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(raw)));
+}
+
+// ---- PDA helpers ----
+
+export function deriveJobPda(
+  poster: PublicKey,
+  specHash: Uint8Array | Buffer,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("job"), poster.toBuffer(), Buffer.from(specHash)],
+    PROGRAM_ID,
+  );
+}
+
+export function deriveClaimPda(jobPda: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("claim"), jobPda.toBuffer()],
+    PROGRAM_ID,
+  );
+}
+
+// ---- ClaimListing decoder ----
+
+export type ClaimStatus = "Listed" | "Bought" | "Cancelled" | "Settled" | "Unknown";
+
+export interface OnChainClaimListing {
+  pda: string;
+  job: string;
+  seller: string;
+  buyer: string | null;
+  price: number; // human units
+  priceAtomic: bigint;
+  faceValue: number;
+  faceValueAtomic: bigint;
+  listedAt: number;
+  boughtAt: number;
+  status: ClaimStatus;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function statusKey(status: any): ClaimStatus {
+  if (!status || typeof status !== "object") return "Unknown";
+  const k = Object.keys(status)[0];
+  if (!k) return "Unknown";
+  const capitalized = k.charAt(0).toUpperCase() + k.slice(1);
+  if (
+    capitalized === "Listed" ||
+    capitalized === "Bought" ||
+    capitalized === "Cancelled" ||
+    capitalized === "Settled"
+  ) {
+    return capitalized;
+  }
+  return "Unknown";
+}
+
+/**
+ * Fetch + decode a ClaimListing by its PDA. Returns null if the account
+ * does not exist (never listed or cancelled+closed).
+ */
+export async function fetchClaimListing(
+  claimPda: PublicKey,
+): Promise<OnChainClaimListing | null> {
+  const program = getReadOnlyProgram();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = await (program.account as any).claimListing.fetchNullable(
+    claimPda,
+  );
+  if (!raw) return null;
+
+  const priceAtomic: bigint = BigInt(raw.price.toString());
+  const faceValueAtomic: bigint = BigInt(raw.faceValue.toString());
+  const buyerStr = new PublicKey(raw.buyer).toBase58();
+  const isBuyerDefault = buyerStr === PublicKey.default.toBase58();
+
+  return {
+    pda: claimPda.toBase58(),
+    job: new PublicKey(raw.job).toBase58(),
+    seller: new PublicKey(raw.seller).toBase58(),
+    buyer: isBuyerDefault ? null : buyerStr,
+    price: Number(priceAtomic) / 10 ** USDC_DECIMALS,
+    priceAtomic,
+    faceValue: Number(faceValueAtomic) / 10 ** USDC_DECIMALS,
+    faceValueAtomic,
+    listedAt: Number(raw.listedAt.toString()),
+    boughtAt: Number(raw.boughtAt.toString()),
+    status: statusKey(raw.status),
+  };
+}
+
+/** Convenience: derive + fetch in one call. */
+export async function fetchClaimForJob(
+  jobPda: PublicKey,
+): Promise<OnChainClaimListing | null> {
+  const [claimPda] = deriveClaimPda(jobPda);
+  return fetchClaimListing(claimPda);
+}
+
+// ---- Tx verification ----
+
+/**
+ * Verify a transaction both landed successfully AND invoked the
+ * Covenant program at least once. Blocks the "arbitrary confirmed
+ * signature" replay pattern flagged in audit C-04.
+ */
+export async function verifyTxInvokedCovenant(sig: string): Promise<void> {
+  const conn = getConnection();
+  const tx = await conn.getTransaction(sig, {
+    maxSupportedTransactionVersion: 0,
+    commitment: "confirmed",
+  });
+  if (!tx) throw new Error(`tx ${sig.slice(0, 8)}… not found on chain`);
+  if (tx.meta?.err) {
+    throw new Error(`tx reverted: ${JSON.stringify(tx.meta.err)}`);
+  }
+  const keys = tx.transaction.message.staticAccountKeys ?? [];
+  const programIdStr = PROGRAM_ID.toBase58();
+  const invoked = keys.some((k) => k.toBase58() === programIdStr);
+  if (!invoked) {
+    throw new Error(
+      `tx ${sig.slice(0, 8)}… did not invoke Covenant program ${programIdStr.slice(0, 8)}…`,
+    );
+  }
+}
+
+// ---- Bot-signed instruction helpers (arena/battle/autonomous) ----
+
+/**
+ * Bot-signed `list_claim`. Used only when the bot has an on-chain
+ * Delivered job of its own to factor (i.e. bot is the original taker).
+ */
+export async function botListClaim(params: {
+  takerBotKeypair: Keypair;
+  poster: PublicKey;
+  specHash: Buffer;
+  priceAtomic: BN;
+}): Promise<{ sig: string; claimPda: PublicKey }> {
+  const { takerBotKeypair, poster, specHash, priceAtomic } = params;
+  const program = getBotProgram(takerBotKeypair);
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  const sig = (await (program.methods as { listClaim: (...a: unknown[]) => unknown })
+    .listClaim(priceAtomic)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .accounts({
+      seller: takerBotKeypair.publicKey,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      systemProgram: SystemProgram.programId,
+    } as Record<string, PublicKey>)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .rpc()) as string;
+
+  return { sig, claimPda };
+}
+
+/**
+ * Bot-signed `buy_claim`. Used by an autonomous lender bot that
+ * auto-matches claims meeting reputation + discount thresholds.
+ */
+export async function botBuyClaim(params: {
+  buyerBotKeypair: Keypair;
+  poster: PublicKey;
+  specHash: Buffer;
+}): Promise<string> {
+  const { buyerBotKeypair, poster, specHash } = params;
+  const program = getBotProgram(buyerBotKeypair);
+  const [jobPda] = deriveJobPda(poster, specHash);
+  const [claimPda] = deriveClaimPda(jobPda);
+
+  // Fetch the listing to discover the seller ATA we need to pay.
+  const listing = await fetchClaimListing(claimPda);
+  if (!listing) throw new Error("claim listing not found");
+  const sellerPubkey = new PublicKey(listing.seller);
+
+  const buyerAta = await getAssociatedTokenAddress(
+    USDC_MINT,
+    buyerBotKeypair.publicKey,
+  );
+  const sellerAta = await getAssociatedTokenAddress(USDC_MINT, sellerPubkey);
+
+  return (await (program.methods as { buyClaim: () => unknown })
+    .buyClaim()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .accounts({
+      buyer: buyerBotKeypair.publicKey,
+      jobEscrow: jobPda,
+      poster,
+      claimListing: claimPda,
+      buyerTokenAccount: buyerAta,
+      sellerTokenAccount: sellerAta,
+      tokenProgram: TOKEN_PROGRAM_ID,
+    } as Record<string, PublicKey>)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .rpc()) as string;
+}

--- a/app/lib/program-server.ts
+++ b/app/lib/program-server.ts
@@ -341,14 +341,14 @@ export async function botCreateJob(params: {
 
   const amountAtomic = new BN(Math.round(amount * 10 ** USDC_DECIMALS));
 
-  const sig = await (program.methods as { createJob: (...args: unknown[]) => unknown })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sig: string = await (program.methods as any)
     .createJob(
       amountAtomic,
       Array.from(specHash),
       new BN(deadline),
       new BN(challengePeriod),
     )
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .accounts({
       poster: botKeypair.publicKey,
       config: configPda,
@@ -359,11 +359,9 @@ export async function botCreateJob(params: {
       tokenProgram: TOKEN_PROGRAM_ID,
       systemProgram: SystemProgram.programId,
       rent: SYSVAR_RENT_PUBKEY,
-    } as Record<string, PublicKey>)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .signers([escrowKp] as any)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .rpc() as Promise<string>;
+    })
+    .signers([escrowKp])
+    .rpc();
 
   return { sig, jobPda, escrowTokenAccount: escrowKp.publicKey };
 }
@@ -380,16 +378,15 @@ export async function botAcceptJob(params: {
   const program = getBotProgram(takerBotKeypair);
   const [jobPda] = deriveJobPda(poster, specHash);
 
-  return await (program.methods as { acceptJob: (...args: unknown[]) => unknown })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (await (program.methods as any)
     .acceptJob(Array.from(specHash))
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .accounts({
       taker: takerBotKeypair.publicKey,
       jobEscrow: jobPda,
       poster,
-    } as Record<string, PublicKey>)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .rpc() as Promise<string>;
+    })
+    .rpc()) as string;
 }
 
 /**
@@ -406,16 +403,15 @@ export async function botSubmitWork(params: {
   const program = getBotProgram(takerBotKeypair);
   const [jobPda] = deriveJobPda(poster, specHash);
 
-  return await (program.methods as { submitWork: (...args: unknown[]) => unknown })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (await (program.methods as any)
     .submitWork(Array.from(workHash), deliveryUri)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .accounts({
       taker: takerBotKeypair.publicKey,
       jobEscrow: jobPda,
       poster,
-    } as Record<string, PublicKey>)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .rpc() as Promise<string>;
+    })
+    .rpc()) as string;
 }
 
 /**
@@ -436,9 +432,9 @@ export async function botFinalizePayment(params: {
   const [reputationPda] = deriveReputationPda(taker);
   const takerAta = await getAssociatedTokenAddress(USDC_MINT, taker);
 
-  return await (program.methods as { finalizePayment: () => unknown })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (await (program.methods as any)
     .finalizePayment()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .accounts({
       crank: crankKeypair.publicKey,
       jobEscrow: jobPda,
@@ -449,7 +445,6 @@ export async function botFinalizePayment(params: {
       takerReputation: reputationPda,
       tokenProgram: TOKEN_PROGRAM_ID,
       systemProgram: SystemProgram.programId,
-    } as Record<string, PublicKey>)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .rpc() as Promise<string>;
+    })
+    .rpc()) as string;
 }

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -14,7 +14,7 @@ datasource db {
 model Job {
   id               String      @id @default(cuid())
   pda              String?     @unique // on-chain JobEscrow PDA (base58)
-  escrowAta        String?     // SPL escrow token account (base58); not a PDA in v1
+  escrowAta        String?     // SPL escrow token account (base58); random keypair in v1, not a PDA
   posterWallet     String
   takerWallet      String?
   amount           Float

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Job {
 
   delivery         Delivery?
   dispute          Dispute?
+  claim            ClaimListing?
   submissions      Submission[]
   events           JobEvent[]
   interests        JobInterest[]
@@ -47,6 +48,45 @@ model Job {
   @@index([takerWallet])
   @@index([status])
   @@index([challengeEndAt])
+}
+
+// ============================================================================
+// Covenant Credit — BNPL / factoring for pending claims
+// ============================================================================
+//
+// Mirrors the on-chain `ClaimListing` account introduced in PR #36. Every
+// row MUST correspond to a real PDA at seeds=[b"claim", job_escrow.key()]
+// on the Covenant program. This table is a denormalized view for fast
+// marketplace queries — chain is always the source of truth.
+
+model ClaimListing {
+  id              String    @id @default(cuid())
+  pda             String    @unique         // on-chain ClaimListing PDA (base58)
+  jobId           String    @unique         // 1:1 with our Job row
+  jobPda          String                    // on-chain JobEscrow PDA (base58)
+  sellerWallet   String                     // original taker / seller
+  buyerWallet    String?                    // lender after purchase
+  price          Float                      // USDC human units the buyer pays
+  faceValue      Float                      // USDC human units the buyer receives on finalize
+  priceAtomic    String                     // atomic u64 as string (avoid JS precision loss)
+  faceValueAtomic String
+  status         String    @default("Listed") // Listed | Bought | Cancelled | Settled
+  listedAt       DateTime  @default(now())
+  boughtAt       DateTime?
+  settledAt      DateTime?
+  listTxHash     String?                    // list_claim tx signature
+  buyTxHash      String?                    // buy_claim tx signature
+  cancelTxHash   String?                    // cancel_claim tx signature
+  settleTxHash   String?                    // finalize/resolve tx that paid the buyer
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  job            Job       @relation(fields: [jobId], references: [id])
+
+  @@index([sellerWallet])
+  @@index([buyerWallet])
+  @@index([status])
+  @@index([listedAt])
 }
 
 // Delivery commitment submitted by the taker via submit_work.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -178,6 +178,78 @@ Implement `DeliveryStorage` for IPFS, Arweave, S3, or any other backend.
 | `DELIVERY_URI_MAX_LEN` | `128` bytes | Hard on-chain cap |
 | `ARBITRATOR_COUNT` | `3` | 2-of-3 multisig in v1 |
 
+## Covenant Credit — BNPL for agents
+
+A taker who has delivered work may sell their pending payment claim to
+a lender at a discount. The lender pays the seller immediately and
+inherits the right to collect the full face value when
+`finalize_payment` fires. If the job ends up `FavorPoster` during the
+challenge window, the lender loses their principal — that risk is
+priced into the discount.
+
+### Listing a claim (seller side)
+
+```ts
+import BN from "bn.js";
+
+// Seller = taker of a Delivered, non-disputed job.
+// Price in USDC atomic units (6 decimals). Must be strictly less
+// than the job's face value — no rational buyer at par.
+const { txSig, claimPda } = await covenant.listClaim({
+  seller: takerKeypair,
+  jobPda,
+  price: new BN(9_700_000), // 9.7 USDC on a 10 USDC claim = ~3% discount
+});
+```
+
+### Buying a claim (lender side)
+
+```ts
+const { txSig } = await covenant.buyClaim({
+  buyer: lenderKeypair,
+  jobPda,
+  buyerTokenAccount,
+  sellerTokenAccount,
+});
+// Seller receives 9.7 USDC immediately. When finalize_payment fires,
+// the full 10 USDC face value goes to the buyer.
+```
+
+### Cancelling an unsold listing
+
+```ts
+await covenant.cancelClaim({
+  seller: takerKeypair,
+  jobPda,
+});
+// Account is closed, rent refunded to seller.
+// Only valid while status === "Listed".
+```
+
+### Reading claim state
+
+```ts
+const claim = await covenant.fetchClaim(jobPda);
+if (claim?.status === "Bought") {
+  console.log(`Sold to ${claim.buyer.toBase58()} for ${claim.price.toString()} atomic units`);
+}
+```
+
+### Why this is a Solana-native primitive
+
+At Ethereum mainnet gas prices, factoring a $10 claim over a 24-hour
+window would cost more in gas than the yield. Solana's sub-cent fees
++ sub-second finality make sub-$50 claim markets economically viable.
+
+## Examples
+
+See [`examples/`](./examples) for integrations with:
+
+- **MCP** — expose Covenant as an agent-payable tool server via the
+  Model Context Protocol
+- **LangChain** — drop Covenant payment into a LangChain agent graph
+  with a single tool node
+
 ## License
 
 Apache-2.0

--- a/sdk/examples/langchain-integration.ts
+++ b/sdk/examples/langchain-integration.ts
@@ -1,0 +1,202 @@
+/**
+ * Covenant × LangChain — payment rail as a LangChain Tool.
+ *
+ * Wraps Covenant's job lifecycle as LangChain StructuredTools so an
+ * agent graph can post paying jobs, and agents on the other side can
+ * accept + deliver + collect USDC autonomously.
+ *
+ * The demo shows BOTH sides:
+ *   - Poster agent posts a writing job with 5 USDC locked in escrow
+ *   - Taker agent accepts, delivers, lists the claim on Covenant Credit
+ *     at a 3% discount, and gets paid in sub-second wall time instead
+ *     of waiting 24h
+ *
+ * NOTE: This is illustrative. You'll want to swap the in-memory
+ * keypair loader with a secure wallet provider in production.
+ */
+
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import { getAssociatedTokenAddress } from "@solana/spl-token";
+import {
+  CovenantClient,
+  DEVNET_USDC_MINT,
+  hashSpec,
+  type JobSpec,
+} from "@wienerlabs/covenant-sdk";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import idl from "../dist/covenant-idl.json" with { type: "json" };
+
+function clientFor(keypair: Keypair): CovenantClient {
+  const conn = new Connection(
+    process.env.HELIUS_RPC_URL ?? "https://api.devnet.solana.com",
+    "confirmed",
+  );
+  const provider = new AnchorProvider(conn, new Wallet(keypair), {
+    commitment: "confirmed",
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return CovenantClient.fromProvider(provider, idl as any);
+}
+
+function loadKeypair(envVar: string): Keypair {
+  const raw = process.env[envVar];
+  if (!raw) throw new Error(`${envVar} not set`);
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(raw)));
+}
+
+// --- Tools ---------------------------------------------------------------
+
+export const covenantPostJobTool = new DynamicStructuredTool({
+  name: "covenant_post_job",
+  description:
+    "Create a paying job on Covenant. USDC is locked in a per-job PDA " +
+    "escrow on Solana and released to whoever delivers the work first. " +
+    "Returns the job PDA so the agent can track it.",
+  schema: z.object({
+    title: z.string(),
+    amountUsdc: z.number().positive(),
+    minWords: z.number().int().positive(),
+    deadlineHoursFromNow: z.number().positive(),
+  }),
+  func: async ({ title, amountUsdc, minWords, deadlineHoursFromNow }) => {
+    const poster = loadKeypair("POSTER_KEYPAIR");
+    const covenant = clientFor(poster);
+
+    const spec: JobSpec = {
+      type: "langchain.job.v1",
+      category: "text_writing",
+      language: "English",
+      minWords,
+      deadlineUnix:
+        Math.floor(Date.now() / 1000) + Math.round(deadlineHoursFromNow * 3600),
+      metadata: { title, source: "langchain-agent" },
+    };
+    const posterAta = await getAssociatedTokenAddress(
+      DEVNET_USDC_MINT,
+      poster.publicKey,
+    );
+
+    const { jobPda, txSig } = await covenant.createJob({
+      poster,
+      spec,
+      amount: new BN(Math.round(amountUsdc * 1_000_000)),
+      posterTokenAccount: posterAta,
+      tokenMint: DEVNET_USDC_MINT,
+    });
+
+    const specHash = hashSpec(spec);
+    return JSON.stringify({
+      jobPda: jobPda.toBase58(),
+      txSig,
+      specHash,
+    });
+  },
+});
+
+export const covenantSellClaimTool = new DynamicStructuredTool({
+  name: "covenant_sell_claim",
+  description:
+    "Covenant Credit: after the agent has DELIVERED work on a job, " +
+    "sell the pending payment claim at a discount to a lender and get " +
+    "paid immediately instead of waiting for the 24h challenge window " +
+    "to expire. Use this when the agent needs cash flow to accept the " +
+    "next job.",
+  schema: z.object({
+    jobPda: z.string(),
+    discountPct: z.number().min(0.5).max(20).default(3),
+  }),
+  func: async ({ jobPda, discountPct }) => {
+    const seller = loadKeypair("TAKER_KEYPAIR");
+    const covenant = clientFor(seller);
+
+    const jobKey = new PublicKey(jobPda);
+    const job = await covenant.fetchJob(jobKey);
+    const faceValue = job.amount.toNumber();
+    const price = new BN(Math.round(faceValue * (1 - discountPct / 100)));
+
+    const { txSig, claimPda } = await covenant.listClaim({
+      seller,
+      jobPda: jobKey,
+      price,
+    });
+
+    return JSON.stringify({
+      claimPda: claimPda.toBase58(),
+      txSig,
+      facedValueAtomic: faceValue,
+      priceAtomic: price.toString(),
+      discountPct,
+    });
+  },
+});
+
+export const covenantBuyClaimTool = new DynamicStructuredTool({
+  name: "covenant_buy_claim",
+  description:
+    "Covenant Credit: lender side. Buy a listed agent claim at its " +
+    "discounted price. On success the buyer receives the full face " +
+    "value when the job settles on chain — earning yield for bearing " +
+    "dispute risk during the challenge window.",
+  schema: z.object({
+    jobPda: z.string(),
+  }),
+  func: async ({ jobPda }) => {
+    const buyer = loadKeypair("LENDER_KEYPAIR");
+    const covenant = clientFor(buyer);
+
+    const jobKey = new PublicKey(jobPda);
+    const claim = await covenant.fetchClaim(jobKey);
+    if (!claim) throw new Error("no claim listing for this job");
+    if (claim.status !== "Listed") {
+      throw new Error(`claim is ${claim.status}, expected Listed`);
+    }
+
+    const buyerAta = await getAssociatedTokenAddress(
+      DEVNET_USDC_MINT,
+      buyer.publicKey,
+    );
+    const sellerAta = await getAssociatedTokenAddress(
+      DEVNET_USDC_MINT,
+      claim.seller,
+    );
+
+    const { txSig } = await covenant.buyClaim({
+      buyer,
+      jobPda: jobKey,
+      buyerTokenAccount: buyerAta,
+      sellerTokenAccount: sellerAta,
+    });
+
+    return JSON.stringify({
+      txSig,
+      paidAtomic: claim.price.toString(),
+      willReceiveAtomic: claim.faceValue.toString(),
+    });
+  },
+});
+
+/**
+ * All Covenant tools, ready to plug into an AgentExecutor.
+ *
+ * Example:
+ *
+ *   const agent = await createOpenAIToolsAgent({
+ *     llm: new ChatOpenAI({ model: "gpt-4o" }),
+ *     tools: covenantTools,
+ *     prompt: myPrompt,
+ *   });
+ *   const executor = new AgentExecutor({ agent, tools: covenantTools });
+ *   await executor.invoke({
+ *     input: "Post a $5 job for a 500-word product description, " +
+ *            "then once the work lands, sell my claim at 3% to lock in cash flow.",
+ *   });
+ */
+export const covenantTools = [
+  covenantPostJobTool,
+  covenantSellClaimTool,
+  covenantBuyClaimTool,
+];

--- a/sdk/examples/mcp-integration.ts
+++ b/sdk/examples/mcp-integration.ts
@@ -1,0 +1,159 @@
+/**
+ * Covenant × MCP — agent-payable tool server over Model Context Protocol.
+ *
+ * This example exposes two MCP tools:
+ *   - `post_job`   : clients (typically LLMs or agent frameworks) create
+ *                    a paying Covenant job with USDC locked in escrow.
+ *   - `finalize`   : once work has been delivered and the challenge
+ *                    period has elapsed, the crank releases the escrow
+ *                    (or routes it to the buyer if the claim was sold
+ *                    on Covenant Credit).
+ *
+ * Pair this with an MCP-speaking LLM agent to demo the end-to-end
+ * "agent earns money for a paid tool call" flow.
+ *
+ * NOTE: This is illustrative, not production code. It omits the MCP
+ * server boilerplate (transport, stdio wiring, etc.) and focuses on
+ * the Covenant surface.
+ */
+
+import { AnchorProvider, Wallet } from "@coral-xyz/anchor";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import {
+  CovenantClient,
+  DEVNET_USDC_MINT,
+  hashSpec,
+  type JobSpec,
+} from "@wienerlabs/covenant-sdk";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import idl from "../dist/covenant-idl.json" with { type: "json" };
+
+// --- MCP tool handlers ---------------------------------------------------
+
+export async function mcpPostJobTool(args: {
+  title: string;
+  amount: number; // USDC (human)
+  minWords: number;
+  deadlineHoursFromNow: number;
+}): Promise<{ jobPda: string; txSig: string; specHash: string }> {
+  const conn = new Connection(
+    process.env.HELIUS_RPC_URL ?? "https://api.devnet.solana.com",
+    "confirmed",
+  );
+  const poster = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(process.env.POSTER_KEYPAIR!)),
+  );
+  const provider = new AnchorProvider(conn, new Wallet(poster), {
+    commitment: "confirmed",
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const covenant = CovenantClient.fromProvider(provider, idl as any);
+
+  const spec: JobSpec = {
+    type: "mcp.prompt.v1",
+    category: "text_writing",
+    language: "English",
+    minWords: args.minWords,
+    deadlineUnix:
+      Math.floor(Date.now() / 1000) + args.deadlineHoursFromNow * 3600,
+    metadata: { title: args.title },
+  };
+  const specHashHex = hashSpec(spec);
+  const specHashBytes = Uint8Array.from(Buffer.from(specHashHex, "hex"));
+
+  // Derive poster's USDC ATA (assumed pre-funded).
+  const { getAssociatedTokenAddress } = await import("@solana/spl-token");
+  const posterAta = await getAssociatedTokenAddress(
+    DEVNET_USDC_MINT,
+    poster.publicKey,
+  );
+
+  const { jobPda, txSig, escrowTokenAccount } = await covenant.createJob({
+    poster,
+    spec,
+    amount: new BN(Math.round(args.amount * 1_000_000)), // USDC has 6 decimals
+    posterTokenAccount: posterAta,
+    tokenMint: DEVNET_USDC_MINT,
+  });
+
+  // In a real MCP server, stash escrowTokenAccount somewhere durable —
+  // you'll need it for finalize.
+  console.log("[mcp] created job", {
+    jobPda: jobPda.toBase58(),
+    escrow: escrowTokenAccount.toBase58(),
+  });
+
+  return {
+    jobPda: jobPda.toBase58(),
+    txSig,
+    specHash: specHashHex,
+  };
+}
+
+export async function mcpFinalizeTool(args: {
+  jobPda: string;
+  escrowTokenAccount: string;
+  takerTokenAccount: string;
+}): Promise<{ txSig: string; routedToBuyer: boolean }> {
+  const conn = new Connection(
+    process.env.HELIUS_RPC_URL ?? "https://api.devnet.solana.com",
+    "confirmed",
+  );
+  const crank = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(process.env.CRANK_KEYPAIR!)),
+  );
+  const provider = new AnchorProvider(conn, new Wallet(crank), {
+    commitment: "confirmed",
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const covenant = CovenantClient.fromProvider(provider, idl as any);
+
+  const jobPda = new PublicKey(args.jobPda);
+
+  // If the seller sold their claim via Covenant Credit, route payment
+  // to the buyer; otherwise to the taker. The SDK's fetchClaim handles
+  // the lookup.
+  const claim = await covenant.fetchClaim(jobPda);
+  const routedToBuyer =
+    claim !== null && claim.status === "Bought" && !claim.buyer.equals(PublicKey.default);
+
+  const { txSig } = await covenant.finalizePayment({
+    crank,
+    jobPda,
+    escrowTokenAccount: new PublicKey(args.escrowTokenAccount),
+    takerTokenAccount: new PublicKey(args.takerTokenAccount),
+  });
+
+  return { txSig, routedToBuyer };
+}
+
+// --- Minimal MCP server stub --------------------------------------------
+//
+// Replace with your MCP transport of choice. See the MCP spec at
+// https://modelcontextprotocol.io for the wire protocol.
+/*
+import { Server } from "@modelcontextprotocol/sdk/server";
+const server = new Server({ name: "covenant-payments", version: "0.1.0" });
+
+server.setTool("post_job", {
+  schema: {
+    type: "object",
+    properties: {
+      title: { type: "string" },
+      amount: { type: "number" },
+      minWords: { type: "number" },
+      deadlineHoursFromNow: { type: "number" },
+    },
+    required: ["title", "amount", "minWords", "deadlineHoursFromNow"],
+  },
+  handler: mcpPostJobTool,
+});
+
+server.setTool("finalize", {
+  schema: { ... },
+  handler: mcpFinalizeTool,
+});
+
+await server.connect(/* your transport here */);
+*/

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -16,7 +16,13 @@ import {
   DEFAULT_BOND_BPS,
   DEFAULT_MIN_BOND_ABSOLUTE,
 } from "./constants";
-import { deriveConfigPda, deriveJobPda, deriveReputationPda, deriveBondPda } from "./pda";
+import {
+  deriveConfigPda,
+  deriveJobPda,
+  deriveReputationPda,
+  deriveBondPda,
+  deriveClaimPda,
+} from "./pda";
 import { hashSpec } from "./spec";
 import { validateDeliveryUri } from "./delivery";
 import type {
@@ -27,6 +33,8 @@ import type {
   ProtocolConfigAccount,
   DisputeInfo,
   DisputeResolutionKind,
+  ClaimListingAccount,
+  ClaimStatus,
 } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -86,6 +94,14 @@ function decodeDispute(raw: RawAccount): DisputeInfo {
 function decodeDeliveryUri(bytes: Uint8Array | number[], len: number): string {
   const buf = Uint8Array.from(bytes).slice(0, len);
   return Buffer.from(buf).toString("utf8");
+}
+
+function parseClaimStatus(raw: RawAccount): ClaimStatus {
+  if ("listed" in raw) return "Listed";
+  if ("bought" in raw) return "Bought";
+  if ("cancelled" in raw) return "Cancelled";
+  if ("settled" in raw) return "Settled";
+  throw new Error(`Unknown claim status: ${JSON.stringify(raw)}`);
 }
 
 /**
@@ -418,6 +434,120 @@ export class CovenantClient {
       .rpc();
 
     return { txSig };
+  }
+
+  // ---- Covenant Credit ----
+
+  /**
+   * Derive the ClaimListing PDA for a job.
+   * seeds = [b"claim", job_escrow]
+   */
+  claimPda(jobPda: PublicKey): PublicKey {
+    return deriveClaimPda(jobPda, this.program.programId)[0];
+  }
+
+  /**
+   * List a pending payment claim at a discounted price. Only the taker
+   * of a Delivered, non-disputed job may list. Exactly one listing per
+   * job (PDA collision otherwise).
+   */
+  async listClaim(params: {
+    seller: Keypair;
+    jobPda: PublicKey;
+    price: BN;
+  }): Promise<{ txSig: TransactionSignature; claimPda: PublicKey }> {
+    const job = await this.fetchJob(params.jobPda);
+    const claimPda = this.claimPda(params.jobPda);
+
+    const txSig = await (this.program.methods as any)
+      .listClaim(params.price)
+      .accounts({
+        seller: params.seller.publicKey,
+        jobEscrow: params.jobPda,
+        poster: job.poster,
+        claimListing: claimPda,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([params.seller])
+      .rpc();
+
+    return { txSig, claimPda };
+  }
+
+  /**
+   * Buy a listed claim. The buyer pays `listing.price` USDC to the
+   * seller atomically and becomes the beneficiary of subsequent
+   * `finalize_payment` or `resolve_dispute` FavorTaker/Split proceeds.
+   */
+  async buyClaim(params: {
+    buyer: Keypair;
+    jobPda: PublicKey;
+    buyerTokenAccount: PublicKey;
+    sellerTokenAccount: PublicKey;
+  }): Promise<{ txSig: TransactionSignature }> {
+    const job = await this.fetchJob(params.jobPda);
+    const claimPda = this.claimPda(params.jobPda);
+
+    const txSig = await (this.program.methods as any)
+      .buyClaim()
+      .accounts({
+        buyer: params.buyer.publicKey,
+        jobEscrow: params.jobPda,
+        poster: job.poster,
+        claimListing: claimPda,
+        buyerTokenAccount: params.buyerTokenAccount,
+        sellerTokenAccount: params.sellerTokenAccount,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([params.buyer])
+      .rpc();
+
+    return { txSig };
+  }
+
+  /**
+   * Cancel an unsold claim listing. Refunds rent to the seller.
+   */
+  async cancelClaim(params: {
+    seller: Keypair;
+    jobPda: PublicKey;
+  }): Promise<{ txSig: TransactionSignature }> {
+    const claimPda = this.claimPda(params.jobPda);
+    const txSig = await (this.program.methods as any)
+      .cancelClaim()
+      .accounts({
+        seller: params.seller.publicKey,
+        claimListing: claimPda,
+      })
+      .signers([params.seller])
+      .rpc();
+    return { txSig };
+  }
+
+  /**
+   * Fetch + decode a ClaimListing account. Returns null if the PDA is
+   * uninitialized (no listing, or already cancelled + closed).
+   */
+  async fetchClaim(jobPda: PublicKey): Promise<ClaimListingAccount | null> {
+    const claimPda = this.claimPda(jobPda);
+    try {
+      const raw = (await (this.program.account as any)["claimListing"].fetch(
+        claimPda,
+      )) as RawAccount;
+      return {
+        job: raw.job,
+        seller: raw.seller,
+        buyer: raw.buyer,
+        price: new BN(raw.price),
+        faceValue: new BN(raw.faceValue),
+        listedAt: new BN(raw.listedAt),
+        boughtAt: new BN(raw.boughtAt),
+        status: parseClaimStatus(raw.status as RawAccount),
+        bump: Number(raw.bump),
+      };
+    } catch {
+      return null;
+    }
   }
 
   // ---- Account fetchers ----

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -42,4 +42,5 @@ export const PDA_SEEDS = {
   job: Buffer.from("job"),
   reputation: Buffer.from("reputation"),
   bond: Buffer.from("bond"),
+  claim: Buffer.from("claim"),
 } as const;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -22,6 +22,7 @@ export {
   deriveJobPda,
   deriveReputationPda,
   deriveBondPda,
+  deriveClaimPda,
 } from "./pda";
 export { parseLogLine, parseLogs } from "./events";
 export type { CovenantEvent } from "./events";
@@ -47,4 +48,6 @@ export type {
   DisputeInfo,
   DisputeResolutionKind,
   DeliveryCommitment,
+  ClaimListingAccount,
+  ClaimStatus,
 } from "./types";

--- a/sdk/src/pda.ts
+++ b/sdk/src/pda.ts
@@ -41,3 +41,14 @@ export function deriveBondPda(
     programId,
   );
 }
+
+/** Derive the ClaimListing PDA for a job (Covenant Credit). */
+export function deriveClaimPda(
+  job: PublicKey,
+  programId: PublicKey = COVENANT_PROGRAM_ID,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [PDA_SEEDS.claim, job.toBuffer()],
+    programId,
+  );
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -89,3 +89,29 @@ export interface DeliveryCommitment {
   /** Resolvable URI where the content lives. */
   deliveryUri: string;
 }
+
+// ---- Covenant Credit types ----
+
+/** Status of a ClaimListing on chain. */
+export type ClaimStatus = "Listed" | "Bought" | "Cancelled" | "Settled";
+
+/**
+ * On-chain ClaimListing account. Represents a taker's pending payment
+ * claim offered for sale to lenders.
+ */
+export interface ClaimListingAccount {
+  job: PublicKey;
+  seller: PublicKey;
+  /** `PublicKey.default` before purchase. */
+  buyer: PublicKey;
+  /** Price the buyer pays the seller (atomic token units, u64). */
+  price: BN;
+  /** Full escrow amount the buyer receives on finalize (atomic units). */
+  faceValue: BN;
+  /** Unix seconds when listed. */
+  listedAt: BN;
+  /** Unix seconds when bought. 0 until bought. */
+  boughtAt: BN;
+  status: ClaimStatus;
+  bump: number;
+}


### PR DESCRIPTION
## What & why

PR #37 (Phase 2 marketplace) and PR #38 (Phase 3 finalize + visualizer + SDK) were merged into their stacked parent branches but **never reached \`main\`**. Combined with PR #35 (on-chain settlement) which did land, the current main is missing:

- Marketplace UI (\`/credit\` + Sell button + API routes)
- Claim-aware finalize wiring
- Live visualizer dashboard (\`/credit/dashboard\`)
- SDK BNPL methods + integration examples

This PR brings all of it onto main as a **single integrated commit chain** (per user request — no more stacked PRs). Also includes the Vercel build type fix that #39 was carrying separately.

## What's in it

### Cherry-picked from the orphaned branches
- \`53d1e4f\` — Phase 2 (credit-server.ts, anchor-browser.ts credit helpers, /api/claims/*, /credit page, SellClaimButton, Prisma ClaimListing model, NavBar)
- \`6efe172\` — Phase 3 (finalizeWithClaim helper, /credit/dashboard visualizer, /api/claims/stats, SDK BNPL methods, MCP + LangChain examples)

### Resolved conflicts
Three files had merge conflicts against #35's on-chain settlement refactor:
- \`app/prisma/schema.prisma\` — trivial escrowAta comment diff
- \`app/app/api/cron/finalize/route.ts\` — merged to use **only** \`finalizeWithClaim\` (dropped the dead \`releaseFundsToTaker\` fallback since #35 made it a throwing stub)
- \`app/app/api/jobs/[id]/finalize/route.ts\` — merged three paths cleanly: (A) synthetic agent, (B) client-cranked with \`verifyTxInvokedCovenant\`, (C) server-cranked with \`finalizeWithClaim\`. Custodial release path removed entirely.

### Vercel fix (\`005e064\`)
\`lib/program-server.ts\` had 4 bot helpers using narrow \`{ method: (...) => unknown }\` casts that broke TypeScript chaining. Switched to \`(program.methods as any)\` pattern matching the already-working \`anchor-browser.ts\`. Same content as PR #39 — once this merges, #39 can be closed.

## What still works unchanged

- Battle Arena — untouched per user requirement
- All audit fixes from previous PRs (admin auth, H-01, H-03, C-04, etc.)
- On-chain settlement refactor from #35

## Post-merge checklist

- [ ] \`cd app && npx prisma generate && npx prisma db push\` (new \`Job.escrowAta\` and \`ClaimListing\` model)
- [ ] \`cd app && yarn build\` — confirm Vercel-equivalent typecheck passes
- [ ] (optional) \`anchor build && anchor deploy\` if not already deployed
- [ ] Close PRs #37, #38, #39 as superseded
- [ ] Delete stale branches: \`feat/covenant-credit-onchain\`, \`feat/covenant-credit-phase2\`, \`feat/covenant-credit-phase3\`, \`fix/program-server-types\`

## Verification (cannot run here)

- Vercel should build green after this merges
- \`/credit\` page renders, marketplace polling works
- \`/credit/dashboard\` sparklines render
- \`sdk/\` examples typecheck
- The full demo loop: deliver → sell → buy → finalize routes to buyer

## Diff size

~30 files touched (mostly new files from Phase 2+3). ~3400 lines added, ~70 removed.