### PR TITLE
feat(m1): server-side on-chain verification, reconciliation, failure handling - Closes #51, #53, #62, #64, #66

### DIFF
--- a/app/app/api/jobs/[id]/accept/route.ts
+++ b/app/app/api/jobs/[id]/accept/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { sendMarkerTransaction } from "@/lib/solana";
+import { PublicKey } from "@solana/web3.js";
+import {
+  fetchJobEscrow,
+  deriveJobPda,
+  verifyTxInvokedCovenant,
+} from "@/lib/program-server";
+import { checkAcceptJob } from "@/lib/onchain-verify";
+import { classifySolanaError } from "@/lib/solana-errors";
 
 /**
  * POST /api/jobs/[id]/accept
@@ -22,7 +30,7 @@ export async function POST(
   try {
     const { id } = await params;
     const body = await request.json();
-    const { takerWallet } = body;
+    const { takerWallet, txHash: acceptTxHash } = body;
 
     if (!takerWallet || typeof takerWallet !== "string") {
       return NextResponse.json(
@@ -69,6 +77,40 @@ export async function POST(
         { error: "You already accepted this job", interest: existing },
         { status: 409 },
       );
+    }
+
+    // C-012b: when the taker signed accept_job on chain (passes a txHash),
+    // mirror only after confirming the on-chain JobEscrow binds them as taker
+    // and is Accepted. A mismatched submitter is rejected — no DB row written.
+    if (acceptTxHash && typeof acceptTxHash === "string") {
+      try {
+        await verifyTxInvokedCovenant(acceptTxHash);
+        const jobPda = job.pda
+          ? new PublicKey(job.pda)
+          : deriveJobPda(
+              new PublicKey(job.posterWallet),
+              Buffer.from(job.specHash, "hex"),
+            )[0];
+        const escrow = await fetchJobEscrow(jobPda);
+        const verdict = checkAcceptJob(escrow, takerWallet);
+        if (!verdict.ok) {
+          return NextResponse.json(
+            { error: `accept_job verification failed: ${verdict.reason}` },
+            { status: 400 },
+          );
+        }
+      } catch (err) {
+        const cls = classifySolanaError(err);
+        return NextResponse.json(
+          {
+            error: "accept_job verification failed. No DB row written.",
+            detail: err instanceof Error ? err.message : String(err),
+            failureMode: cls.mode,
+            retryable: cls.retryable,
+          },
+          { status: cls.mode === "rate_limited" ? 503 : 400 },
+        );
+      }
     }
 
     // Create interest + update job status atomically

--- a/app/app/api/jobs/[id]/route.ts
+++ b/app/app/api/jobs/[id]/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import { PublicKey } from "@solana/web3.js";
 import { prisma } from "@/lib/prisma";
+import { fetchJobEscrow } from "@/lib/program-server";
+import { reconcileJobRow } from "@/lib/onchain-verify";
 
 export async function GET(
   _request: NextRequest,
@@ -24,6 +27,26 @@ export async function GET(
 
     if (!job) {
       return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+
+    // C-021: chain is the source of truth — heal any DB drift on read. If the
+    // RPC is unreachable, fall back to the DB mirror (non-fatal).
+    if (job.pda) {
+      try {
+        const escrow = await fetchJobEscrow(new PublicKey(job.pda));
+        if (escrow) {
+          const { drifted, updates } = reconcileJobRow(
+            { status: job.status, takerWallet: job.takerWallet, amount: job.amount },
+            escrow,
+          );
+          if (drifted) {
+            await prisma.job.update({ where: { id: job.id }, data: updates });
+            Object.assign(job, updates);
+          }
+        }
+      } catch (err) {
+        console.error("[jobs/[id]] on-read reconcile (non-fatal):", err);
+      }
     }
 
     return NextResponse.json(job);

--- a/app/app/api/jobs/route.ts
+++ b/app/app/api/jobs/route.ts
@@ -13,6 +13,9 @@ import {
   verifyTxInvokedCovenant,
   keypairFromEnv,
 } from "@/lib/program-server";
+import { checkCreateJob } from "@/lib/onchain-verify";
+import { classifySolanaError } from "@/lib/solana-errors";
+import { USDC_MINT } from "@/lib/constants";
 
 export async function GET(request: NextRequest) {
   try {
@@ -418,16 +421,17 @@ export async function POST(request: NextRequest) {
           `Tx may have been for a different spec hash.`,
         );
       }
-      if (onchain.poster !== posterWallet) {
-        throw new Error(
-          `JobEscrow.poster mismatch (on-chain ${onchain.poster.slice(0, 8)}… vs ` +
-          `claimed ${posterWallet.slice(0, 8)}…)`,
-        );
-      }
-      if (Math.abs(onchain.amount - amount) > 1e-6) {
-        throw new Error(
-          `JobEscrow.amount mismatch (on-chain ${onchain.amount} vs claimed ${amount})`,
-        );
+      // C-011: the escrow must be ours, hold the stated amount AND the required
+      // USDC mint (not a forged worthless token), at the PDA derived from
+      // [b"job", poster, spec_hash]. Reject mismatches — no DB row is written.
+      const verdict = checkCreateJob(onchain, {
+        poster: posterWallet,
+        specHashHex: specHash,
+        minAmountAtomic: BigInt(Math.round(amount * 1_000_000)),
+        mint: USDC_MINT.toBase58(),
+      });
+      if (!verdict.ok) {
+        throw new Error(verdict.reason);
       }
 
       // 3) Mirror to DB. Replay protection: txHash is unique per Job row.
@@ -470,13 +474,18 @@ export async function POST(request: NextRequest) {
       );
     } catch (err) {
       console.error("[create_job] on-chain verification failed:", err);
+      // C-023: classify the failure so the caller gets a clear, actionable
+      // error (and retryable RPC blips read as 503). No DB row was written —
+      // verification happens before any create.
+      const cls = classifySolanaError(err);
       return NextResponse.json(
         {
-          error:
-            "On-chain create_job verification failed. No DB row written. " +
-            (err instanceof Error ? err.message : String(err)),
+          error: "On-chain create_job verification failed. No DB row written.",
+          detail: err instanceof Error ? err.message : String(err),
+          failureMode: cls.mode,
+          retryable: cls.retryable,
         },
-        { status: 400 },
+        { status: cls.mode === "rate_limited" ? 503 : 400 },
       );
     }
   } catch (error) {

--- a/app/lib/compute-budget.ts
+++ b/app/lib/compute-budget.ts
@@ -1,0 +1,45 @@
+/**
+ * Compute-budget + priority-fee instructions for lifecycle txs (C-025).
+ *
+ * Under network load a transaction with the default compute budget and no
+ * priority fee can fail to land. Prepending a `SetComputeUnitLimit` +
+ * `SetComputeUnitPrice` pair raises the odds the tx confirms during
+ * congestion — important on mainnet. Tunable via env so ops can react to
+ * fee markets without a redeploy.
+ */
+
+import { ComputeBudgetProgram, type TransactionInstruction } from "@solana/web3.js";
+
+/** Default per-tx compute-unit ceiling — generous for our lifecycle ixs. */
+export const DEFAULT_COMPUTE_UNIT_LIMIT = 200_000;
+/** Default priority fee in micro-lamports per compute unit. */
+export const DEFAULT_PRIORITY_FEE_MICROLAMPORTS = 1_000;
+
+/** Compute-unit limit from `COMPUTE_UNIT_LIMIT`, else the default. */
+export function computeUnitLimit(): number {
+  const v = Number(process.env.COMPUTE_UNIT_LIMIT);
+  return Number.isFinite(v) && v > 0 ? Math.floor(v) : DEFAULT_COMPUTE_UNIT_LIMIT;
+}
+
+/** Priority fee (micro-lamports/CU) from `PRIORITY_FEE_MICROLAMPORTS`, else default. */
+export function priorityFeeMicroLamports(): number {
+  const v = Number(process.env.PRIORITY_FEE_MICROLAMPORTS);
+  return Number.isFinite(v) && v >= 0 ? Math.floor(v) : DEFAULT_PRIORITY_FEE_MICROLAMPORTS;
+}
+
+/**
+ * Build the `[SetComputeUnitLimit, SetComputeUnitPrice]` instructions to
+ * prepend (via `.preInstructions(...)`) to a lifecycle transaction so it
+ * lands under load (C-025).
+ */
+export function computeBudgetInstructions(opts?: {
+  units?: number;
+  microLamports?: number;
+}): TransactionInstruction[] {
+  const units = opts?.units ?? computeUnitLimit();
+  const microLamports = opts?.microLamports ?? priorityFeeMicroLamports();
+  return [
+    ComputeBudgetProgram.setComputeUnitLimit({ units }),
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
+  ];
+}

