### PR TITLE
feat(x402): real on-chain payments — C-030/031/032/033/034/035/036/037/039 -> closes #67 #68 #69 #70 #71 #72 #73 #74 #78

### DIFF
--- a/app/app/api/hosted-agents/[id]/chat/route.ts
+++ b/app/app/api/hosted-agents/[id]/chat/route.ts
@@ -8,6 +8,12 @@ import {
   verifyPayment,
   encodePaymentRequiredHeader,
 } from "@/lib/x402-server";
+import {
+  hashPaymentRequest,
+  claimPayment,
+  finalizePayment,
+  releasePayment,
+} from "@/lib/x402-payments";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -79,6 +85,9 @@ export async function POST(
 
   const paymentSig = req.headers.get("payment-signature");
   let paymentTxHash = "";
+  // True once we hold a fresh (first-use) payment that this request must
+  // finalize on success or release on failure (C-036).
+  let paymentClaimed = false;
 
   if (agent.pricePerPrompt > 0) {
     const paymentRequired = buildPaymentRequired(
@@ -100,16 +109,17 @@ export async function POST(
       });
     }
 
-    // Payment signature provided — verify it
-    const { valid, txHash } = await verifyPayment(paymentSig, paymentRequired);
+    // Payment signature provided — verify it on chain (amount, mint,
+    // recipient, confirmed). No bypass tokens (C-030/C-031/C-033/C-034).
+    const verification = await verifyPayment(paymentSig, paymentRequired);
 
-    if (!valid) {
-      // Payment verification failed — return 402 again
+    if (!verification.valid) {
+      // Payment verification failed — return 402 again with the reason.
       const encodedHeader = encodePaymentRequiredHeader(paymentRequired);
       return new Response(
         JSON.stringify({
           ...paymentRequired,
-          error: "Payment verification failed. Please try again.",
+          error: `Payment verification failed: ${verification.reason ?? "invalid payment"}.`,
         }),
         {
           status: 402,
@@ -121,8 +131,62 @@ export async function POST(
       );
     }
 
-    paymentTxHash = txHash;
+    paymentTxHash = verification.txHash;
+
+    // C-032 / C-036: a verified payment is spent exactly once. An
+    // idempotent retry of the same prompt replays the cached response;
+    // the same payment for a different prompt is rejected as consumed.
+    const claim = await claimPayment({
+      txSignature: verification.txHash,
+      agentId: id,
+      payer: verification.payer,
+      amountAtomic: verification.amountAtomic ?? "0",
+      requestHash: hashPaymentRequest(id, message),
+    });
+
+    if (claim.kind === "replay") {
+      return new NextResponse(claim.body, {
+        status: claim.code,
+        headers: {
+          "Content-Type": "application/json",
+          "x-idempotent-replay": "true",
+        },
+      });
+    }
+    if (claim.kind === "consumed") {
+      return NextResponse.json(
+        {
+          error:
+            "This payment has already been used for a different prompt. Each payment is valid for one message.",
+        },
+        { status: 409 },
+      );
+    }
+    if (claim.kind === "pending") {
+      return NextResponse.json(
+        { error: "This payment is still being processed. Please retry in a moment." },
+        { status: 409 },
+      );
+    }
+
+    // claim.kind === "fresh" — we own this payment for this request.
+    paymentClaimed = true;
   }
+
+  /**
+   * Serve a paid response and finalize the payment so an idempotent
+   * retry replays it byte-for-byte (C-036). On the free path this is a
+   * plain JSON response.
+   */
+  const servePaid = async (
+    payload: Record<string, unknown>,
+  ): Promise<NextResponse> => {
+    const res = NextResponse.json(payload);
+    if (paymentClaimed) {
+      await finalizePayment(paymentTxHash, JSON.stringify(payload), 200);
+    }
+    return res;
+  };
 
   /* ---------------------------------------------------------------- */
   /*  Design agent fast path                                           */
@@ -202,7 +266,7 @@ export async function POST(
       }
     }
 
-    return NextResponse.json({
+    return servePaid({
       response,
       imageUrl,
       mode: "image",
@@ -317,7 +381,7 @@ export async function POST(
       }
     }
 
-    return NextResponse.json({
+    return servePaid({
       response,
       wordCount: response.split(/\s+/).length,
       agentId: id,
@@ -326,6 +390,9 @@ export async function POST(
     });
   } catch (err) {
     console.error("[hosted-agents/chat] AI call error:", err);
+    // The payer was charged on chain but we produced nothing — release
+    // the payment so they can retry the same payment (C-036, one charge).
+    if (paymentClaimed) await releasePayment(paymentTxHash);
     return NextResponse.json(
       { error: "Failed to generate response" },
       { status: 500 }

--- a/app/app/api/hosted-agents/[id]/chat/route.ts
+++ b/app/app/api/hosted-agents/[id]/chat/route.ts
@@ -88,6 +88,9 @@ export async function POST(
   // True once we hold a fresh (first-use) payment that this request must
   // finalize on success or release on failure (C-036).
   let paymentClaimed = false;
+  // Verified payment facts captured for revenue reconciliation (C-037).
+  let paidAmountUsdc = 0;
+  let paidPayer = "";
 
   if (agent.pricePerPrompt > 0) {
     const paymentRequired = buildPaymentRequired(
@@ -171,6 +174,8 @@ export async function POST(
 
     // claim.kind === "fresh" — we own this payment for this request.
     paymentClaimed = true;
+    paidAmountUsdc = Number(verification.amountAtomic ?? "0") / 1_000_000;
+    paidPayer = verification.payer;
   }
 
   /**
@@ -184,6 +189,26 @@ export async function POST(
     const res = NextResponse.json(payload);
     if (paymentClaimed) {
       await finalizePayment(paymentTxHash, JSON.stringify(payload), 200);
+      // C-037: one revenue row per verified payment, at the amount actually
+      // paid on chain, so the revenue total reconciles to verified payments.
+      try {
+        await prisma.$transaction([
+          prisma.agentRevenue.create({
+            data: {
+              agentId: id,
+              userWallet: walletAddress || paidPayer || "anonymous",
+              amount: paidAmountUsdc,
+              paymentTx: paymentTxHash,
+            },
+          }),
+          prisma.hostedAgent.update({
+            where: { id },
+            data: { totalRevenue: { increment: paidAmountUsdc } },
+          }),
+        ]);
+      } catch {
+        /* best effort — reconcileAgentRevenue surfaces any drift */
+      }
     }
     return res;
   };
@@ -245,26 +270,6 @@ export async function POST(
     await prisma.chatMessage.create({
       data: { agentId: id, userWallet, role: "agent", content: response },
     });
-
-    if (walletAddress && agent.pricePerPrompt > 0) {
-      try {
-        await prisma.$transaction([
-          prisma.agentRevenue.create({
-            data: {
-              agentId: id,
-              userWallet: walletAddress,
-              amount: agent.pricePerPrompt,
-            },
-          }),
-          prisma.hostedAgent.update({
-            where: { id },
-            data: { totalRevenue: { increment: agent.pricePerPrompt } },
-          }),
-        ]);
-      } catch {
-        /* best effort */
-      }
-    }
 
     return servePaid({
       response,
@@ -359,27 +364,6 @@ export async function POST(
     await prisma.chatMessage.create({
       data: { agentId: id, userWallet, role: "agent", content: response },
     });
-
-    // Record revenue (with real tx hash from x402 payment)
-    if (walletAddress && agent.pricePerPrompt > 0) {
-      try {
-        await prisma.$transaction([
-          prisma.agentRevenue.create({
-            data: {
-              agentId: id,
-              userWallet: walletAddress,
-              amount: agent.pricePerPrompt,
-            },
-          }),
-          prisma.hostedAgent.update({
-            where: { id },
-            data: { totalRevenue: { increment: agent.pricePerPrompt } },
-          }),
-        ]);
-      } catch {
-        /* best effort */
-      }
-    }
 
     return servePaid({
       response,

--- a/app/lib/prisma.ts
+++ b/app/lib/prisma.ts
@@ -153,6 +153,10 @@ const MIGRATION_SQL = [
   )`,
   `CREATE INDEX IF NOT EXISTS "X402Payment_agentId_idx" ON "X402Payment"("agentId")`,
   `CREATE INDEX IF NOT EXISTS "X402Payment_payer_idx" ON "X402Payment"("payer")`,
+
+  // AgentRevenue.paymentTx — ties each paid row to a verified payment (C-037).
+  `ALTER TABLE "AgentRevenue" ADD COLUMN IF NOT EXISTS "paymentTx" TEXT`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS "AgentRevenue_paymentTx_key" ON "AgentRevenue"("paymentTx")`,
 ];
 
 export async function ensureSchema(): Promise<void> {

--- a/app/lib/prisma.ts
+++ b/app/lib/prisma.ts
@@ -139,6 +139,20 @@ const MIGRATION_SQL = [
 
   // Job.pda unique index (partial — only where value is present)
   `CREATE UNIQUE INDEX IF NOT EXISTS "Job_pda_key" ON "Job"("pda") WHERE "pda" IS NOT NULL`,
+
+  // X402Payment — consumed x402 payment signatures (replay + idempotency).
+  `CREATE TABLE IF NOT EXISTS "X402Payment" (
+    "txSignature" TEXT NOT NULL PRIMARY KEY,
+    "agentId" TEXT NOT NULL,
+    "payer" TEXT NOT NULL,
+    "amountAtomic" TEXT NOT NULL,
+    "requestHash" TEXT NOT NULL,
+    "responseBody" TEXT,
+    "responseCode" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )`,
+  `CREATE INDEX IF NOT EXISTS "X402Payment_agentId_idx" ON "X402Payment"("agentId")`,
+  `CREATE INDEX IF NOT EXISTS "X402Payment_payer_idx" ON "X402Payment"("payer")`,
 ];
 
 export async function ensureSchema(): Promise<void> {

--- a/app/lib/x402-payments.ts
+++ b/app/lib/x402-payments.ts
@@ -172,3 +172,69 @@ export async function releasePayment(txSignature: string): Promise<void> {
     /* already gone or never reserved — fine */
   }
 }
+
+/* ------------------------------------------------------------------ */
+/*  C-037 — revenue reconciliation against verified payments           */
+/* ------------------------------------------------------------------ */
+
+export interface RevenueReconciliation {
+  /** Sum of recorded AgentRevenue, in atomic units. */
+  revenueAtomic: string;
+  /** Sum of verified on-chain payments, in atomic units. */
+  verifiedAtomic: string;
+  /** revenue − verified, in atomic units (0 when in sync). */
+  driftAtomic: string;
+  reconciled: boolean;
+}
+
+/**
+ * Compare recorded revenue against verified on-chain payments, in atomic
+ * units to avoid float drift (C-037). Pure — unit-tested in isolation.
+ */
+export function reconcileRevenue(
+  revenueAmounts: number[],
+  verifiedAtomic: string[],
+  decimals = 6,
+): RevenueReconciliation {
+  const factor = 10 ** decimals;
+  const rev = revenueAmounts.reduce(
+    (sum, a) => sum + BigInt(Math.round(a * factor)),
+    0n,
+  );
+  const ver = verifiedAtomic.reduce((sum, a) => sum + BigInt(a || "0"), 0n);
+  return {
+    revenueAtomic: rev.toString(),
+    verifiedAtomic: ver.toString(),
+    driftAtomic: (rev - ver).toString(),
+    reconciled: rev === ver,
+  };
+}
+
+/**
+ * Reconcile an agent's recorded revenue against its served verified
+ * payments (C-037). The revenue dashboard total (sum of AgentRevenue) must
+ * equal the sum of verified on-chain payments; this surfaces any drift.
+ */
+export async function reconcileAgentRevenue(
+  agentId: string,
+): Promise<RevenueReconciliation> {
+  const { prisma, retryable } = await db();
+  const [revenue, payments] = await Promise.all([
+    retryable(() =>
+      prisma.agentRevenue.findMany({
+        where: { agentId, paymentTx: { not: null } },
+        select: { amount: true },
+      }),
+    ),
+    retryable(() =>
+      prisma.x402Payment.findMany({
+        where: { agentId, responseBody: { not: null } },
+        select: { amountAtomic: true },
+      }),
+    ),
+  ]);
+  return reconcileRevenue(
+    revenue.map((r) => r.amount),
+    payments.map((p) => p.amountAtomic),
+  );
+}

--- a/app/lib/x402-payments.ts
+++ b/app/lib/x402-payments.ts
@@ -1,0 +1,174 @@
+/**
+ * x402 consumed-payment store — durable replay protection (C-032) and
+ * idempotent payment-gated serving (C-036).
+ *
+ * A verified payment signature can be spent exactly once. The signature
+ * is the natural idempotency key: the first request that presents a
+ * verified payment reserves it; a later request presenting the SAME
+ * signature either
+ *   - replays the SAME request (same prompt) ⇒ gets the cached response
+ *     byte-for-byte, with no second charge (C-036), or
+ *   - presents a DIFFERENT request (a second prompt) ⇒ is rejected
+ *     because the payment is already consumed (C-032).
+ *
+ * Persistence is the `X402Payment` table so the guarantee survives
+ * serverless cold starts — an in-memory map would let an attacker replay
+ * a consumed signature after an instance recycle.
+ */
+
+import crypto from "node:crypto";
+
+/**
+ * Lazily load the Prisma client. Kept out of module scope so importing
+ * the pure helpers (`hashPaymentRequest`, `decidePaymentClaim`) does not
+ * pull in the DB client or fire its cold-start schema sync.
+ */
+async function db() {
+  return import("./prisma");
+}
+
+/**
+ * Stable fingerprint of the served request, used to tell an idempotent
+ * retry (same prompt) apart from a replay attack (same payment, new
+ * prompt). Bound to the agent + the exact message that was paid for.
+ */
+export function hashPaymentRequest(agentId: string, message: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${agentId}\n${message}`)
+    .digest("hex");
+}
+
+export interface ConsumedPaymentRecord {
+  requestHash: string;
+  responseBody: string | null;
+  responseCode: number | null;
+}
+
+export type PaymentClaimDecision =
+  | { kind: "fresh" }
+  | { kind: "replay"; body: string; code: number }
+  | { kind: "consumed" }
+  | { kind: "pending" };
+
+/**
+ * Pure decision: given the stored record for a payment signature (or
+ * null) and the incoming request fingerprint, decide how to handle the
+ * request. No IO — unit-tested in isolation.
+ *
+ *   null                              ⇒ fresh    (first use, proceed)
+ *   same request + finalized response ⇒ replay   (serve cached, C-036)
+ *   same request + still in flight    ⇒ pending  (concurrent duplicate)
+ *   different request                 ⇒ consumed (replay attack, C-032)
+ */
+export function decidePaymentClaim(
+  existing: ConsumedPaymentRecord | null,
+  incomingRequestHash: string,
+): PaymentClaimDecision {
+  if (!existing) return { kind: "fresh" };
+  if (existing.requestHash !== incomingRequestHash) return { kind: "consumed" };
+  if (existing.responseBody != null && existing.responseCode != null) {
+    return { kind: "replay", body: existing.responseBody, code: existing.responseCode };
+  }
+  return { kind: "pending" };
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "P2002"
+  );
+}
+
+export interface ClaimPaymentInput {
+  txSignature: string;
+  agentId: string;
+  payer: string;
+  amountAtomic: string;
+  requestHash: string;
+}
+
+/**
+ * Claim a verified payment for serving. On first use this atomically
+ * reserves the signature (so concurrent duplicates can't both proceed),
+ * and returns the decision for this request. The `txSignature` primary
+ * key makes the reserve race-safe: a concurrent insert loses with a
+ * unique-constraint error and falls back to reading the winner's row.
+ */
+export async function claimPayment(
+  input: ClaimPaymentInput,
+): Promise<PaymentClaimDecision> {
+  const { prisma, retryable } = await db();
+
+  const existing = await retryable(() =>
+    prisma.x402Payment.findUnique({ where: { txSignature: input.txSignature } }),
+  );
+  if (existing) {
+    return decidePaymentClaim(existing, input.requestHash);
+  }
+
+  try {
+    await retryable(() =>
+      prisma.x402Payment.create({
+        data: {
+          txSignature: input.txSignature,
+          agentId: input.agentId,
+          payer: input.payer,
+          amountAtomic: input.amountAtomic,
+          requestHash: input.requestHash,
+        },
+      }),
+    );
+    return { kind: "fresh" };
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      const raced = await retryable(() =>
+        prisma.x402Payment.findUnique({
+          where: { txSignature: input.txSignature },
+        }),
+      );
+      if (raced) return decidePaymentClaim(raced, input.requestHash);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Record the served response against a reserved payment so an
+ * idempotent retry can replay it (C-036). Best-effort: if this fails the
+ * row stays reserved and a later retry is treated as `pending`.
+ */
+export async function finalizePayment(
+  txSignature: string,
+  body: string,
+  code: number,
+): Promise<void> {
+  try {
+    const { prisma, retryable } = await db();
+    await retryable(() =>
+      prisma.x402Payment.update({
+        where: { txSignature },
+        data: { responseBody: body, responseCode: code },
+      }),
+    );
+  } catch (err) {
+    console.error("[x402] finalizePayment failed:", err);
+  }
+}
+
+/**
+ * Release a reserved (not-yet-finalized) payment so the payer can retry
+ * the same payment after a server-side failure — they paid on chain, so
+ * an error must not burn their payment.
+ */
+export async function releasePayment(txSignature: string): Promise<void> {
+  try {
+    const { prisma, retryable } = await db();
+    await retryable(() =>
+      prisma.x402Payment.delete({ where: { txSignature } }),
+    );
+  } catch {
+    /* already gone or never reserved — fine */
+  }
+}

--- a/app/lib/x402-server.ts
+++ b/app/lib/x402-server.ts
@@ -358,12 +358,36 @@ export interface VerifyPaymentResult {
   reason?: string;
 }
 
+/**
+ * Commitment required before a payment grants access (C-034). `confirmed`
+ * (not `processed`) means a dropped or forked transaction is not visible
+ * here yet and therefore cannot grant access.
+ */
+export const PAYMENT_COMMITMENT = "confirmed" as const;
+
+/** Result shape from an x402 facilitator's verify endpoint (C-035). */
+export interface FacilitatorVerifyResult {
+  isValid: boolean;
+  payer?: string;
+  amountAtomic?: string;
+  invalidReason?: string;
+}
+
 export interface VerifyPaymentDeps {
   /**
    * Fetch a transaction by signature at `confirmed` commitment. Injected
    * in tests; defaults to a failover RPC read.
    */
   fetchTransaction?: (sig: string) => Promise<TxMetaLike | null>;
+  /**
+   * Optional x402 facilitator verifier (C-035). When provided — or when
+   * `X402_FACILITATOR_URL` is set — payment validity is delegated to the
+   * facilitator instead of direct RPC parsing. Injected in tests.
+   */
+  verifyViaFacilitator?: (
+    parsed: ParsedPaymentSignature,
+    paymentRequired: PaymentRequired,
+  ) => Promise<FacilitatorVerifyResult>;
 }
 
 /**
@@ -372,9 +396,9 @@ export interface VerifyPaymentDeps {
  * is treated as not-found and does not grant access.
  */
 async function defaultFetchTransaction(sig: string): Promise<TxMetaLike | null> {
-  const connection = createFailoverConnection("confirmed");
+  const connection = createFailoverConnection(PAYMENT_COMMITMENT);
   const tx = await connection.getTransaction(sig, {
-    commitment: "confirmed",
+    commitment: PAYMENT_COMMITMENT,
     maxSupportedTransactionVersion: 0,
   });
   if (!tx) return null;
@@ -388,6 +412,47 @@ async function defaultFetchTransaction(sig: string): Promise<TxMetaLike | null> 
         | TokenBalanceLike[]
         | null,
     },
+  };
+}
+
+/**
+ * Build a facilitator verifier from `X402_FACILITATOR_URL` if set (C-035).
+ * Posts the payment to the facilitator's `/verify` endpoint and maps its
+ * verdict. Returns undefined when no facilitator is configured, in which
+ * case verifyPayment falls back to direct RPC parsing.
+ */
+function facilitatorFromEnv():
+  | VerifyPaymentDeps["verifyViaFacilitator"]
+  | undefined {
+  const base = process.env.X402_FACILITATOR_URL;
+  if (!base) return undefined;
+  const url = `${base.replace(/\/$/, "")}/verify`;
+  return async (parsed, paymentRequired): Promise<FacilitatorVerifyResult> => {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        x402Version: paymentRequired.x402Version,
+        paymentPayload: {
+          transaction: parsed.txSignature,
+          scheme: parsed.scheme,
+          network: parsed.network,
+        },
+        paymentRequirements: paymentRequired.accepts[0],
+      }),
+    });
+    if (!res.ok) {
+      return { isValid: false, invalidReason: `facilitator returned ${res.status}` };
+    }
+    const data = (await res.json()) as Record<string, unknown>;
+    return {
+      isValid: data.isValid === true,
+      payer: typeof data.payer === "string" ? data.payer : undefined,
+      amountAtomic:
+        typeof data.amountAtomic === "string" ? data.amountAtomic : undefined,
+      invalidReason:
+        typeof data.invalidReason === "string" ? data.invalidReason : undefined,
+    };
   };
 }
 
@@ -430,13 +495,49 @@ export async function verifyPayment(
     };
   }
 
-  // C-030: a real on-chain signature is mandatory — no bypass tokens.
+  // C-030: a real on-chain signature is mandatory — no bypass tokens. This
+  // also keeps the signature usable as the replay/idempotency key even on
+  // the facilitator path below.
   if (!isPlausibleTxSignature(parsed.txSignature)) {
     return {
       valid: false,
       txHash: parsed.txSignature,
       payer: "",
       reason: "not a valid Solana transaction signature",
+    };
+  }
+
+  // C-035: optional facilitator path — delegate validity to the facilitator
+  // instead of parsing the transfer ourselves. Off unless configured.
+  const facilitator = deps.verifyViaFacilitator ?? facilitatorFromEnv();
+  if (facilitator) {
+    let fres: FacilitatorVerifyResult;
+    try {
+      fres = await facilitator(parsed, paymentRequired);
+    } catch (err) {
+      console.error("[x402] facilitator verification failed:", err);
+      return {
+        valid: false,
+        txHash: parsed.txSignature,
+        payer: "",
+        reason: "could not reach the payment facilitator",
+      };
+    }
+    if (!fres.isValid) {
+      return {
+        valid: false,
+        txHash: parsed.txSignature,
+        payer: "",
+        reason: fres.invalidReason ?? "facilitator rejected the payment",
+      };
+    }
+    return {
+      valid: true,
+      txHash: parsed.txSignature,
+      payer: fres.payer ?? "",
+      // The facilitator validated the payment meets the requirement; fall
+      // back to the quoted amount when it doesn't echo the exact paid value.
+      amountAtomic: fres.amountAtomic ?? accept.amount,
     };
   }
 

--- a/app/lib/x402-server.ts
+++ b/app/lib/x402-server.ts
@@ -1,14 +1,36 @@
 /**
- * x402 HTTP 402 Payment Protocol — Covenant Implementation.
+ * x402 HTTP 402 Payment Protocol — Covenant implementation.
  *
- * Devnet-only: self-verification via Solana RPC, no external
- * facilitator dependency. Test USDC handled the same way real USDC
- * would be on a production cluster.
+ * Real on-chain verification. A payment is valid only when an actual
+ * **confirmed** Solana transaction transferred at least the required
+ * amount of the required USDC mint to the creator's wallet. There are
+ * no bypass tokens and no "the signature exists ⇒ valid" shortcuts.
+ *
+ * Roadmap coverage:
+ *   - C-030: no `x402:<ts>:<wallet>` bypass, no `len>10 ⇒ valid` fallback.
+ *   - C-031: assert amount ≥ required, mint == required, recipient == payTo.
+ *   - C-033: validate the Payment-Signature / Payment-Required header shapes
+ *            against the x402 schema; the Solana "exact" scheme is supported
+ *            exactly (declared scheme/network/asset must match what we quote).
+ *   - C-034: require `confirmed` commitment before granting access.
+ *
+ * The advertised asset is the platform's canonical USDC mint
+ * (`lib/network.ts`), so a payment made with faucet/test USDC verifies
+ * against the same mint the rest of the app uses.
  */
 
-// Devnet USDC mint
-export const USDC_DEVNET_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+import { USDC_MINT, USDC_DECIMALS } from "./constants";
+import { createFailoverConnection } from "./rpc-failover";
+
+/** CAIP-2 network id for Solana devnet (genesis-hash prefix). */
 export const SOLANA_DEVNET_NETWORK = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
+
+/**
+ * Canonical platform USDC mint, as base58. Single source of truth is
+ * `lib/network.ts`; this re-export keeps the x402 advertised asset and
+ * the rest of the app (faucet, escrow) on the same mint.
+ */
+export const USDC_DEVNET_MINT = USDC_MINT.toBase58();
 
 export interface PaymentRequired {
   x402Version: number;
@@ -45,7 +67,7 @@ export function buildPaymentRequired(
       scheme: "exact",
       network: SOLANA_DEVNET_NETWORK,
       asset: USDC_DEVNET_MINT,
-      amount: String(Math.round(pricePerPrompt * 1_000_000)), // 6 decimals
+      amount: String(Math.round(pricePerPrompt * 10 ** USDC_DECIMALS)),
       payTo,
       maxTimeoutSeconds: 120,
     }],
@@ -57,87 +79,418 @@ export function buildPaymentRequired(
  */
 export function encodePaymentRequiredHeader(pr: PaymentRequired): string {
   const json = JSON.stringify(pr);
-  // Use Buffer for server-side encoding (always available in Node)
+  // Use Buffer for server-side encoding (always available in Node).
   return Buffer.from(json).toString("base64");
 }
 
+/* ------------------------------------------------------------------ */
+/*  C-033 — Payment-Signature parsing + schema validation              */
+/* ------------------------------------------------------------------ */
+
+export interface ParsedPaymentSignature {
+  /** The Solana transaction signature that settled the payment. */
+  txSignature: string;
+  /** Declared scheme (e.g. "exact"), when the client sends one. */
+  scheme?: string;
+  /** Declared CAIP-2 network, when the client sends one. */
+  network?: string;
+  /** Declared asset (mint), when the client sends one. */
+  asset?: string;
+}
+
+/** Base58 alphabet (Bitcoin/Solana variant — no 0, O, I, l). */
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]+$/;
+
 /**
- * Verify payment — devnet self-verification.
+ * Whether a string is structurally a Solana transaction signature: a
+ * base58 string of the right length (64-byte signature ⇒ 86-88 chars).
  *
- * Accepts either:
- * 1. A real Solana tx signature (verified via RPC)
- * 2. A simplified devnet payment token (for testing without real USDC)
+ * This alone rejects the legacy `x402:<ts>:<wallet>` token (contains
+ * ":") and arbitrary short strings, before any RPC call (C-030).
+ */
+export function isPlausibleTxSignature(sig: unknown): sig is string {
+  return (
+    typeof sig === "string" &&
+    sig.length >= 64 &&
+    sig.length <= 90 &&
+    BASE58_RE.test(sig)
+  );
+}
+
+/**
+ * Decode a Payment-Signature header into a JSON object. The header may
+ * be raw JSON, base64-encoded JSON, URI-encoded JSON, or base64 of
+ * URI-encoded JSON (the encoding the in-app client uses). Returns null
+ * when no JSON object can be recovered.
+ */
+function decodeToJson(header: string): Record<string, unknown> | null {
+  const attempts: Array<() => string> = [
+    () => header,
+    () => Buffer.from(header, "base64").toString("utf-8"),
+    () => decodeURIComponent(header),
+    () => decodeURIComponent(Buffer.from(header, "base64").toString("utf-8")),
+  ];
+  for (const attempt of attempts) {
+    try {
+      const parsed = JSON.parse(attempt());
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* try the next decoding */
+    }
+  }
+  return null;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Parse a Payment-Signature header into a normalized shape. Accepts the
+ * standard x402 PaymentPayload (`{ x402Version, scheme, network, payload }`)
+ * as well as the in-app envelope (`{ accepted, payload: { transaction } }`)
+ * and a bare transaction signature string. Returns null when no
+ * transaction signature can be extracted.
+ */
+export function parsePaymentSignature(
+  header: string | null | undefined,
+): ParsedPaymentSignature | null {
+  if (typeof header !== "string" || header.trim().length === 0) return null;
+  const trimmed = header.trim();
+
+  const obj = decodeToJson(trimmed);
+  if (obj) {
+    const payload = (obj.payload ?? {}) as Record<string, unknown>;
+    const accepted = (obj.accepted ?? {}) as Record<string, unknown>;
+    const txSignature =
+      str(payload.transaction) ??
+      str(obj.transaction) ??
+      str(payload.txHash) ??
+      str(obj.txHash);
+    if (!txSignature) return null;
+    return {
+      txSignature,
+      scheme: str(obj.scheme) ?? str(accepted.scheme) ?? str(payload.scheme),
+      network: str(obj.network) ?? str(accepted.network) ?? str(payload.network),
+      asset: str(obj.asset) ?? str(accepted.asset) ?? str(payload.asset),
+    };
+  }
+
+  // Not JSON — treat the header itself as a bare transaction signature.
+  return { txSignature: trimmed };
+}
+
+export interface PaymentSchemaIssue {
+  field: string;
+  message: string;
+}
+
+/**
+ * Validate a parsed Payment-Signature against the requirement we quoted.
+ * When the client declares a scheme / network / asset, each must match
+ * the advertised value exactly ("support the Solana scheme exactly",
+ * C-033). Declared fields are optional so a minimal client still works,
+ * but the on-chain checks downstream are not optional.
+ */
+export function validatePaymentSchema(
+  parsed: ParsedPaymentSignature,
+  accept: PaymentRequired["accepts"][number],
+): PaymentSchemaIssue[] {
+  const issues: PaymentSchemaIssue[] = [];
+  if (parsed.scheme != null && parsed.scheme !== accept.scheme) {
+    issues.push({
+      field: "scheme",
+      message: `unsupported payment scheme '${parsed.scheme}' (expected '${accept.scheme}')`,
+    });
+  }
+  if (parsed.network != null && parsed.network !== accept.network) {
+    issues.push({
+      field: "network",
+      message: `wrong network '${parsed.network}' (expected '${accept.network}')`,
+    });
+  }
+  if (parsed.asset != null && parsed.asset !== accept.asset) {
+    issues.push({
+      field: "asset",
+      message: `wrong asset '${parsed.asset}' (expected '${accept.asset}')`,
+    });
+  }
+  return issues;
+}
+
+/* ------------------------------------------------------------------ */
+/*  C-031 — on-chain transfer inspection                               */
+/* ------------------------------------------------------------------ */
+
+/** Minimal shape of a token balance entry from `getTransaction`. */
+export interface TokenBalanceLike {
+  accountIndex: number;
+  mint: string;
+  owner?: string | null;
+  uiTokenAmount: { amount: string };
+}
+
+/** Minimal shape of the fetched transaction we need to verify a payment. */
+export interface TxMetaLike {
+  /** Non-null when the transaction failed on chain. */
+  err: unknown | null;
+  meta: {
+    preTokenBalances?: TokenBalanceLike[] | null;
+    postTokenBalances?: TokenBalanceLike[] | null;
+  } | null;
+}
+
+interface RecipientCredit {
+  amountAtomic: bigint;
+  payer: string;
+}
+
+/**
+ * For a given recipient owner, compute the net positive atomic amount
+ * credited per mint, and a representative payer (the owner whose balance
+ * of that mint decreased the most). Works off pre/post token balances so
+ * it is agnostic to transfer / transferChecked / CPI shapes.
+ */
+export function summarizeCreditsToRecipient(
+  meta: TxMetaLike["meta"],
+  recipientOwner: string,
+): Map<string, RecipientCredit> {
+  const pre = meta?.preTokenBalances ?? [];
+  const post = meta?.postTokenBalances ?? [];
+
+  const preByIndex = new Map<number, TokenBalanceLike>();
+  for (const b of pre) preByIndex.set(b.accountIndex, b);
+  const postByIndex = new Map<number, TokenBalanceLike>();
+  for (const b of post) postByIndex.set(b.accountIndex, b);
+
+  // Per-mint running totals: credit to the recipient, and the largest debit.
+  const credit = new Map<string, bigint>();
+  const biggestDebit = new Map<string, { amount: bigint; owner: string }>();
+
+  const indices = new Set<number>([
+    ...preByIndex.keys(),
+    ...postByIndex.keys(),
+  ]);
+
+  for (const idx of indices) {
+    const p = postByIndex.get(idx);
+    const q = preByIndex.get(idx);
+    const entry = p ?? q;
+    if (!entry) continue;
+    const mint = entry.mint;
+    const owner = p?.owner ?? q?.owner ?? "";
+    const postAmount = p ? BigInt(p.uiTokenAmount.amount) : 0n;
+    const preAmount = q ? BigInt(q.uiTokenAmount.amount) : 0n;
+    const delta = postAmount - preAmount;
+
+    if (delta > 0n && owner === recipientOwner) {
+      credit.set(mint, (credit.get(mint) ?? 0n) + delta);
+    }
+    if (delta < 0n) {
+      const debit = -delta;
+      const cur = biggestDebit.get(mint);
+      if (!cur || debit > cur.amount) {
+        biggestDebit.set(mint, { amount: debit, owner });
+      }
+    }
+  }
+
+  const result = new Map<string, RecipientCredit>();
+  for (const [mint, amountAtomic] of credit) {
+    result.set(mint, {
+      amountAtomic,
+      payer: biggestDebit.get(mint)?.owner ?? "",
+    });
+  }
+  return result;
+}
+
+export interface TransferRequirement {
+  mint: string;
+  payTo: string;
+  minAmountAtomic: bigint;
+}
+
+export type TransferCheck =
+  | { ok: true; amountAtomic: bigint; payer: string }
+  | { ok: false; reason: string };
+
+/**
+ * Decide whether the transfers in a transaction satisfy the payment
+ * requirement: the recipient received ≥ the required amount of the
+ * required mint (C-031). Distinguishes wrong-recipient, wrong-mint and
+ * underpayment so the caller can report a precise reason.
+ */
+export function verifyTransfer(
+  meta: TxMetaLike["meta"],
+  req: TransferRequirement,
+): TransferCheck {
+  const credits = summarizeCreditsToRecipient(meta, req.payTo);
+  if (credits.size === 0) {
+    return { ok: false, reason: "no token transfer to the creator wallet" };
+  }
+  const credit = credits.get(req.mint);
+  if (!credit || credit.amountAtomic <= 0n) {
+    return { ok: false, reason: "payment was made in the wrong mint" };
+  }
+  if (credit.amountAtomic < req.minAmountAtomic) {
+    return {
+      ok: false,
+      reason: `underpayment: paid ${credit.amountAtomic} of required ${req.minAmountAtomic}`,
+    };
+  }
+  return { ok: true, amountAtomic: credit.amountAtomic, payer: credit.payer };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Orchestration — verifyPayment                                      */
+/* ------------------------------------------------------------------ */
+
+export interface VerifyPaymentResult {
+  valid: boolean;
+  txHash: string;
+  payer: string;
+  /** Atomic amount actually paid, when valid. */
+  amountAtomic?: string;
+  /** Human-readable rejection reason, when invalid. */
+  reason?: string;
+}
+
+export interface VerifyPaymentDeps {
+  /**
+   * Fetch a transaction by signature at `confirmed` commitment. Injected
+   * in tests; defaults to a failover RPC read.
+   */
+  fetchTransaction?: (sig: string) => Promise<TxMetaLike | null>;
+}
+
+/**
+ * Default transaction fetch: failover RPC, `confirmed` commitment (C-034).
+ * A transaction that is only `processed` (could still be dropped/forked)
+ * is treated as not-found and does not grant access.
+ */
+async function defaultFetchTransaction(sig: string): Promise<TxMetaLike | null> {
+  const connection = createFailoverConnection("confirmed");
+  const tx = await connection.getTransaction(sig, {
+    commitment: "confirmed",
+    maxSupportedTransactionVersion: 0,
+  });
+  if (!tx) return null;
+  return {
+    err: tx.meta?.err ?? null,
+    meta: {
+      preTokenBalances: (tx.meta?.preTokenBalances ?? null) as
+        | TokenBalanceLike[]
+        | null,
+      postTokenBalances: (tx.meta?.postTokenBalances ?? null) as
+        | TokenBalanceLike[]
+        | null,
+    },
+  };
+}
+
+/**
+ * Verify an x402 payment against the requirement we advertised.
  *
- * Returns { valid, txHash, payer }
+ * Returns `valid: true` only after: the header parses to a real Solana
+ * signature (C-030/C-033), the declared scheme/network/asset match
+ * (C-033), the transaction is found at `confirmed` commitment and did
+ * not fail (C-034), and it transferred ≥ the required amount of the
+ * required mint to the creator wallet (C-031).
  */
 export async function verifyPayment(
-  paymentSignatureHeader: string,
-  _paymentRequired: PaymentRequired,
-): Promise<{ valid: boolean; txHash: string; payer: string }> {
-  try {
-    // Decode the payment signature header
-    let decoded: string;
-    try {
-      decoded = Buffer.from(paymentSignatureHeader, "base64").toString("utf-8");
-    } catch {
-      decoded = paymentSignatureHeader; // might be plain text
-    }
-
-    // Try to parse as JSON
-    let paymentData: Record<string, unknown>;
-    try {
-      // Handle URI-encoded content
-      const jsonStr = decoded.includes("%7B") ? decodeURIComponent(decoded) : decoded;
-      paymentData = JSON.parse(jsonStr);
-    } catch {
-      // Not JSON — treat as raw tx signature
-      paymentData = { transaction: decoded };
-    }
-
-    // Extract transaction hash
-    const txHash = String(
-      paymentData.transaction ||
-      (paymentData.payload as Record<string, unknown>)?.transaction ||
-      paymentData.txHash ||
-      ""
-    );
-
-    if (!txHash) {
-      return { valid: false, txHash: "", payer: "" };
-    }
-
-    // For devnet: accept simplified payment tokens (x402:timestamp:wallet)
-    if (txHash.startsWith("x402:")) {
-      const parts = txHash.split(":");
-      const payer = parts[2] || "anonymous";
-      return { valid: true, txHash, payer };
-    }
-
-    // For real Solana transactions: verify via RPC
-    try {
-      const { Connection } = await import("@solana/web3.js");
-      const rpcUrl = process.env.HELIUS_RPC_URL || "https://api.devnet.solana.com";
-      const connection = new Connection(rpcUrl);
-      const txInfo = await connection.getTransaction(txHash, {
-        maxSupportedTransactionVersion: 0,
-      });
-
-      if (txInfo && !txInfo.meta?.err) {
-        return { valid: true, txHash, payer: "" };
-      }
-    } catch (rpcErr) {
-      console.error("[x402] RPC verification failed:", rpcErr);
-    }
-
-    // Fallback: accept the payment on devnet (for hackathon demo)
-    // In production, this would be a hard reject
-    if (txHash.length > 10) {
-      return { valid: true, txHash, payer: "" };
-    }
-
-    return { valid: false, txHash: "", payer: "" };
-  } catch (err) {
-    console.error("[x402] Payment verification error:", err);
-    return { valid: false, txHash: "", payer: "" };
+  paymentSignatureHeader: string | null | undefined,
+  paymentRequired: PaymentRequired,
+  deps: VerifyPaymentDeps = {},
+): Promise<VerifyPaymentResult> {
+  const accept = paymentRequired.accepts?.[0];
+  if (!accept) {
+    return { valid: false, txHash: "", payer: "", reason: "no payment requirements" };
   }
+
+  const parsed = parsePaymentSignature(paymentSignatureHeader);
+  if (!parsed) {
+    return {
+      valid: false,
+      txHash: "",
+      payer: "",
+      reason: "malformed Payment-Signature header",
+    };
+  }
+
+  const schemaIssues = validatePaymentSchema(parsed, accept);
+  if (schemaIssues.length > 0) {
+    return {
+      valid: false,
+      txHash: parsed.txSignature,
+      payer: "",
+      reason: schemaIssues[0].message,
+    };
+  }
+
+  // C-030: a real on-chain signature is mandatory — no bypass tokens.
+  if (!isPlausibleTxSignature(parsed.txSignature)) {
+    return {
+      valid: false,
+      txHash: parsed.txSignature,
+      payer: "",
+      reason: "not a valid Solana transaction signature",
+    };
+  }
+
+  const fetchTransaction = deps.fetchTransaction ?? defaultFetchTransaction;
+  let tx: TxMetaLike | null;
+  try {
+    tx = await fetchTransaction(parsed.txSignature);
+  } catch (err) {
+    console.error("[x402] transaction fetch failed:", err);
+    return {
+      valid: false,
+      txHash: parsed.txSignature,
+      payer: "",
+      reason: "could not fetch transaction from RPC",
+    };
+  }
+
+  // C-034: not found at `confirmed` ⇒ not (yet) settled ⇒ no access.
+  if (!tx) {
+    return {
+      valid: false,
+      txHash: parsed.txSignature,
+      payer: "",
+      reason: "transaction not found at confirmed commitment",
+    };
+  }
+  if (tx.err) {
+    return {
+      valid: false,
+      txHash: parsed.txSignature,
+      payer: "",
+      reason: "transaction failed on chain",
+    };
+  }
+
+  // C-031: amount / recipient / mint.
+  const check = verifyTransfer(tx.meta, {
+    mint: accept.asset,
+    payTo: accept.payTo,
+    minAmountAtomic: BigInt(accept.amount),
+  });
+  if (!check.ok) {
+    return {
+      valid: false,
+      txHash: parsed.txSignature,
+      payer: "",
+      reason: check.reason,
+    };
+  }
+
+  return {
+    valid: true,
+    txHash: parsed.txSignature,
+    payer: check.payer,
+    amountAtomic: check.amountAtomic.toString(),
+  };
 }

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,9 @@
     "build": "prisma generate && prisma db push --accept-data-loss --skip-generate && next build",
     "postinstall": "prisma generate",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "npx --yes tsx --test tests/unit/*.test.ts",
+    "test:x402": "npx --yes tsx --test tests/unit/x402-server.test.ts tests/unit/x402-payments.test.ts tests/unit/x402-flow.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -449,12 +449,16 @@ model ChatMessage {
   @@index([userWallet])
 }
 
-/// Per-message revenue ledger for hosted agents.
+/// Per-message revenue ledger for hosted agents. Each paid row corresponds
+/// to exactly one verified on-chain x402 payment (C-037): `paymentTx` is the
+/// verified payment signature and `amount` is the amount actually paid, so
+/// the revenue total reconciles to the sum of verified payments.
 model AgentRevenue {
   id            String   @id @default(cuid())
   agentId       String
   userWallet    String
-  amount        Float    // USDC charged for this prompt
+  amount        Float    // USDC actually paid for this prompt
+  paymentTx     String?  @unique // verified x402 payment signature (C-037)
   createdAt     DateTime @default(now())
 
   @@index([agentId])

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -461,6 +461,24 @@ model AgentRevenue {
   @@index([userWallet])
 }
 
+/// Consumed x402 payment signatures — durable replay + idempotency guard.
+/// Each verified on-chain payment maps to exactly one served chat response
+/// (C-032 replay protection, C-036 idempotent payment-gated chat). The tx
+/// signature is the natural idempotency key: a signature is spent once.
+model X402Payment {
+  txSignature  String   @id              // Solana payment tx signature (consumed once)
+  agentId      String                    // hosted agent the payment was for
+  payer        String                    // payer wallet (from the verified transfer)
+  amountAtomic String                    // atomic USDC paid (u64 as string)
+  requestHash  String                    // sha256(agentId\nmessage) — retry vs replay
+  responseBody String?  @db.Text         // cached JSON response for idempotent replay
+  responseCode Int?                       // cached HTTP status for idempotent replay
+  createdAt    DateTime @default(now())
+
+  @@index([agentId])
+  @@index([payer])
+}
+
 /// Referral tracking.
 model Referral {
   id             String    @id @default(cuid())

--- a/app/tests/unit/x402-flow.test.ts
+++ b/app/tests/unit/x402-flow.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Integration tests for the x402 payment gate (C-039).
+ *
+ * Wires the real modules together — verifyPayment (lib/x402-server) with
+ * the replay/idempotency decision and revenue reconciliation
+ * (lib/x402-payments) — to exercise the full sequence a paid chat request
+ * runs through: advertise a requirement, verify a real on-chain payment,
+ * claim it once, replay it on a retry, reject the same payment reused for a
+ * new prompt, and reconcile revenue to the verified payments.
+ *
+ * The durable store is simulated on top of the real `decidePaymentClaim`
+ * so the cross-module data flow (verify → claim → finalize → replay) is
+ * exercised without a database.
+ *
+ * Run with:  npx tsx --test tests/unit/x402-flow.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  verifyPayment,
+  buildPaymentRequired,
+  USDC_DEVNET_MINT,
+  type TxMetaLike,
+} from "../../lib/x402-server";
+import {
+  hashPaymentRequest,
+  decidePaymentClaim,
+  reconcileRevenue,
+  type ConsumedPaymentRecord,
+} from "../../lib/x402-payments";
+
+const CREATOR = "AgentCreatorWallet1111111111111111111111111";
+const PAYER = "UserPayerWallet11111111111111111111111111111";
+
+const B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+/** Deterministic 88-char base58 signature, varied by seed. */
+function makeSig(seed: number, len = 88): string {
+  let s = "";
+  for (let i = 0; i < len; i++) s += B58[(i * 7 + seed) % B58.length];
+  return s;
+}
+
+/** Base64 Payment-Signature envelope carrying a transaction signature. */
+function envelope(transaction: string): string {
+  const payload = { x402Version: 2, payload: { transaction } };
+  return Buffer.from(JSON.stringify(payload), "utf-8").toString("base64");
+}
+
+/** A confirmed tx moving `amountAtomic` of the canonical USDC PAYER→CREATOR. */
+function transferMeta(amountAtomic: bigint): TxMetaLike {
+  const pre = 1_000_000n;
+  return {
+    err: null,
+    meta: {
+      preTokenBalances: [
+        { accountIndex: 1, mint: USDC_DEVNET_MINT, owner: PAYER, uiTokenAmount: { amount: pre.toString() } },
+        { accountIndex: 2, mint: USDC_DEVNET_MINT, owner: CREATOR, uiTokenAmount: { amount: "0" } },
+      ],
+      postTokenBalances: [
+        { accountIndex: 1, mint: USDC_DEVNET_MINT, owner: PAYER, uiTokenAmount: { amount: (pre - amountAtomic).toString() } },
+        { accountIndex: 2, mint: USDC_DEVNET_MINT, owner: CREATOR, uiTokenAmount: { amount: amountAtomic.toString() } },
+      ],
+    },
+  };
+}
+
+/**
+ * Simulated durable consumed-payment store, built on the real
+ * `decidePaymentClaim`, mirroring claimPayment/finalizePayment so the gate
+ * sequence integrates without a database.
+ */
+function makeStore() {
+  const rows = new Map<string, ConsumedPaymentRecord & { amountAtomic: string }>();
+  return {
+    claim(sig: string, requestHash: string, amountAtomic: string) {
+      const existing = rows.get(sig) ?? null;
+      const decision = decidePaymentClaim(existing, requestHash);
+      if (decision.kind === "fresh") {
+        rows.set(sig, { requestHash, responseBody: null, responseCode: null, amountAtomic });
+      }
+      return decision;
+    },
+    finalize(sig: string, body: string, code: number) {
+      const r = rows.get(sig);
+      if (r) {
+        r.responseBody = body;
+        r.responseCode = code;
+      }
+    },
+    /** Atomic amounts of payments that were served (finalized). */
+    servedAmounts(): string[] {
+      return [...rows.values()]
+        .filter((r) => r.responseBody != null)
+        .map((r) => r.amountAtomic);
+    },
+  };
+}
+
+describe("x402 gate flow (C-039 integration)", () => {
+  test("the advertised requirement and verification agree on the canonical mint", async () => {
+    const pr = buildPaymentRequired("agent_1", "Poet", 0.05, CREATOR);
+    assert.equal(pr.accepts[0].asset, USDC_DEVNET_MINT);
+    assert.equal(pr.accepts[0].amount, "50000");
+    assert.equal(pr.accepts[0].payTo, CREATOR);
+    assert.equal(pr.accepts[0].scheme, "exact");
+
+    const v = await verifyPayment(envelope(makeSig(1)), pr, {
+      fetchTransaction: async () => transferMeta(50000n),
+    });
+    assert.equal(v.valid, true);
+    assert.equal(v.payer, PAYER);
+    assert.equal(v.amountAtomic, "50000");
+  });
+
+  test("verify → claim once → retry replays the same response, one charge", async () => {
+    const pr = buildPaymentRequired("agent_1", "Poet", 0.05, CREATOR);
+    const header = envelope(makeSig(2));
+    const store = makeStore();
+    const reqHash = hashPaymentRequest("agent_1", "write me a haiku");
+
+    // First paid request: verify, claim, serve, finalize.
+    const v1 = await verifyPayment(header, pr, { fetchTransaction: async () => transferMeta(50000n) });
+    assert.equal(v1.valid, true);
+    const first = store.claim(v1.txHash, reqHash, v1.amountAtomic ?? "0");
+    assert.equal(first.kind, "fresh");
+    const body = JSON.stringify({ response: "an old silent pond" });
+    store.finalize(v1.txHash, body, 200);
+
+    // Network retry: identical payment + prompt replays the cached body.
+    const v2 = await verifyPayment(header, pr, { fetchTransaction: async () => transferMeta(50000n) });
+    const retry = store.claim(v2.txHash, reqHash, v2.amountAtomic ?? "0");
+    assert.deepEqual(retry, { kind: "replay", body, code: 200 });
+
+    // One charge: revenue (the single finalized payment) reconciles to chain.
+    const revenue = [Number(v1.amountAtomic) / 1_000_000];
+    assert.equal(reconcileRevenue(revenue, store.servedAmounts()).reconciled, true);
+  });
+
+  test("the same payment reused for a different prompt is rejected as consumed", async () => {
+    const pr = buildPaymentRequired("agent_1", "Poet", 0.05, CREATOR);
+    const header = envelope(makeSig(3));
+    const store = makeStore();
+
+    const v = await verifyPayment(header, pr, { fetchTransaction: async () => transferMeta(50000n) });
+    store.claim(v.txHash, hashPaymentRequest("agent_1", "prompt one"), v.amountAtomic ?? "0");
+    store.finalize(v.txHash, "{}", 200);
+
+    const attack = store.claim(
+      v.txHash,
+      hashPaymentRequest("agent_1", "a second, free prompt"),
+      v.amountAtomic ?? "0",
+    );
+    assert.deepEqual(attack, { kind: "consumed" });
+  });
+
+  test("an underpaid transaction never reaches the store", async () => {
+    const pr = buildPaymentRequired("agent_1", "Poet", 0.05, CREATOR); // requires 50000
+    const store = makeStore();
+
+    const v = await verifyPayment(envelope(makeSig(4)), pr, {
+      fetchTransaction: async () => transferMeta(40000n),
+    });
+    assert.equal(v.valid, false);
+    assert.match(v.reason ?? "", /underpayment/);
+    // The gate would return 402 here; nothing is claimed or served.
+    assert.deepEqual(store.servedAmounts(), []);
+  });
+
+  test("the facilitator path integrates the same way", async () => {
+    const pr = buildPaymentRequired("agent_1", "Poet", 0.05, CREATOR);
+    const store = makeStore();
+
+    const v = await verifyPayment(envelope(makeSig(5)), pr, {
+      verifyViaFacilitator: async () => ({ isValid: true, payer: PAYER, amountAtomic: "50000" }),
+    });
+    assert.equal(v.valid, true);
+    const claim = store.claim(v.txHash, hashPaymentRequest("agent_1", "hi"), v.amountAtomic ?? "0");
+    assert.equal(claim.kind, "fresh");
+  });
+});

--- a/app/tests/unit/x402-payments.test.ts
+++ b/app/tests/unit/x402-payments.test.ts
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import {
   hashPaymentRequest,
   decidePaymentClaim,
+  reconcileRevenue,
 } from "../../lib/x402-payments";
 
 describe("hashPaymentRequest", () => {
@@ -91,5 +92,41 @@ describe("decidePaymentClaim", () => {
       otherHash,
     );
     assert.deepEqual(decision, { kind: "consumed" });
+  });
+});
+
+describe("reconcileRevenue (C-037)", () => {
+  test("reconciles when revenue equals verified payments", () => {
+    const r = reconcileRevenue([0.05, 0.1], ["50000", "100000"]);
+    assert.equal(r.reconciled, true);
+    assert.equal(r.driftAtomic, "0");
+    assert.equal(r.revenueAtomic, "150000");
+    assert.equal(r.verifiedAtomic, "150000");
+  });
+
+  test("detects drift when revenue exceeds verified payments", () => {
+    const r = reconcileRevenue([0.05, 0.05], ["50000"]);
+    assert.equal(r.reconciled, false);
+    assert.equal(r.driftAtomic, "50000");
+  });
+
+  test("detects drift when a verified payment recorded no revenue", () => {
+    const r = reconcileRevenue([0.05], ["50000", "50000"]);
+    assert.equal(r.reconciled, false);
+    assert.equal(r.driftAtomic, "-50000");
+  });
+
+  test("handles empty ledgers", () => {
+    const r = reconcileRevenue([], []);
+    assert.equal(r.reconciled, true);
+    assert.equal(r.revenueAtomic, "0");
+    assert.equal(r.verifiedAtomic, "0");
+  });
+
+  test("avoids float drift on fractional amounts", () => {
+    // 0.1 + 0.2 = 0.30000000000000004 in float; atomic rounding fixes it.
+    const r = reconcileRevenue([0.1, 0.2], ["100000", "200000"]);
+    assert.equal(r.reconciled, true);
+    assert.equal(r.revenueAtomic, "300000");
   });
 });

--- a/app/tests/unit/x402-payments.test.ts
+++ b/app/tests/unit/x402-payments.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for lib/x402-payments — replay + idempotency decision logic.
+ *
+ * Covers C-032 (a signature spent for a different prompt is consumed)
+ * and C-036 (a retry of the same prompt replays the cached response).
+ * Only the pure functions are exercised here; the Prisma-backed wiring
+ * is a thin shell over `decidePaymentClaim`.
+ *
+ * Run with:  npx tsx --test tests/unit/x402-payments.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  hashPaymentRequest,
+  decidePaymentClaim,
+} from "../../lib/x402-payments";
+
+describe("hashPaymentRequest", () => {
+  test("is deterministic for the same agent + message", () => {
+    assert.equal(
+      hashPaymentRequest("agent_1", "hello world"),
+      hashPaymentRequest("agent_1", "hello world"),
+    );
+  });
+  test("differs by message", () => {
+    assert.notEqual(
+      hashPaymentRequest("agent_1", "prompt A"),
+      hashPaymentRequest("agent_1", "prompt B"),
+    );
+  });
+  test("differs by agent", () => {
+    assert.notEqual(
+      hashPaymentRequest("agent_1", "same"),
+      hashPaymentRequest("agent_2", "same"),
+    );
+  });
+  test("produces a 64-char hex digest", () => {
+    assert.match(hashPaymentRequest("a", "b"), /^[a-f0-9]{64}$/);
+  });
+});
+
+describe("decidePaymentClaim", () => {
+  const reqHash = hashPaymentRequest("agent_1", "the paid prompt");
+
+  test("fresh: no prior record ⇒ proceed", () => {
+    assert.deepEqual(decidePaymentClaim(null, reqHash), { kind: "fresh" });
+  });
+
+  test("C-036 replay: same prompt + finalized response ⇒ serve cached", () => {
+    const decision = decidePaymentClaim(
+      { requestHash: reqHash, responseBody: '{"response":"hi"}', responseCode: 200 },
+      reqHash,
+    );
+    assert.deepEqual(decision, {
+      kind: "replay",
+      body: '{"response":"hi"}',
+      code: 200,
+    });
+  });
+
+  test("pending: same prompt but response not yet finalized ⇒ retry", () => {
+    const decision = decidePaymentClaim(
+      { requestHash: reqHash, responseBody: null, responseCode: null },
+      reqHash,
+    );
+    assert.deepEqual(decision, { kind: "pending" });
+  });
+
+  test("pending: body present but code missing is still in-flight", () => {
+    const decision = decidePaymentClaim(
+      { requestHash: reqHash, responseBody: "partial", responseCode: null },
+      reqHash,
+    );
+    assert.deepEqual(decision, { kind: "pending" });
+  });
+
+  test("C-032 consumed: same payment, different prompt ⇒ reject", () => {
+    const otherHash = hashPaymentRequest("agent_1", "a different prompt");
+    const decision = decidePaymentClaim(
+      { requestHash: reqHash, responseBody: '{"response":"hi"}', responseCode: 200 },
+      otherHash,
+    );
+    assert.deepEqual(decision, { kind: "consumed" });
+  });
+
+  test("C-032 consumed: replay attack even before the first response finalizes", () => {
+    const otherHash = hashPaymentRequest("agent_1", "second prompt");
+    const decision = decidePaymentClaim(
+      { requestHash: reqHash, responseBody: null, responseCode: null },
+      otherHash,
+    );
+    assert.deepEqual(decision, { kind: "consumed" });
+  });
+});

--- a/app/tests/unit/x402-server.test.ts
+++ b/app/tests/unit/x402-server.test.ts
@@ -16,6 +16,7 @@ import {
   summarizeCreditsToRecipient,
   verifyTransfer,
   verifyPayment,
+  PAYMENT_COMMITMENT,
   type PaymentRequired,
   type TxMetaLike,
 } from "../../lib/x402-server";
@@ -328,5 +329,72 @@ describe("verifyPayment", () => {
     });
     assert.equal(res.valid, false);
     assert.match(res.reason ?? "", /no token transfer to the creator/);
+  });
+});
+
+/* ---- confirmation depth (C-034) ---------------------------------- */
+
+describe("PAYMENT_COMMITMENT (C-034)", () => {
+  test("requires confirmed, not processed", () => {
+    assert.equal(PAYMENT_COMMITMENT, "confirmed");
+  });
+});
+
+/* ---- facilitator path (C-035) ------------------------------------ */
+
+describe("verifyPayment via facilitator", () => {
+  test("accepts when the facilitator validates the payment", async () => {
+    const res = await verifyPayment(
+      envelope(SIG, { scheme: "exact", network: NET, asset: MINT }),
+      reqFor("50000"),
+      {
+        verifyViaFacilitator: async (parsed, pr) => {
+          assert.equal(parsed.txSignature, SIG);
+          assert.equal(pr.accepts[0].amount, "50000");
+          return { isValid: true, payer: PAYER, amountAtomic: "50000" };
+        },
+      },
+    );
+    assert.equal(res.valid, true);
+    assert.equal(res.payer, PAYER);
+    assert.equal(res.amountAtomic, "50000");
+  });
+
+  test("rejects with the facilitator's reason when it says invalid", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor(), {
+      verifyViaFacilitator: async () => ({ isValid: false, invalidReason: "underpaid" }),
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /underpaid/);
+  });
+
+  test("falls back to the quoted amount when the facilitator omits it", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor("12345"), {
+      verifyViaFacilitator: async () => ({ isValid: true, payer: PAYER }),
+    });
+    assert.equal(res.valid, true);
+    assert.equal(res.amountAtomic, "12345");
+  });
+
+  test("rejects the bypass token before reaching the facilitator (C-030)", async () => {
+    let called = false;
+    const res = await verifyPayment(envelope("x402:1:wallet"), reqFor(), {
+      verifyViaFacilitator: async () => {
+        called = true;
+        return { isValid: true };
+      },
+    });
+    assert.equal(res.valid, false);
+    assert.equal(called, false);
+  });
+
+  test("reports a clear error when the facilitator is unreachable", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor(), {
+      verifyViaFacilitator: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /facilitator/);
   });
 });

--- a/app/tests/unit/x402-server.test.ts
+++ b/app/tests/unit/x402-server.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Unit tests for lib/x402-server — real on-chain payment verification.
+ *
+ * Covers C-030 (no bypass), C-031 (amount/recipient/mint), C-033 (schema
+ * + Solana scheme), C-034 (confirmed commitment / not-found rejects).
+ *
+ * Run with:  npx tsx --test tests/unit/x402-server.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isPlausibleTxSignature,
+  parsePaymentSignature,
+  validatePaymentSchema,
+  summarizeCreditsToRecipient,
+  verifyTransfer,
+  verifyPayment,
+  type PaymentRequired,
+  type TxMetaLike,
+} from "../../lib/x402-server";
+
+/* ---- fixtures ---------------------------------------------------- */
+
+const MINT = "F7RYRqCy8uWYxjxrXVhU3iUCRwa9bKBUTkGKktpyYueQ";
+const OTHER_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const CREATOR = "Creator11111111111111111111111111111111111";
+const PAYER = "Payer111111111111111111111111111111111111111";
+const NET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
+
+const B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+/** Deterministic base58 string of `len` chars (a structurally-valid sig). */
+function makeSig(len = 88): string {
+  let s = "";
+  for (let i = 0; i < len; i++) s += B58[(i * 7) % B58.length];
+  return s;
+}
+const SIG = makeSig(88);
+
+function reqFor(amount = "50000"): PaymentRequired {
+  return {
+    x402Version: 2,
+    error: "Payment required",
+    resource: { url: "/x", description: "d", mimeType: "application/json" },
+    accepts: [
+      {
+        scheme: "exact",
+        network: NET,
+        asset: MINT,
+        amount,
+        payTo: CREATOR,
+        maxTimeoutSeconds: 120,
+      },
+    ],
+  };
+}
+
+/** Base64-encode the in-app Payment-Signature envelope. */
+function envelope(
+  transaction: string,
+  accepted: { scheme?: string; network?: string; asset?: string } = {},
+): string {
+  const payload = { x402Version: 2, accepted, payload: { transaction } };
+  return Buffer.from(JSON.stringify(payload), "utf-8").toString("base64");
+}
+
+/** A tx that moves `amount` atomic of `mint` from `from` to `to`. */
+function transferMeta(opts: {
+  mint?: string;
+  from?: string;
+  to?: string;
+  amount?: bigint;
+  recipientPreExists?: boolean;
+  err?: unknown;
+}): TxMetaLike {
+  const mint = opts.mint ?? MINT;
+  const from = opts.from ?? PAYER;
+  const to = opts.to ?? CREATOR;
+  const amount = opts.amount ?? 50000n;
+  const preFrom = 100000n;
+
+  const pre: NonNullable<TxMetaLike["meta"]>["preTokenBalances"] = [
+    { accountIndex: 1, mint, owner: from, uiTokenAmount: { amount: preFrom.toString() } },
+  ];
+  // Model an ATA that may or may not have existed before the transfer.
+  if (opts.recipientPreExists !== false) {
+    pre.push({ accountIndex: 2, mint, owner: to, uiTokenAmount: { amount: "0" } });
+  }
+  const post = [
+    { accountIndex: 1, mint, owner: from, uiTokenAmount: { amount: (preFrom - amount).toString() } },
+    { accountIndex: 2, mint, owner: to, uiTokenAmount: { amount: amount.toString() } },
+  ];
+  return { err: opts.err ?? null, meta: { preTokenBalances: pre, postTokenBalances: post } };
+}
+
+/** A fetch that fails the test if it is ever called. */
+const rejectFetch = async (): Promise<TxMetaLike | null> => {
+  throw new Error("RPC should not have been called");
+};
+
+/* ---- isPlausibleTxSignature (C-030) ------------------------------ */
+
+describe("isPlausibleTxSignature", () => {
+  test("accepts a base58 signature of the right length", () => {
+    assert.equal(isPlausibleTxSignature(SIG), true);
+  });
+  test("rejects the legacy x402:<ts>:<wallet> bypass token", () => {
+    assert.equal(isPlausibleTxSignature(`x402:${1700000000000}:${PAYER}`), false);
+  });
+  test("rejects arbitrary short strings (len>10 fallback class)", () => {
+    assert.equal(isPlausibleTxSignature("abcdefghijklmnop"), false);
+    assert.equal(isPlausibleTxSignature("anystring-longer-than-ten"), false);
+  });
+  test("rejects non-base58 characters", () => {
+    assert.equal(isPlausibleTxSignature(makeSig(88).slice(0, 87) + "0"), false); // '0' not base58
+    assert.equal(isPlausibleTxSignature(makeSig(88).slice(0, 87) + "+"), false);
+  });
+  test("rejects non-strings", () => {
+    assert.equal(isPlausibleTxSignature(null), false);
+    assert.equal(isPlausibleTxSignature(12345), false);
+  });
+});
+
+/* ---- parsePaymentSignature (C-033) ------------------------------- */
+
+describe("parsePaymentSignature", () => {
+  test("parses the base64 in-app envelope", () => {
+    const parsed = parsePaymentSignature(
+      envelope(SIG, { scheme: "exact", network: NET, asset: MINT }),
+    );
+    assert.ok(parsed);
+    assert.equal(parsed!.txSignature, SIG);
+    assert.equal(parsed!.scheme, "exact");
+    assert.equal(parsed!.network, NET);
+    assert.equal(parsed!.asset, MINT);
+  });
+
+  test("parses a raw JSON standard payload", () => {
+    const raw = JSON.stringify({
+      x402Version: 2,
+      scheme: "exact",
+      network: NET,
+      payload: { transaction: SIG },
+    });
+    const parsed = parsePaymentSignature(raw);
+    assert.equal(parsed!.txSignature, SIG);
+    assert.equal(parsed!.scheme, "exact");
+  });
+
+  test("parses a bare signature string", () => {
+    const parsed = parsePaymentSignature(SIG);
+    assert.equal(parsed!.txSignature, SIG);
+    assert.equal(parsed!.scheme, undefined);
+  });
+
+  test("extracts the (fake) transaction from a wrapped bypass token", () => {
+    const parsed = parsePaymentSignature(envelope("x402:123:wallet"));
+    assert.equal(parsed!.txSignature, "x402:123:wallet");
+  });
+
+  test("returns null for empty / non-string headers", () => {
+    assert.equal(parsePaymentSignature(""), null);
+    assert.equal(parsePaymentSignature("   "), null);
+    assert.equal(parsePaymentSignature(null), null);
+    assert.equal(parsePaymentSignature(undefined), null);
+  });
+});
+
+/* ---- validatePaymentSchema (C-033) ------------------------------- */
+
+describe("validatePaymentSchema", () => {
+  const accept = reqFor().accepts[0];
+
+  test("passes when declared fields match the advertised ones", () => {
+    assert.deepEqual(
+      validatePaymentSchema({ txSignature: SIG, scheme: "exact", network: NET, asset: MINT }, accept),
+      [],
+    );
+  });
+  test("passes when fields are absent (minimal client)", () => {
+    assert.deepEqual(validatePaymentSchema({ txSignature: SIG }, accept), []);
+  });
+  test("flags a wrong scheme", () => {
+    const issues = validatePaymentSchema({ txSignature: SIG, scheme: "permit" }, accept);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].field, "scheme");
+  });
+  test("flags a wrong network and asset", () => {
+    const issues = validatePaymentSchema(
+      { txSignature: SIG, network: "solana:mainnet", asset: OTHER_MINT },
+      accept,
+    );
+    assert.deepEqual(issues.map((i) => i.field).sort(), ["asset", "network"]);
+  });
+});
+
+/* ---- summarizeCreditsToRecipient + verifyTransfer (C-031) -------- */
+
+describe("summarizeCreditsToRecipient", () => {
+  test("nets the credit to the recipient and identifies the payer", () => {
+    const credits = summarizeCreditsToRecipient(transferMeta({}).meta, CREATOR);
+    assert.equal(credits.get(MINT)?.amountAtomic, 50000n);
+    assert.equal(credits.get(MINT)?.payer, PAYER);
+  });
+  test("handles a recipient ATA created in the same tx (no pre balance)", () => {
+    const credits = summarizeCreditsToRecipient(
+      transferMeta({ recipientPreExists: false }).meta,
+      CREATOR,
+    );
+    assert.equal(credits.get(MINT)?.amountAtomic, 50000n);
+  });
+  test("returns nothing when the recipient received no tokens", () => {
+    const credits = summarizeCreditsToRecipient(transferMeta({}).meta, "nobody");
+    assert.equal(credits.size, 0);
+  });
+});
+
+describe("verifyTransfer", () => {
+  const req = { mint: MINT, payTo: CREATOR, minAmountAtomic: 50000n };
+
+  test("accepts an exact payment", () => {
+    const r = verifyTransfer(transferMeta({}).meta, req);
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.amountAtomic, 50000n);
+      assert.equal(r.payer, PAYER);
+    }
+  });
+  test("accepts an overpayment", () => {
+    const r = verifyTransfer(transferMeta({ amount: 60000n }).meta, req);
+    assert.equal(r.ok, true);
+  });
+  test("rejects underpayment", () => {
+    const r = verifyTransfer(transferMeta({ amount: 49999n }).meta, req);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /underpayment/);
+  });
+  test("rejects the wrong mint", () => {
+    const r = verifyTransfer(transferMeta({ mint: OTHER_MINT }).meta, req);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /wrong mint/);
+  });
+  test("rejects the wrong recipient", () => {
+    const r = verifyTransfer(transferMeta({ to: "someone-else" }).meta, req);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /no token transfer to the creator/);
+  });
+});
+
+/* ---- verifyPayment orchestration (C-030/C-031/C-033/C-034) ------- */
+
+describe("verifyPayment", () => {
+  test("accepts a real, sufficient, confirmed payment", async () => {
+    const res = await verifyPayment(
+      envelope(SIG, { scheme: "exact", network: NET, asset: MINT }),
+      reqFor("50000"),
+      { fetchTransaction: async () => transferMeta({}) },
+    );
+    assert.equal(res.valid, true);
+    assert.equal(res.txHash, SIG);
+    assert.equal(res.payer, PAYER);
+    assert.equal(res.amountAtomic, "50000");
+  });
+
+  test("C-030: rejects the x402:<ts>:<wallet> bypass without touching RPC", async () => {
+    let called = false;
+    const res = await verifyPayment(envelope(`x402:1700000000000:${PAYER}`), reqFor(), {
+      fetchTransaction: async () => {
+        called = true;
+        return transferMeta({});
+      },
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /not a valid Solana transaction signature/);
+    assert.equal(called, false);
+  });
+
+  test("C-030: rejects an arbitrary >10-char string", async () => {
+    const res = await verifyPayment("totally-bogus-payment-token", reqFor(), {
+      fetchTransaction: rejectFetch,
+    });
+    assert.equal(res.valid, false);
+  });
+
+  test("C-033: rejects a wrong scheme before any RPC call", async () => {
+    const res = await verifyPayment(envelope(SIG, { scheme: "permit" }), reqFor(), {
+      fetchTransaction: rejectFetch,
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /unsupported payment scheme/);
+  });
+
+  test("C-034: rejects a tx not found at confirmed commitment", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor(), {
+      fetchTransaction: async () => null,
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /not found at confirmed/);
+  });
+
+  test("rejects a transaction that failed on chain", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor(), {
+      fetchTransaction: async () => transferMeta({ err: { InstructionError: [0, "Custom"] } }),
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /failed on chain/);
+  });
+
+  test("C-031: rejects underpayment", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor("50001"), {
+      fetchTransaction: async () => transferMeta({ amount: 50000n }),
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /underpayment/);
+  });
+
+  test("C-031: rejects the wrong mint", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor(), {
+      fetchTransaction: async () => transferMeta({ mint: OTHER_MINT }),
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /wrong mint/);
+  });
+
+  test("C-031: rejects the wrong recipient", async () => {
+    const res = await verifyPayment(envelope(SIG), reqFor(), {
+      fetchTransaction: async () => transferMeta({ to: "attacker-wallet" }),
+    });
+    assert.equal(res.valid, false);
+    assert.match(res.reason ?? "", /no token transfer to the creator/);
+  });
+});


### PR DESCRIPTION
Makes the hosted-agent x402 payment gate **real**. Closes the entire backend
of milestone **M2 — Real x402 payments** (C-030 → C-039; only the frontend
C-038 remains).

Closes #67, #68, #69, #70, #71, #72, #73, #74, #78

---

## Why

Before this PR, `lib/x402-server.ts::verifyPayment` was payment **theater** —
three "accept-anything" paths let unpaid requests through:

1. an `x402:<ts>:<wallet>` token passed **unconditionally**,
2. a "real" tx was only checked for **existence** — never amount / mint /
   recipient,
3. a final fallback accepted **any string longer than 10 characters**.

The only consumer, `POST /api/hosted-agents/[id]/chat`, therefore charged
nothing real. This PR replaces that with real Solana verification, durable
single-use payments, idempotent serving, on-chain-reconciled revenue, an
optional facilitator path, and a full test suite.

**3 commits · 9 files · +1620 / −120 · 57 x402 tests green (150 full) ·
`tsc --noEmit` clean · eslint clean.**

| Area | File |
|---|---|
| Verification (rewritten) | `app/lib/x402-server.ts` |
| Replay + idempotency + reconcile (new) | `app/lib/x402-payments.ts` |
| Payment gate wiring | `app/app/api/hosted-agents/[id]/chat/route.ts` |
| `X402Payment` model + `AgentRevenue.paymentTx` | `app/prisma/schema.prisma`, `app/lib/prisma.ts` |
| Unit + integration suite | `app/tests/unit/x402-{server,payments,flow}.test.ts` |

---

## Issue-by-issue

### C-030 · Remove all x402 accept-anything fallbacks `security · blocker · x402`
**What:** Deleted the `x402:<ts>:<wallet>` bypass and the `len > 10 ⇒ valid`
fallback.
**How:** A Payment-Signature is first screened by `isPlausibleTxSignature()`
— it must be a base58 string of signature length (64–90 chars). The bypass
token (contains `:`) and arbitrary strings fail this **before any RPC call**,
so they can never reach a "valid" return. `verifyPayment()` returns
`valid: true` only after the on-chain transfer check below.
**Where:** `x402-server.ts` → `isPlausibleTxSignature`, `verifyPayment`.
**AC ✓** Tests prove the `x402:` token, short strings and arbitrary tokens all
return `valid: false`, and that no RPC call is made for them.

### C-031 · Verify payment amount, recipient, and mint on-chain `blocker · x402 · backend`
**What:** Assert the SPL transfer paid ≥ the required amount of the required
mint (USDC) to the creator wallet.
**How:** `summarizeCreditsToRecipient()` nets the transaction's
`pre/postTokenBalances` per mint for the `payTo` owner (so it is agnostic to
`transfer` / `transferChecked` / CPI shapes and to a recipient ATA created in
the same tx). `verifyTransfer()` then distinguishes **wrong-recipient**,
**wrong-mint** and **underpayment**, each with a precise reason, and returns
the exact paid amount + payer.
**Where:** `x402-server.ts` → `summarizeCreditsToRecipient`, `verifyTransfer`,
`verifyPayment`.
**AC ✓** Underpayment, wrong mint and wrong recipient all reject (unit-tested
at both the `verifyTransfer` and `verifyPayment` levels).

### C-032 · Replay protection for x402 payments `security · x402`
**What:** A payment signature can be spent exactly once; consumed signatures
are **persisted**.
**How:** New durable `X402Payment` table (the signature is the primary key).
`claimPayment()` reserves the signature on first use; a reuse of the same
signature for a **different** prompt returns `consumed`. Persistence (not an
in-memory map) is deliberate so the guarantee survives serverless cold starts.
The reserve is race-safe: a concurrent duplicate loses on the PK and falls
back to reading the winner's row.
**Where:** `x402-payments.ts` → `decidePaymentClaim` (pure), `claimPayment`;
`schema.prisma` / `prisma.ts` (`X402Payment` + runtime migration); gate in
`route.ts`.
**AC ✓** Re-submitting the same payment for a second prompt is rejected
(`409`), proven by `decidePaymentClaim` unit tests + the integration flow.

### C-033 · Conform to the x402 HTTP 402 spec (headers + scheme) `x402 · backend`
**What:** Validate the Payment-Signature / Payment-Required shapes against the
x402 schema and support the Solana "exact" scheme.
**How:** `parsePaymentSignature()` accepts the standard x402 PaymentPayload
(`{ x402Version, scheme, network, payload }`), the in-app envelope, and a bare
signature — across raw/base64/URI encodings. `validatePaymentSchema()` then
requires any declared `scheme` / `network` / `asset` to match the advertised
`PaymentRequired.accepts[0]` exactly. `buildPaymentRequired()` emits a
spec-shaped 402 body (`scheme: "exact"`, CAIP-2 `network`, `asset`, atomic
`amount`, `payTo`).
**Where:** `x402-server.ts` → `parsePaymentSignature`, `validatePaymentSchema`,
`buildPaymentRequired`.
**AC ✓ (with a nuance, see Notes):** declared fields are validated exactly;
parsing is lenient about the envelope so a minimal client works without custom
code, while the on-chain checks remain mandatory.

### C-034 · Settlement window / confirmation depth `onchain · x402`
**What:** Require `confirmed` (not `processed`) commitment before granting
access.
**How:** Extracted `PAYMENT_COMMITMENT = "confirmed"` and used it for both the
failover connection and `getTransaction`. A tx that is only `processed` (could
still be dropped/forked) is invisible at `confirmed`, treated as not-found, and
denied.
**Where:** `x402-server.ts` → `PAYMENT_COMMITMENT`, `defaultFetchTransaction`,
`verifyPayment`.
**AC ✓** A dropped/forked (not-found-at-confirmed) tx does not grant access; a
unit test pins the constant so it cannot silently regress to `processed`.

### C-035 · x402 facilitator integration (optional path) `x402 · backend`
**What:** Allow verifying via an x402 facilitator service instead of direct RPC
parsing, **behind a flag**.
**How:** When `X402_FACILITATOR_URL` is set (or a `verifyViaFacilitator` dep is
injected), `verifyPayment()` POSTs the payment to the facilitator's `/verify`
endpoint and maps `{ isValid, payer, amountAtomic, invalidReason }`. Off by
default; the C-030 signature check still runs first so the signature remains a
usable replay/idempotency key; facilitator errors fail closed.
**Where:** `x402-server.ts` → `facilitatorFromEnv`, `VerifyPaymentDeps`,
`verifyPayment`.
**AC ✓** Verified end-to-end in tests (valid / invalid / amount-fallback /
bypass-still-rejected / unreachable) and in the integration flow.

### C-036 · Idempotent payment-gated chat `x402 · backend`
**What:** A verified payment maps to exactly one served response; retries do
not double-charge or double-serve.
**How:** On a fresh payment the gate reserves it, the route serves, and
`servePaid()` finalizes by caching the response body against the signature. A
network retry of the same prompt replays that cached body byte-for-byte
(`x-idempotent-replay: true`) with no second charge. On a server error the
payment is **released** so the payer (who already paid on chain) can retry —
"one charge", not "zero service for money taken". `pending` (a concurrent
duplicate still in flight) returns `409 retry`.
**Where:** `x402-payments.ts` → `decidePaymentClaim`, `finalizePayment`,
`releasePayment`; `route.ts` → `servePaid` + catch.
**AC ✓** Network-retry returns the same response, one charge (unit + flow
tests).

### C-037 · Creator payout accounting reconciled to chain `x402 · backend`
**What:** `AgentRevenue` rows must correspond to real on-chain transfers.
**How:** Revenue recording was consolidated into `servePaid()`: exactly **one**
`AgentRevenue` row per verified payment, at the **amount actually paid on
chain** (`amountAtomic`), tied to the payment signature via the new
`AgentRevenue.paymentTx` (`@unique`). The two divergent inline revenue blocks
(design + text paths) were removed. Revenue is now recorded only for real
verified payments — not the old nominal-price + `walletAddress`-gated path.
`reconcileRevenue()` (pure) / `reconcileAgentRevenue()` (DB) compare the two
ledgers in **atomic units** (no float drift) so any divergence is detectable.
**Where:** `x402-payments.ts` → `reconcileRevenue`, `reconcileAgentRevenue`;
`route.ts` → `servePaid`; `schema.prisma` / `prisma.ts`.
**AC ✓** Revenue total equals the sum of verified on-chain payments by
construction; `reconcileRevenue` is unit-tested incl. the 0.1+0.2 float case.

### C-039 · x402 unit + integration test suite `test · x402`
**What:** Coverage for amount / mint / recipient / replay / confirmation; all
x402 tests green.
**How:** 57 tests across three files — `x402-server.test.ts` (parse, schema,
transfer inspection, `verifyPayment`, commitment, facilitator),
`x402-payments.test.ts` (claim decision, reconciliation), and the new
`x402-flow.test.ts` **integration** suite that wires `verifyPayment` →
claim → finalize → replay → consume → reconcile end-to-end and asserts the
advertised mint equals the verified mint. Added `npm run test:x402` and
`npm test` (scripts only — no dependency/lockfile change; they use the repo's
existing `npx tsx --test` runner).
**AC ✓** `test:x402` 57/57, full suite 150/150.

---

## Notes & nuances (please read)

- **Mint correctness (deliberate change).** The advertised asset now derives
  from the canonical `USDC_MINT` (`lib/network.ts`) instead of a stale
  hardcoded mint (`4zMMC9…`, Circle's shared devnet USDC) that **nothing else
  in the app used**. On devnet this resolves to the app's own faucet-minted
  test USDC (`F7RYRq…`, whose on-chain mint authority is the app's deployer
  wallet — confirmed via RPC), which is what the faucet, escrow and SDK all
  use; on mainnet it follows `USDC_MINT` automatically. The old constant would
  have rejected **every real payment** as "wrong mint".

- **Frontend now fails closed (intended).** `app/chat/[id]/page.tsx` still
  builds a fake `x402:` token (line ~285). With the bypass gone it is rejected,
  and the existing `402` "Payment verification failed" UI handles it — no
  crash, no infinite spinner. **Wiring the chat UI to construct a real USDC SPL
  transfer is separate frontend work** (pairs with C-038) and is intentionally
  out of scope here. Paid-agent chat from the UI will not succeed until that
  lands.

- **C-033 scope.** We validate the documented schema shape and the Solana
  "exact" scheme exactly; full byte-level interop against a specific reference
  client/facilitator SDK is exercised by the optional facilitator path (C-035)
  and belongs to the MCP/E2E milestones (C-126/C-130+).

- **Testability by design.** Verification IO is dependency-injected
  (`fetchTransaction`, `verifyViaFacilitator`) and the replay/idempotency and
  reconcile decisions are pure functions, so everything is unit-tested without
  a live chain or DB. The Prisma client is lazy-imported in `x402-payments.ts`
  so importing the pure helpers in a test does not fire the cold-start schema
  sync.

- **Migrations / ops.** `X402Payment` and `AgentRevenue.paymentTx` are added to
  both `schema.prisma` and the idempotent `ensureSchema()` runtime migration in
  `lib/prisma.ts` (the repo's established pattern), so production picks them up
  on cold start with no manual migration. New optional env var:
  `X402_FACILITATOR_URL` (unset = direct RPC verification).

- **No scope creep.** Verification is unit-tested against **mocked transaction
  metadata**, not live devnet — appropriate for a backend-only, no-manual-test
  change. There are no mock/placeholder paths left in production code; the only
  mocks are test doubles.

## How to run

```bash
cd app
npm run test:x402   # 57/57 — the C-030…C-039 gate
npm test            # 150/150 — full unit suite
npx tsc --noEmit    # clean
```

## Not in this PR

- **C-038** (x402 error UX) — frontend, requires manual UI testing.
- Wiring the chat UI to make a real USDC payment (frontend follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
