### PR TITLE
Harden webhook signatures against replay

### DIFF
--- a/app/app/integrate/page.tsx
+++ b/app/app/integrate/page.tsx
@@ -93,19 +93,29 @@ connection.onLogs(COVENANT_PROGRAM_ID, (logs) => {
     label: "Webhook",
     lang: "typescript",
     code: `// Register a webhook so Covenant pings your server when state changes.
-// HMAC-signed Stripe-style: t=<unix>,v1=<hex>
+// HMAC-signed Stripe-style: t=<unix>,d=<delivery>,v1=<hex>
 import crypto from "node:crypto";
 
-function verifyCovenantSignature(req: Request, secret: string): boolean {
-  const header = req.headers.get("covenant-signature") ?? "";
-  const [tPart, vPart] = header.split(",");
-  const t = tPart.split("=")[1];
-  const v1 = vPart.split("=")[1];
+const seenDeliveries = new Set<string>(); // Replace with durable storage in production.
+
+async function verifyCovenantSignature(req: Request, secret: string): Promise<boolean> {
+  const header = req.headers.get("x-covenant-signature") ?? "";
+  const parts = Object.fromEntries(header.split(",").map((p) => p.split("=")));
+  const t = parts.t;
+  const d = parts.d;
+  const v1 = parts.v1;
+  if (!t || !d || !v1 || seenDeliveries.has(d)) return false;
+  if (Math.abs(Date.now() - Number(t)) > 5 * 60_000) return false;
+  const body = await req.text();
   const expected = crypto
     .createHmac("sha256", secret)
-    .update(\`\${t}.\${req.body}\`)
+    .update(\`\${t}.\${d}.\${body}\`)
     .digest("hex");
-  return crypto.timingSafeEqual(Buffer.from(v1), Buffer.from(expected));
+  const ok =
+    expected.length === v1.length &&
+    crypto.timingSafeEqual(Buffer.from(v1, "hex"), Buffer.from(expected, "hex"));
+  if (ok) seenDeliveries.add(d);
+  return ok;
 }
 
 // Subscribe via POST /api/webhooks { url, events: ["job.delivered","job.finalized"] }`,

--- a/app/lib/webhooks.ts
+++ b/app/lib/webhooks.ts
@@ -77,20 +77,30 @@ export interface WebhookSignOptions {
   secret: string;
   /** Defaults to Date.now() — override for deterministic tests. */
   timestampMs?: number;
+  /** Stable delivery attempt id, signed so receivers can reject replays. */
+  deliveryId?: string;
+}
+
+export interface WebhookReplayCache {
+  has(deliveryId: string): boolean;
+  add(deliveryId: string): void;
 }
 
 /**
  * Build a signed `X-Covenant-Signature` header value for a given
- * payload. Format mirrors Stripe's: `t=<unix>,v1=<hex>`.
+ * payload. Format mirrors Stripe's: `t=<unix>,d=<delivery>,v1=<hex>`.
  *
- * The signed string is `${timestampMs}.${rawBody}` so a receiver
- * who only has the rendered text can verify without re-serializing.
+ * If a delivery id is provided, the signed string is
+ * `${timestampMs}.${deliveryId}.${rawBody}` so receivers can reject
+ * replays without allowing an attacker to swap the delivery id.
  */
 export function signWebhook(rawBody: string, opts: WebhookSignOptions): string {
   const ts = opts.timestampMs ?? Date.now();
-  const payload = `${ts}.${rawBody}`;
+  const payload = opts.deliveryId
+    ? `${ts}.${opts.deliveryId}.${rawBody}`
+    : `${ts}.${rawBody}`;
   const mac = crypto.createHmac("sha256", opts.secret).update(payload).digest("hex");
-  return `t=${ts},v1=${mac}`;
+  return opts.deliveryId ? `t=${ts},d=${opts.deliveryId},v1=${mac}` : `t=${ts},v1=${mac}`;
 }
 
 /**
@@ -103,8 +113,9 @@ export function signWebhook(rawBody: string, opts: WebhookSignOptions): string {
 export function verifyWebhookSignature(args: {
   header: string | null | undefined;
   body: string;
-  secret: string;
+  secret: string | readonly string[];
   toleranceMs?: number;
+  replayCache?: WebhookReplayCache;
 }): boolean {
   if (!args.header) return false;
   const tolerance = args.toleranceMs ?? 5 * 60_000;
@@ -116,17 +127,34 @@ export function verifyWebhookSignature(args: {
   }, {});
   const ts = Number(parts.t);
   const v1 = parts.v1;
+  const deliveryId = parts.d;
   if (!ts || !v1) return false;
   if (Math.abs(Date.now() - ts) > tolerance) return false;
+  if (args.replayCache) {
+    if (!deliveryId) return false;
+    if (args.replayCache.has(deliveryId)) return false;
+  }
 
-  const expected = crypto
-    .createHmac("sha256", args.secret)
-    .update(`${ts}.${args.body}`)
-    .digest("hex");
+  const payload = deliveryId ? `${ts}.${deliveryId}.${args.body}` : `${ts}.${args.body}`;
+  const secrets = Array.isArray(args.secret) ? args.secret : [args.secret];
 
-  // Constant-time comparison to avoid timing attacks.
-  if (expected.length !== v1.length) return false;
-  return crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(v1, "hex"));
+  for (const secret of secrets) {
+    const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+    const expectedBytes = Buffer.from(expected, "hex");
+    const actualBytes = Buffer.from(v1, "hex");
+
+    // Constant-time comparison to avoid timing attacks.
+    if (
+      expected.length === v1.length &&
+      expectedBytes.length === actualBytes.length &&
+      crypto.timingSafeEqual(expectedBytes, actualBytes)
+    ) {
+      args.replayCache?.add(deliveryId!);
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -190,8 +218,11 @@ export async function deliverWebhook(
       await sleep(Math.min(125_000, 1000 * Math.pow(5, attempt - 2)));
     }
 
-    const signature = signWebhook(rawBody, { secret: opts.secret });
     const deliveryId = `${event.id}-${attempt}`;
+    const signature = signWebhook(rawBody, {
+      secret: opts.secret,
+      deliveryId,
+    });
     const t0 = Date.now();
     const controller = new AbortController();
     const tHandle = setTimeout(() => controller.abort(), timeout);

--- a/app/tests/unit/webhooks.test.ts
+++ b/app/tests/unit/webhooks.test.ts
@@ -81,6 +81,76 @@ describe("signWebhook + verifyWebhookSignature", () => {
     assert.equal(r1, false);
     assert.equal(r2, false);
   });
+
+  test("rejects malformed hex signatures without throwing", () => {
+    const ok = verifyWebhookSignature({
+      header: `t=${Date.now()},v1=${"z".repeat(64)}`,
+      body: "x",
+      secret: "sk",
+    });
+    assert.equal(ok, false);
+  });
+
+  test("rejects replayed delivery ids when a replay cache is provided", () => {
+    const body = JSON.stringify({ id: "evt_replay", type: "job.finalized" });
+    const header = signWebhook(body, {
+      secret: "sk",
+      deliveryId: "evt_replay-1",
+    });
+    const replayCache = new Set<string>();
+    const first = verifyWebhookSignature({
+      header,
+      body,
+      secret: "sk",
+      replayCache,
+    });
+    const second = verifyWebhookSignature({
+      header,
+      body,
+      secret: "sk",
+      replayCache,
+    });
+    assert.equal(first, true);
+    assert.equal(second, false);
+  });
+
+  test("requires a signed delivery id when replay protection is enabled", () => {
+    const body = "x";
+    const header = signWebhook(body, { secret: "sk" });
+    const ok = verifyWebhookSignature({
+      header,
+      body,
+      secret: "sk",
+      replayCache: new Set<string>(),
+    });
+    assert.equal(ok, false);
+  });
+
+  test("rejects delivery-id tampering", () => {
+    const body = "x";
+    const header = signWebhook(body, {
+      secret: "sk",
+      deliveryId: "evt_abc-1",
+    });
+    const tampered = header.replace("d=evt_abc-1", "d=evt_abc-2");
+    const ok = verifyWebhookSignature({
+      header: tampered,
+      body,
+      secret: "sk",
+    });
+    assert.equal(ok, false);
+  });
+
+  test("accepts any active secret during rotation", () => {
+    const body = "x";
+    const header = signWebhook(body, { secret: "previous-secret" });
+    const ok = verifyWebhookSignature({
+      header,
+      body,
+      secret: ["current-secret", "previous-secret"],
+    });
+    assert.equal(ok, true);
+  });
 });
 
 describe("generateEventId", () => {
@@ -148,7 +218,10 @@ describe("deliverWebhook", () => {
     assert.equal(result.attempts[0].status_code, 200);
     assert.ok(receivedHeaders);
     assert.equal(receivedHeaders!["x-covenant-event"], "job.created");
-    assert.match(receivedHeaders!["x-covenant-signature"], /^t=\d+,v1=[a-f0-9]+$/);
+    assert.match(
+      receivedHeaders!["x-covenant-signature"],
+      /^t=\d+,d=evt_.+-1,v1=[a-f0-9]+$/,
+    );
     assert.match(receivedHeaders!["x-covenant-delivery"], /^evt_.+-1$/);
     assert.equal(JSON.parse(receivedBody!).id, event.id);
   });


### PR DESCRIPTION
## Summary
- sign each outbound webhook attempt with its delivery id (`t=...,d=...,v1=...`) so receivers can reject replayed deliveries without trusting an unsigned header
- add optional replay-cache enforcement to `verifyWebhookSignature` and reject unsigned delivery ids when replay protection is enabled
- allow verification against multiple active secrets for rotation windows
- update the integration snippet to verify `X-Covenant-Signature`, timestamp freshness, signed delivery id, and replay cache state

Fixes #146.

## Validation
- `npx tsx --test tests/unit/webhooks.test.ts` -> 20 tests passed
- `npx tsc --noEmit`
- `npx eslint lib/webhooks.ts tests/unit/webhooks.test.ts app/integrate/page.tsx`
- `git diff --check`
- `NEXT_TELEMETRY_DISABLED=1 npx next build` exited 0 and compiled successfully, but local build output is noisy because this checkout has no `DATABASE_URL` for static data collection and Next reports the lockfile is missing SWC dependency metadata.

Install note: `npm ci` is blocked by existing repo state (`@x402/next@2.10.0` peer wants Next 16 while the app pins Next 14, and the lockfile has an `@anthropic-ai/sdk` mismatch). I used `npm install --legacy-peer-deps --package-lock=false` locally to validate without changing the lockfile.