--- a/app/lib/onchain-verify.ts
+++ b/app/lib/onchain-verify.ts
@@ -1,0 +1,164 @@
+/**
+ * On-chain verification + reconciliation (M1).
+ *
+ * Pure decision functions: given an already-fetched on-chain `JobEscrow`
+ * view plus the values a request claims, decide whether to trust the request.
+ * No RPC, no Prisma — the route fetches the escrow (via lib/program-server)
+ * and passes it here, so this logic is fully unit-testable without a chain.
+ *
+ *   - C-011: checkCreateJob  — escrow holds the stated amount + mint, the PDA
+ *            derived from [b"job", poster, spec_hash] matches, poster matches.
+ *   - C-012b: checkAcceptJob — on-chain taker == submitter and status Accepted.
+ *   - C-021: reconcileJobRow — compute the DB fields that drifted from chain.
+ */
+
+/** The subset of an on-chain JobEscrow these checks read (see program-server). */
+export interface EscrowView {
+  poster: string;
+  taker: string;
+  tokenMint: string;
+  /** Human-unit amount (informational). */
+  amount: number;
+  /** Atomic amount — authoritative for the under-funded check. */
+  amountAtomic: bigint;
+  specHashHex: string;
+  status: string;
+}
+
+export type VerifyResult = { ok: true } | { ok: false; reason: string };
+
+/** Solana's all-zero pubkey, used by the program for "no taker yet". */
+export const SYSTEM_ZERO_PUBKEY = "11111111111111111111111111111111";
+
+/* ------------------------------------------------------------------ */
+/*  C-011 — create_job verification                                    */
+/* ------------------------------------------------------------------ */
+
+export interface CreateJobExpectation {
+  poster: string;
+  specHashHex: string;
+  /** Minimum atomic amount the escrow must hold (reject under-funding). */
+  minAmountAtomic: bigint;
+  /** Required token mint (USDC). */
+  mint: string;
+}
+
+/**
+ * Verify a confirmed `create_job` escrow matches what the request claims
+ * (C-011). The caller must separately confirm the tx invoked our program
+ * (`verifyTxInvokedCovenant`) and that the escrow was fetched at the PDA
+ * derived from `[b"job", poster, spec_hash]`.
+ */
+export function checkCreateJob(
+  escrow: EscrowView | null,
+  expect: CreateJobExpectation,
+): VerifyResult {
+  if (!escrow) {
+    return { ok: false, reason: "JobEscrow PDA not found after the tx confirmed" };
+  }
+  if (escrow.poster !== expect.poster) {
+    return {
+      ok: false,
+      reason: `escrow poster mismatch (on-chain ${escrow.poster} vs claimed ${expect.poster})`,
+    };
+  }
+  if (escrow.specHashHex !== expect.specHashHex) {
+    return { ok: false, reason: "escrow spec_hash does not match the submitted spec" };
+  }
+  if (escrow.tokenMint !== expect.mint) {
+    return {
+      ok: false,
+      reason: `escrow holds the wrong mint (${escrow.tokenMint}, expected USDC ${expect.mint})`,
+    };
+  }
+  if (escrow.amountAtomic < expect.minAmountAtomic) {
+    return {
+      ok: false,
+      reason: `under-funded escrow: holds ${escrow.amountAtomic}, requires ${expect.minAmountAtomic}`,
+    };
+  }
+  return { ok: true };
+}
+
+/* ------------------------------------------------------------------ */
+/*  C-012b — accept_job verification                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Verify an on-chain `accept_job` bound the submitter as taker (C-012b).
+ * Mirror to the DB only when this returns ok.
+ */
+export function checkAcceptJob(
+  escrow: EscrowView | null,
+  submitter: string,
+): VerifyResult {
+  if (!escrow) {
+    return { ok: false, reason: "JobEscrow not found on chain" };
+  }
+  if (escrow.taker !== submitter) {
+    return {
+      ok: false,
+      reason: `on-chain taker (${escrow.taker}) does not match submitter (${submitter})`,
+    };
+  }
+  if (escrow.status !== "Accepted") {
+    return {
+      ok: false,
+      reason: `on-chain status is '${escrow.status}', expected 'Accepted'`,
+    };
+  }
+  return { ok: true };
+}
+
+/* ------------------------------------------------------------------ */
+/*  C-021 — DB ↔ chain reconciliation                                  */
+/* ------------------------------------------------------------------ */
+
+export interface JobRowView {
+  status: string;
+  takerWallet: string | null;
+  amount: number;
+}
+
+export interface JobRowRepair {
+  status?: string;
+  takerWallet?: string;
+  amount?: number;
+}
+
+export interface ReconcileResult {
+  drifted: boolean;
+  /** The DB fields to overwrite from chain (empty when in sync). */
+  updates: JobRowRepair;
+}
+
+/**
+ * Compute how a DB Job row has drifted from its on-chain JobEscrow, treating
+ * the chain as the source of truth (C-021). Returns the fields to overwrite;
+ * applying them heals a corrupted/stale mirror.
+ */
+export function reconcileJobRow(
+  db: JobRowView,
+  escrow: EscrowView,
+): ReconcileResult {
+  const updates: JobRowRepair = {};
+
+  if (escrow.status && escrow.status !== "Unknown" && db.status !== escrow.status) {
+    updates.status = escrow.status;
+  }
+
+  const chainTaker =
+    escrow.taker && escrow.taker !== SYSTEM_ZERO_PUBKEY ? escrow.taker : null;
+  if (chainTaker && db.takerWallet !== chainTaker) {
+    updates.takerWallet = chainTaker;
+  }
+
+  if (
+    Number.isFinite(escrow.amount) &&
+    Math.abs(db.amount - escrow.amount) > 1e-6
+  ) {
+    updates.amount = escrow.amount;
+  }
+
+  return { drifted: Object.keys(updates).length > 0, updates };
+}

--- a/app/lib/program-server.ts
+++ b/app/lib/program-server.ts
@@ -37,6 +37,7 @@ import {
   USDC_DECIMALS,
 } from "./constants";
 import { createFailoverConnection } from "./rpc-failover";
+import { computeBudgetInstructions } from "./compute-budget";
 
 // ---------- Connection ----------
 
@@ -353,6 +354,7 @@ export async function botCreateJob(params: {
       new BN(deadline),
       new BN(challengePeriod),
     )
+    .preInstructions(computeBudgetInstructions())
     .accounts({
       poster: botKeypair.publicKey,
       config: configPda,
@@ -396,6 +398,7 @@ export async function botAcceptJob(params: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (await (program.methods as any)
     .acceptJob(Array.from(specHash))
+    .preInstructions(computeBudgetInstructions())
     .accounts({
       taker: takerBotKeypair.publicKey,
       jobEscrow: jobPda,
@@ -421,6 +424,7 @@ export async function botSubmitWork(params: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (await (program.methods as any)
     .submitWork(Array.from(workHash), deliveryUri)
+    .preInstructions(computeBudgetInstructions())
     .accounts({
       taker: takerBotKeypair.publicKey,
       jobEscrow: jobPda,
@@ -450,6 +454,7 @@ export async function botFinalizePayment(params: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (await (program.methods as any)
     .finalizePayment()
+    .preInstructions(computeBudgetInstructions())
     .accounts({
       crank: crankKeypair.publicKey,
       jobEscrow: jobPda,

--- a/app/lib/solana-errors.ts
+++ b/app/lib/solana-errors.ts
@@ -1,0 +1,143 @@
+/**
+ * Solana failure-mode classifier (C-023).
+ *
+ * Every signed on-chain flow can fail in a handful of well-known ways. This
+ * maps a raw error (from web3.js / Anchor / the RPC) to a stable category, a
+ * user-facing message, and whether a retry could help — so routes return a
+ * clear error instead of a 500 stack, and callers can decide to retry vs
+ * surface. Pure + synchronous; the per-mode behavior is unit-tested.
+ *
+ * Pair with the "verify before you write" rule: classify the failure and
+ * return *before* any DB mutation, so a failed tx never half-commits the DB.
+ */
+
+export type SolanaFailureMode =
+  | "blockhash_expired"
+  | "insufficient_sol"
+  | "ata_not_found"
+  | "simulation_failed"
+  | "rate_limited"
+  | "tx_reverted"
+  | "unknown";
+
+export interface ClassifiedSolanaError {
+  mode: SolanaFailureMode;
+  /** Safe, user-facing message. */
+  message: string;
+  /** Whether retrying the same operation could succeed. */
+  retryable: boolean;
+}
+
+function errorText(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) {
+    // Anchor/web3 errors often stash detail in `.logs`.
+    const logs = (err as { logs?: unknown }).logs;
+    const logStr = Array.isArray(logs) ? " " + logs.join(" ") : "";
+    return `${err.name}: ${err.message}${logStr}`;
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+/**
+ * Classify a Solana error into one of the known failure modes (C-023).
+ * Order matters: more specific patterns are tested before generic ones.
+ */
+export function classifySolanaError(err: unknown): ClassifiedSolanaError {
+  const text = errorText(err).toLowerCase();
+
+  // RPC rate limiting — almost always transient.
+  if (
+    text.includes("429") ||
+    text.includes("too many requests") ||
+    text.includes("rate limit") ||
+    text.includes("rate-limit")
+  ) {
+    return {
+      mode: "rate_limited",
+      message: "The network is busy (RPC rate limit). Please try again in a moment.",
+      retryable: true,
+    };
+  }
+
+  // Blockhash expired — the tx wasn't landed in time; rebuild + resend.
+  if (
+    text.includes("blockhash not found") ||
+    text.includes("blockhashnotfound") ||
+    text.includes("block height exceeded") ||
+    text.includes("blockheightexceeded") ||
+    text.includes("transactionexpired")
+  ) {
+    return {
+      mode: "blockhash_expired",
+      message: "The transaction expired before it landed. Please retry.",
+      retryable: true,
+    };
+  }
+
+  // Missing associated token account.
+  if (
+    text.includes("tokenaccountnotfound") ||
+    text.includes("could not find account") ||
+    text.includes("account does not exist") ||
+    text.includes("associated token account")
+  ) {
+    return {
+      mode: "ata_not_found",
+      message: "A required token account is missing. Create your USDC account and retry.",
+      retryable: false,
+    };
+  }
+
+  // Insufficient SOL for fees / rent. ("Attempt to debit an account but found
+  // no record of a prior credit" is the canonical fee-payer-has-no-SOL error.)
+  if (
+    text.includes("insufficient lamports") ||
+    text.includes("insufficient funds for rent") ||
+    text.includes("insufficient funds for fee") ||
+    text.includes("attempt to debit an account but found no record")
+  ) {
+    return {
+      mode: "insufficient_sol",
+      message: "Not enough SOL to pay network fees. Fund the wallet and retry.",
+      retryable: false,
+    };
+  }
+
+  // Generic simulation failure (constraint violations, program errors).
+  if (
+    text.includes("transaction simulation failed") ||
+    text.includes("simulation failed") ||
+    text.includes("sendtransactionerror")
+  ) {
+    return {
+      mode: "simulation_failed",
+      message: "The transaction failed simulation and was not sent. No changes were made.",
+      retryable: false,
+    };
+  }
+
+  // Tx landed but reverted on chain.
+  if (
+    text.includes("reverted") ||
+    text.includes("instructionerror") ||
+    text.includes("custom program error")
+  ) {
+    return {
+      mode: "tx_reverted",
+      message: "The transaction was rejected on chain. No changes were made.",
+      retryable: false,
+    };
+  }
+
+  return {
+    mode: "unknown",
+    message: "An unexpected on-chain error occurred. No changes were made.",
+    retryable: false,
+  };
+}

--- a/app/tests/unit/compute-budget.test.ts
+++ b/app/tests/unit/compute-budget.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for lib/compute-budget (C-025).
+ *
+ * Run with:  npx tsx --test tests/unit/compute-budget.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { ComputeBudgetProgram } from "@solana/web3.js";
+import {
+  computeBudgetInstructions,
+  computeUnitLimit,
+  priorityFeeMicroLamports,
+  DEFAULT_COMPUTE_UNIT_LIMIT,
+  DEFAULT_PRIORITY_FEE_MICROLAMPORTS,
+} from "../../lib/compute-budget";
+
+describe("computeBudgetInstructions", () => {
+  test("returns SetComputeUnitLimit + SetComputeUnitPrice for the ComputeBudget program", () => {
+    const ixs = computeBudgetInstructions({ units: 250_000, microLamports: 5_000 });
+    assert.equal(ixs.length, 2);
+    for (const ix of ixs) {
+      assert.ok(ix.programId.equals(ComputeBudgetProgram.programId));
+    }
+    // Instruction discriminators: 2 = SetComputeUnitLimit, 3 = SetComputeUnitPrice.
+    assert.equal(ixs[0].data[0], 2);
+    assert.equal(ixs[1].data[0], 3);
+    // The encoded params round-trip.
+    assert.equal(ixs[0].data.readUInt32LE(1), 250_000);
+    assert.equal(ixs[1].data.readBigUInt64LE(1), 5_000n);
+  });
+
+  test("uses the defaults when no opts are given", () => {
+    delete process.env.COMPUTE_UNIT_LIMIT;
+    delete process.env.PRIORITY_FEE_MICROLAMPORTS;
+    const ixs = computeBudgetInstructions();
+    assert.equal(ixs[0].data.readUInt32LE(1), DEFAULT_COMPUTE_UNIT_LIMIT);
+    assert.equal(ixs[1].data.readBigUInt64LE(1), BigInt(DEFAULT_PRIORITY_FEE_MICROLAMPORTS));
+  });
+});
+
+describe("env tunables", () => {
+  const ORIG_LIMIT = process.env.COMPUTE_UNIT_LIMIT;
+  const ORIG_FEE = process.env.PRIORITY_FEE_MICROLAMPORTS;
+  function restore() {
+    if (ORIG_LIMIT === undefined) delete process.env.COMPUTE_UNIT_LIMIT;
+    else process.env.COMPUTE_UNIT_LIMIT = ORIG_LIMIT;
+    if (ORIG_FEE === undefined) delete process.env.PRIORITY_FEE_MICROLAMPORTS;
+    else process.env.PRIORITY_FEE_MICROLAMPORTS = ORIG_FEE;
+  }
+
+  test("reads COMPUTE_UNIT_LIMIT / PRIORITY_FEE_MICROLAMPORTS", () => {
+    process.env.COMPUTE_UNIT_LIMIT = "300000";
+    process.env.PRIORITY_FEE_MICROLAMPORTS = "2500";
+    assert.equal(computeUnitLimit(), 300_000);
+    assert.equal(priorityFeeMicroLamports(), 2_500);
+    restore();
+  });
+
+  test("falls back to defaults on invalid env", () => {
+    process.env.COMPUTE_UNIT_LIMIT = "not-a-number";
+    process.env.PRIORITY_FEE_MICROLAMPORTS = "-5";
+    assert.equal(computeUnitLimit(), DEFAULT_COMPUTE_UNIT_LIMIT);
+    assert.equal(priorityFeeMicroLamports(), DEFAULT_PRIORITY_FEE_MICROLAMPORTS);
+    restore();
+  });
+});

--- a/app/tests/unit/onchain-verify.test.ts
+++ b/app/tests/unit/onchain-verify.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for lib/onchain-verify (C-011 / C-012b / C-021).
+ *
+ * Run with:  npx tsx --test tests/unit/onchain-verify.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  checkCreateJob,
+  checkAcceptJob,
+  reconcileJobRow,
+  SYSTEM_ZERO_PUBKEY,
+  type EscrowView,
+} from "../../lib/onchain-verify";
+
+const USDC = "F7RYRqCy8uWYxjxrXVhU3iUCRwa9bKBUTkGKktpyYueQ";
+const OTHER_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+function escrow(over: Partial<EscrowView> = {}): EscrowView {
+  return {
+    poster: "PosterWallet",
+    taker: "TakerWallet",
+    tokenMint: USDC,
+    amount: 5,
+    amountAtomic: 5_000_000n,
+    specHashHex: "abc123",
+    status: "Open",
+    ...over,
+  };
+}
+
+describe("checkCreateJob (C-011)", () => {
+  const expect = {
+    poster: "PosterWallet",
+    specHashHex: "abc123",
+    minAmountAtomic: 5_000_000n,
+    mint: USDC,
+  };
+
+  test("accepts a matching, fully-funded escrow", () => {
+    assert.deepEqual(checkCreateJob(escrow(), expect), { ok: true });
+  });
+
+  test("accepts an over-funded escrow", () => {
+    assert.equal(checkCreateJob(escrow({ amountAtomic: 6_000_000n }), expect).ok, true);
+  });
+
+  test("rejects when the PDA was not found", () => {
+    const r = checkCreateJob(null, expect);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /not found/);
+  });
+
+  test("rejects a poster mismatch", () => {
+    const r = checkCreateJob(escrow({ poster: "Attacker" }), expect);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /poster mismatch/);
+  });
+
+  test("rejects a spec_hash mismatch", () => {
+    const r = checkCreateJob(escrow({ specHashHex: "deadbeef" }), expect);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /spec_hash/);
+  });
+
+  test("rejects the wrong mint (forged-token escrow)", () => {
+    const r = checkCreateJob(escrow({ tokenMint: OTHER_MINT }), expect);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /wrong mint/);
+  });
+
+  test("rejects an under-funded escrow", () => {
+    const r = checkCreateJob(escrow({ amountAtomic: 4_999_999n }), expect);
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /under-funded/);
+  });
+});
+
+describe("checkAcceptJob (C-012b)", () => {
+  test("accepts when taker == submitter and status Accepted", () => {
+    assert.deepEqual(
+      checkAcceptJob(escrow({ taker: "Alice", status: "Accepted" }), "Alice"),
+      { ok: true },
+    );
+  });
+
+  test("rejects a mismatched submitter", () => {
+    const r = checkAcceptJob(escrow({ taker: "Alice", status: "Accepted" }), "Mallory");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /does not match submitter/);
+  });
+
+  test("rejects when the on-chain status is not Accepted", () => {
+    const r = checkAcceptJob(escrow({ taker: "Alice", status: "Open" }), "Alice");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /expected 'Accepted'/);
+  });
+
+  test("rejects when the escrow is missing", () => {
+    assert.equal(checkAcceptJob(null, "Alice").ok, false);
+  });
+});
+
+describe("reconcileJobRow (C-021)", () => {
+  test("reports no drift when in sync", () => {
+    const r = reconcileJobRow(
+      { status: "Accepted", takerWallet: "Alice", amount: 5 },
+      escrow({ status: "Accepted", taker: "Alice", amount: 5 }),
+    );
+    assert.equal(r.drifted, false);
+    assert.deepEqual(r.updates, {});
+  });
+
+  test("heals a corrupted status from chain", () => {
+    const r = reconcileJobRow(
+      { status: "Open", takerWallet: "Alice", amount: 5 },
+      escrow({ status: "Finalized", taker: "Alice", amount: 5 }),
+    );
+    assert.equal(r.drifted, true);
+    assert.equal(r.updates.status, "Finalized");
+  });
+
+  test("heals a missing taker from chain", () => {
+    const r = reconcileJobRow(
+      { status: "Accepted", takerWallet: null, amount: 5 },
+      escrow({ status: "Accepted", taker: "Bob", amount: 5 }),
+    );
+    assert.equal(r.updates.takerWallet, "Bob");
+  });
+
+  test("does not set taker when the chain has none (zero pubkey)", () => {
+    const r = reconcileJobRow(
+      { status: "Open", takerWallet: null, amount: 5 },
+      escrow({ status: "Open", taker: SYSTEM_ZERO_PUBKEY, amount: 5 }),
+    );
+    assert.equal(r.drifted, false);
+    assert.equal(r.updates.takerWallet, undefined);
+  });
+
+  test("heals a drifted amount", () => {
+    const r = reconcileJobRow(
+      { status: "Open", takerWallet: null, amount: 99 },
+      escrow({ status: "Open", taker: SYSTEM_ZERO_PUBKEY, amount: 5 }),
+    );
+    assert.equal(r.updates.amount, 5);
+  });
+
+  test("heals multiple drifted fields at once", () => {
+    const r = reconcileJobRow(
+      { status: "Open", takerWallet: null, amount: 1 },
+      escrow({ status: "Delivered", taker: "Carol", amount: 5 }),
+    );
+    assert.deepEqual(r.updates, { status: "Delivered", takerWallet: "Carol", amount: 5 });
+  });
+});

--- a/app/tests/unit/solana-errors.test.ts
+++ b/app/tests/unit/solana-errors.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for lib/solana-errors — failure-mode classifier (C-023).
+ * Each failure mode has a test (the AC).
+ *
+ * Run with:  npx tsx --test tests/unit/solana-errors.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { classifySolanaError } from "../../lib/solana-errors";
+
+describe("classifySolanaError", () => {
+  test("blockhash expiry", () => {
+    for (const e of [
+      new Error("failed to send transaction: Blockhash not found"),
+      new Error("block height exceeded"),
+      new Error("TransactionExpiredBlockheightExceededError: ..."),
+    ]) {
+      const r = classifySolanaError(e);
+      assert.equal(r.mode, "blockhash_expired");
+      assert.equal(r.retryable, true);
+    }
+  });
+
+  test("insufficient SOL for fees", () => {
+    for (const e of [
+      new Error("Attempt to debit an account but found no record of a prior credit."),
+      new Error("Transfer: insufficient lamports 0, need 5000"),
+      new Error("insufficient funds for rent"),
+    ]) {
+      const r = classifySolanaError(e);
+      assert.equal(r.mode, "insufficient_sol", e.message);
+      assert.equal(r.retryable, false);
+    }
+  });
+
+  test("ATA not found", () => {
+    for (const e of [
+      new Error("TokenAccountNotFoundError"),
+      new Error("could not find account"),
+      new Error("Provided associated token account is invalid"),
+    ]) {
+      assert.equal(classifySolanaError(e).mode, "ata_not_found", e.message);
+    }
+  });
+
+  test("simulation failed", () => {
+    const r = classifySolanaError(
+      new Error("Transaction simulation failed: Error processing Instruction 0"),
+    );
+    assert.equal(r.mode, "simulation_failed");
+    assert.match(r.message, /No changes were made/);
+  });
+
+  test("rate limited (429)", () => {
+    for (const e of [
+      new Error("429 Too Many Requests"),
+      new Error("server responded with rate limit exceeded"),
+    ]) {
+      const r = classifySolanaError(e);
+      assert.equal(r.mode, "rate_limited");
+      assert.equal(r.retryable, true);
+    }
+  });
+
+  test("tx reverted on chain", () => {
+    const r = classifySolanaError(new Error("Transaction reverted: custom program error: 0x1771"));
+    assert.equal(r.mode, "tx_reverted");
+  });
+
+  test("unknown fallback", () => {
+    const r = classifySolanaError(new Error("something totally unexpected"));
+    assert.equal(r.mode, "unknown");
+    assert.equal(r.retryable, false);
+  });
+
+  test("extracts detail from an error's .logs array", () => {
+    const err = Object.assign(new Error("Transaction failed"), {
+      logs: ["Program log: Instruction: Transfer", "Program log: insufficient lamports 0"],
+    });
+    assert.equal(classifySolanaError(err).mode, "insufficient_sol");
+  });
+
+  test("handles non-Error inputs without throwing", () => {
+    assert.equal(classifySolanaError(null).mode, "unknown");
+    assert.equal(classifySolanaError("429: too many requests").mode, "rate_limited");
+    assert.equal(classifySolanaError({ weird: true }).mode, "unknown");
+  });
+});


### PR DESCRIPTION
Wire the real Anchor program's **verification + safety rails** into the job
lifecycle backend — strict create/accept verification, on-read reconciliation,
Solana failure-mode handling, and compute-budget/priority fees.

**Backend only. No new transactions are sent** (signing the real
create/accept/submit/finalize txs from the browser is the frontend/devnet half
of M1 — C-010/012/013/014). Every decision here is a **pure function** that
takes an already-fetched on-chain escrow object, so it is 100% unit-testable
without a live chain (the `lib/x402-server` injectable-fetch pattern).

Closes #51, #53, #62, #64, #66

**1 commit · 10 files · +758 / −15 · 123/123 unit tests (30 new) · `tsc --noEmit` clean · no new dependencies · no prisma/schema changes.**

---

## Issue-by-issue

### C-011 · Server-side verification of create_job tx `#51` `security · blocker`
**What:** `/api/jobs` POST must confirm the tx invoked our program and the
escrow holds the stated **amount + mint** at the PDA derived from
`[b"job", poster, spec_hash]`.
**How / where:** new `lib/onchain-verify.ts::checkCreateJob()` — asserts the
escrow exists, `poster` + `spec_hash` match, the **mint == USDC** (the check
that was *missing* — a forged escrow could hold a worthless token), and
`amountAtomic >= required` (rejects under-funding). Wired into the human-wallet
path of `app/api/jobs/route.ts`; the existing `verifyTxInvokedCovenant` +
`deriveJobPda` + `fetchJobEscrow` plumbing stays.
**AC ✓** A forged or under-funded tx is rejected and **no DB row is written**
(verification precedes `prisma.job.create`).

### C-012b · Server verification of accept_job `#53`
**What:** mirror an acceptance only after confirming on-chain
`JobEscrow.taker == submitter` and `status == Accepted`.
**How / where:** new `checkAcceptJob()`; `app/api/jobs/[id]/accept` verifies
before writing **when the taker passes the on-chain accept tx signature**
(`txHash`). The existing competitive multi-taker `JobInterest` path is
untouched — verification is additive, only on the on-chain path.
**AC ✓** A mismatched submitter is rejected, no DB row written.

### C-021 · Reconcile DB mirror with on-chain `#62`
**What:** the chain is the source of truth; repair DB drift.
**How / where:** new `reconcileJobRow()` computes the fields (status / taker /
amount) where a DB `Job` row drifted from its on-chain `JobEscrow`.
`GET /api/jobs/[id]` heals the row on read; if the RPC is unreachable it serves
the DB mirror (non-fatal). This is distinct from the existing
`cron/reconcile`, which backfills `JobEvent` rows for missed webhooks.
**AC ✓** Corrupting a DB row is auto-healed from chain on next read.

### C-023 · Handle Solana failure modes in every signed flow `#64`
**What:** map each failure mode to a clear error + a safe DB state.
**How / where:** new `lib/solana-errors.ts::classifySolanaError()` maps
blockhash expiry, insufficient SOL, ATA-not-found, simulation failure, RPC 429
and on-chain revert to a stable `{ mode, message, retryable }`. Wired into the
`create_job` / `accept` catch blocks (a rate-limit reads as **503**).
Verification runs **before any DB write**, so a failed tx never half-commits.
**AC ✓** Each failure mode has a test; no half-commit.

### C-025 · Compute-budget + priority fee `#66`
**What:** lifecycle txs should land under load.
**How / where:** new `lib/compute-budget.ts` builds
`SetComputeUnitLimit` + `SetComputeUnitPrice` (tunable via
`COMPUTE_UNIT_LIMIT` / `PRIORITY_FEE_MICROLAMPORTS`), prepended via
`.preInstructions(...)` to the four bot lifecycle txs in `program-server.ts`
(create / accept / submit / finalize).
**AC ✓** The instructions are produced + attached correctly (unit-tested by
decoding the discriminators + params); landing under real congestion is the
devnet integration step.

---

## Notes & nuances

- **No live-chain dependency in tests.** `checkCreateJob` / `checkAcceptJob` /
  `reconcileJobRow` are pure — the route fetches the escrow via
  `lib/program-server` and passes the object in. So "forged mint rejected",
  "taker mismatch rejected", "drift healed" and every failure mode are
  unit-tested with plain objects, no devnet.
- **C-011 was partly there.** The route already checked program-invoked + PDA +
  poster + amount; this PR adds the **mint** assertion (the real gap) and makes
  it strict (atomic under-funded) via the shared pure function.
- **C-012b is additive.** It does not remove the multi-taker `JobInterest`
  design; on-chain verification only runs when an accept `txHash` is supplied
  (that's produced by the frontend C-012 work).
- **What's still frontend/devnet (not here):** actually *sending* the real
  create/accept/submit/finalize txs and confirming "USDC moves on Explorer"
  (C-010/012/013/014, C-019/020) — those need a wallet/bot signer on devnet.

## ⚠️ Merge-conflict risk

- **vs PR #231 (M0 cleanup):** `app/app/api/jobs/route.ts` and
  `app/app/api/jobs/[id]/accept/route.ts` are touched by **both** — #231 adds a
  `blockSimulatedRouteIfOnchain` guard at the **top** of each POST; this PR adds
  verification logic in the **body**. Different regions → should auto-merge; if
  it conflicts, **keep both** (guard then verify). `jobs/[id]/route.ts`,
  `program-server.ts` and the new libs are touched only here.
- **vs #228 (x402) / #230 (M6):** no overlap. No `prisma/schema.prisma` or
  `lib/prisma.ts` changes here.

## Testing
```bash
cd app
npx tsx --test tests/unit/*.test.ts   # 123/123 (30 new: onchain-verify, solana-errors, compute-budget)
npx tsc --noEmit                      # clean
```

> Lint note: running standalone `eslint` on `program-server.ts` prints
> "rule '@typescript-eslint/no-explicit-any' not found" for its **pre-existing**
> `as any` disable comments (13 on `main` before this PR too). `next lint` /
> CI loads the plugin and is unaffected; the changes here add no `any`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
