### PR TITLE
feat(backend): credit-market tests, mutating-endpoint auth (flag-gated), tx-sig logging

### DIFF
--- a/app/app/api/agents/stake/route.ts
+++ b/app/app/api/agents/stake/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { enforceIpLimit } from "@/lib/rateLimit";
+import { requireAuth } from "@/lib/require-auth";
 
 /**
  * POST /api/agents/stake
@@ -13,7 +14,11 @@ export async function POST(req: NextRequest) {
     const limited = await enforceIpLimit(req, "stake");
     if (limited) return limited;
 
-    const body = await req.json();
+    const __raw = await req.text();
+    const __auth = await requireAuth(req, { rawBody: __raw });
+    if (!__auth.ok)
+      return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
+    const body = __raw ? JSON.parse(__raw) : {};
     const { walletAddress, amount } = body as {
       walletAddress?: string;
       amount?: number;

--- a/app/app/api/claims/[id]/buy/route.ts
+++ b/app/app/api/claims/[id]/buy/route.ts
@@ -6,6 +6,8 @@ import {
   verifyTxInvokedCovenant,
 } from "@/lib/credit-server";
 import { PublicKey } from "@solana/web3.js";
+import { requireAuth } from "@/lib/require-auth";
+import { log } from "@/lib/logger";
 
 /**
  * POST /api/claims/[id]/buy
@@ -24,7 +26,11 @@ export async function POST(
     const { id } = await params;
     const limited = await enforceIpLimit(req, "buy_claim");
     if (limited) return limited;
-    const body = await req.json();
+    const __raw = await req.text();
+    const __auth = await requireAuth(req, { rawBody: __raw });
+    if (!__auth.ok)
+      return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
+    const body = __raw ? JSON.parse(__raw) : {};
     const { buyerWallet, txSignature } = body as {
       buyerWallet?: string;
       txSignature?: string;
@@ -88,6 +94,12 @@ export async function POST(
         boughtAt: onchain.boughtAt > 0 ? new Date(onchain.boughtAt * 1000) : new Date(),
         buyTxHash: txSignature,
       },
+    });
+
+    log.forRequest(req).info("claim bought", {
+      claimId: id,
+      buyer: buyerWallet,
+      txHash: txSignature,
     });
 
     return NextResponse.json({ claim: updated });

--- a/app/app/api/disputes/route.ts
+++ b/app/app/api/disputes/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import crypto from "crypto";
 import { enforceIpLimit } from "@/lib/rateLimit";
+import { requireAuth } from "@/lib/require-auth";
 
 const DEFAULT_BOND_BPS = 1_000; // 10%
 const DEFAULT_MIN_BOND_ABSOLUTE = 1; // 1 USDC
@@ -56,7 +57,11 @@ export async function POST(request: NextRequest) {
     const limited = await enforceIpLimit(request, "raise_dispute_ip");
     if (limited) return limited;
 
-    const body = await request.json();
+    const __raw = await request.text();
+    const __auth = await requireAuth(request, { rawBody: __raw });
+    if (!__auth.ok)
+      return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
+    const body = __raw ? JSON.parse(__raw) : {};
     const { jobId, posterWallet, reasonText, bond, txHash } = body as {
       jobId?: string;
       posterWallet?: string;

--- a/app/app/api/faucet/route.ts
+++ b/app/app/api/faucet/route.ts
@@ -8,11 +8,17 @@ import {
   getLimit,
   ipFromRequest,
 } from "@/lib/rateLimit";
+import { requireAuth } from "@/lib/require-auth";
+import { log } from "@/lib/logger";
 
 export async function POST(request: NextRequest) {
   // Devnet-only deployment — faucet is always live.
   try {
-    const body = await request.json();
+    const __raw = await request.text();
+    const __auth = await requireAuth(request, { rawBody: __raw });
+    if (!__auth.ok)
+      return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
+    const body = __raw ? JSON.parse(__raw) : {};
     const { walletAddress } = body;
 
     if (!walletAddress || typeof walletAddress !== "string") {
@@ -52,6 +58,11 @@ export async function POST(request: NextRequest) {
     const amount = 100; // 100 test USDC per faucet request
 
     const result = await mintTestUSDC(walletAddress, amount);
+    log.forRequest(request).info("faucet mint", {
+      wallet: walletAddress,
+      amount,
+      txHash: result.txHash,
+    });
 
     // Store the faucet transaction
     try {

--- a/app/lib/credit-server.ts
+++ b/app/lib/credit-server.ts
@@ -119,8 +119,12 @@ export interface OnChainClaimListing {
   status: ClaimStatus;
 }
 
+/**
+ * Map an Anchor enum object (e.g. `{ bought: {} }`) to a ClaimStatus.
+ * Exported for unit tests (C-085).
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function statusKey(status: any): ClaimStatus {
+export function parseClaimStatus(status: any): ClaimStatus {
   if (!status || typeof status !== "object") return "Unknown";
   const k = Object.keys(status)[0];
   if (!k) return "Unknown";
@@ -166,7 +170,7 @@ export async function fetchClaimListing(
     faceValueAtomic,
     listedAt: Number(raw.listedAt.toString()),
     boughtAt: Number(raw.boughtAt.toString()),
-    status: statusKey(raw.status),
+    status: parseClaimStatus(raw.status),
   };
 }
 
@@ -289,6 +293,40 @@ export function deriveReputationPda(wallet: PublicKey): [PublicKey, number] {
   );
 }
 
+export interface BeneficiaryDecision {
+  /** The wallet whose USDC ATA receives the escrow on finalize. */
+  beneficiary: PublicKey;
+  /** True when proceeds were routed to a claim buyer instead of the taker. */
+  routedToBuyer: boolean;
+  /** The buyer wallet (base58) when routed, else null. */
+  buyer: string | null;
+}
+
+/**
+ * Decide who a `finalize_payment` pays: the original taker, or — when the job's
+ * receivable was *sold* via Covenant Credit (claim status `Bought` with a
+ * buyer) — the buyer who factored it. A claim that is merely Listed, Cancelled,
+ * Settled, or absent routes to the taker.
+ *
+ * This is also the guard for the "dispute-loss-after-buy" case: a job that
+ * loses a dispute ends up `Resolved` (refunded to the poster), never
+ * `Finalized`, so it never reaches this routing — a buyer is never paid on a
+ * lost claim and carries the credit risk. Pure + exported for tests (C-085).
+ */
+export function resolveClaimBeneficiary(
+  listing: Pick<OnChainClaimListing, "status" | "buyer"> | null,
+  taker: PublicKey,
+): BeneficiaryDecision {
+  if (listing && listing.status === "Bought" && listing.buyer) {
+    return {
+      beneficiary: new PublicKey(listing.buyer),
+      routedToBuyer: true,
+      buyer: listing.buyer,
+    };
+  }
+  return { beneficiary: taker, routedToBuyer: false, buyer: null };
+}
+
 /**
  * Permissionless finalize crank that correctly routes payment when a
  * claim has been sold.
@@ -321,14 +359,11 @@ export async function finalizeWithClaim(params: {
 
   // Discover who the beneficiary should be.
   const listing = await fetchClaimListing(claimPda);
-  let beneficiaryWallet: PublicKey = taker;
-  let routedToBuyer = false;
-  let buyerStr: string | null = null;
-  if (listing && listing.status === "Bought" && listing.buyer) {
-    beneficiaryWallet = new PublicKey(listing.buyer);
-    routedToBuyer = true;
-    buyerStr = listing.buyer;
-  }
+  const {
+    beneficiary: beneficiaryWallet,
+    routedToBuyer,
+    buyer: buyerStr,
+  } = resolveClaimBeneficiary(listing, taker);
 
   const beneficiaryAta = await getAssociatedTokenAddress(
     USDC_MINT,

--- a/app/lib/require-auth.ts
+++ b/app/lib/require-auth.ts
@@ -1,0 +1,121 @@
+/**
+ * C-091 — server-side auth for mutating endpoints.
+ *
+ * A mutating route can require that the caller proves control of a wallet (an
+ * Ed25519 signature over a request-bound canonical message) OR presents a valid
+ * API key. The check is **flag-gated**: until `AUTH_ENFORCED=true`, `requireAuth`
+ * is a no-op (`mode: "disabled"`) so existing clients keep working while the
+ * frontend is updated to sign. Flip the flag once the UI signs requests.
+ *
+ * Usage in a route:
+ *
+ *   const raw = await req.text();
+ *   const auth = await requireAuth(req, { rawBody: raw });
+ *   if (!auth.ok) return Response.json({ error: auth.reason }, { status: auth.status });
+ *   const body = JSON.parse(raw);
+ *
+ * The canonical message binds method + path + a hash of the body + timestamp,
+ * so a captured signature cannot be replayed against a different request, and
+ * the freshness window in `verifyWalletSignature` blocks stale replays.
+ */
+import crypto from "node:crypto";
+import { verifyWalletSignature } from "./wallet-auth";
+
+/** Whether mutating-endpoint auth is enforced. Off by default (non-breaking). */
+export function authEnforced(): boolean {
+  return process.env.AUTH_ENFORCED === "true";
+}
+
+/** SHA-256 hex of a (possibly empty) request body. */
+export function sha256Hex(body: string): string {
+  return crypto.createHash("sha256").update(body, "utf8").digest("hex");
+}
+
+/**
+ * The exact string a client must sign to authenticate a mutating request.
+ * Versioned so the scheme can evolve. Pure + exported for tests and for the
+ * SDK/UI to reproduce.
+ */
+export function canonicalAuthMessage(args: {
+  method: string;
+  path: string;
+  ts: number | string;
+  bodyHash: string;
+}): string {
+  return [
+    "covenant-auth:v1",
+    args.method.toUpperCase(),
+    args.path,
+    args.bodyHash,
+    String(args.ts),
+  ].join("\n");
+}
+
+export type AuthResult =
+  | { ok: true; mode: "disabled" | "signature" | "api_key"; wallet?: string }
+  | { ok: false; status: number; reason: string };
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+/** Parse the comma-separated `API_KEYS` allowlist. */
+function allowedApiKeys(): string[] {
+  return (process.env.API_KEYS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Verify a mutating request is authenticated by a wallet signature OR an API
+ * key. Returns `{ ok: true, mode: "disabled" }` when `AUTH_ENFORCED` is unset
+ * so callers stay backwards-compatible until the flag is flipped.
+ *
+ * Pass the already-read raw body (routes can only read it once).
+ */
+export async function requireAuth(
+  req: Request,
+  opts?: { rawBody?: string },
+): Promise<AuthResult> {
+  if (!authEnforced()) return { ok: true, mode: "disabled" };
+
+  // 1. API-key path (server-to-server / trusted automation).
+  const apiKey = req.headers.get("x-api-key");
+  if (apiKey) {
+    const ok = allowedApiKeys().some((k) => timingSafeEqual(k, apiKey));
+    return ok
+      ? { ok: true, mode: "api_key" }
+      : { ok: false, status: 401, reason: "invalid api key" };
+  }
+
+  // 2. Wallet-signature path.
+  const wallet = req.headers.get("x-wallet");
+  const signature = req.headers.get("x-signature");
+  const ts = req.headers.get("x-timestamp");
+  if (!wallet || !signature || !ts) {
+    return {
+      ok: false,
+      status: 401,
+      reason: "missing auth: x-api-key, or x-wallet + x-signature + x-timestamp",
+    };
+  }
+
+  const path = new URL(req.url).pathname;
+  const bodyHash = sha256Hex(opts?.rawBody ?? "");
+  const expected = canonicalAuthMessage({ method: req.method, path, ts, bodyHash });
+
+  const res = verifyWalletSignature({
+    wallet,
+    signature,
+    message: expected,
+    expectedMessage: expected,
+    ts,
+  });
+  return res.ok
+    ? { ok: true, mode: "signature", wallet }
+    : { ok: false, status: 401, reason: res.reason };
+}

--- a/app/tests/unit/credit-market.test.ts
+++ b/app/tests/unit/credit-market.test.ts
@@ -1,0 +1,121 @@
+/**
+ * C-085 — Covenant Credit market unit tests.
+ *
+ * Covers the server-side decision logic that drives the three credit
+ * instructions (list_claim / buy_claim / cancel_claim) and the finalize
+ * routing, **including the dispute-loss-after-buy path**:
+ *   - parseClaimStatus       — decode the on-chain claim state machine.
+ *   - resolveClaimBeneficiary — who finalize pays (taker vs claim buyer); the
+ *                               guard that a lost dispute never pays the buyer.
+ *   - deriveClaimPda/JobPda   — deterministic PDA addressing.
+ *
+ * Full on-chain instruction coverage (revert paths on localnet) is C-048's
+ * scope; this locks in the server logic that the credit market depends on, with
+ * no live chain required.
+ *
+ * Run with:  npx tsx --test tests/unit/credit-market.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { PublicKey } from "@solana/web3.js";
+import {
+  parseClaimStatus,
+  resolveClaimBeneficiary,
+  deriveJobPda,
+  deriveClaimPda,
+  type ClaimStatus,
+} from "../../lib/credit-server";
+
+const taker = PublicKey.unique();
+const buyer = PublicKey.unique();
+
+function listing(status: ClaimStatus, buyerWallet: string | null) {
+  return { status, buyer: buyerWallet };
+}
+
+describe("C-085 · parseClaimStatus (claim state decoding)", () => {
+  test("maps each Anchor enum variant to its ClaimStatus", () => {
+    assert.equal(parseClaimStatus({ listed: {} }), "Listed");
+    assert.equal(parseClaimStatus({ bought: {} }), "Bought");
+    assert.equal(parseClaimStatus({ cancelled: {} }), "Cancelled");
+    assert.equal(parseClaimStatus({ settled: {} }), "Settled");
+  });
+
+  test("null / malformed / unknown variants → Unknown", () => {
+    assert.equal(parseClaimStatus(null), "Unknown");
+    assert.equal(parseClaimStatus(undefined), "Unknown");
+    assert.equal(parseClaimStatus({}), "Unknown");
+    assert.equal(parseClaimStatus({ weird: {} }), "Unknown");
+    assert.equal(parseClaimStatus("listed"), "Unknown");
+  });
+});
+
+describe("C-085 · resolveClaimBeneficiary (finalize routing)", () => {
+  test("a Bought claim with a buyer routes proceeds to the buyer", () => {
+    const r = resolveClaimBeneficiary(listing("Bought", buyer.toBase58()), taker);
+    assert.equal(r.routedToBuyer, true);
+    assert.equal(r.buyer, buyer.toBase58());
+    assert.equal(r.beneficiary.toBase58(), buyer.toBase58());
+  });
+
+  test("Listed / Cancelled / Settled claims route to the taker", () => {
+    for (const status of ["Listed", "Cancelled", "Settled"] as ClaimStatus[]) {
+      const r = resolveClaimBeneficiary(listing(status, buyer.toBase58()), taker);
+      assert.equal(r.routedToBuyer, false, status);
+      assert.equal(r.buyer, null, status);
+      assert.equal(r.beneficiary.toBase58(), taker.toBase58(), status);
+    }
+  });
+
+  test("no listing at all routes to the taker", () => {
+    const r = resolveClaimBeneficiary(null, taker);
+    assert.equal(r.routedToBuyer, false);
+    assert.equal(r.beneficiary.toBase58(), taker.toBase58());
+  });
+
+  test("a Bought claim with NO buyer (corrupt) defensively routes to the taker", () => {
+    const r = resolveClaimBeneficiary(listing("Bought", null), taker);
+    assert.equal(r.routedToBuyer, false);
+    assert.equal(r.beneficiary.toBase58(), taker.toBase58());
+  });
+
+  test("dispute-loss-after-buy: only a Bought status ever pays the buyer", () => {
+    // A job that loses a dispute ends `Resolved` (refunded to poster), never
+    // `Finalized`, so finalizeWithClaim never runs for it. We encode that
+    // safety property here: every non-Bought status keeps proceeds away from
+    // the buyer — the credit buyer carries the loss, not the protocol.
+    const nonBought: ClaimStatus[] = ["Listed", "Cancelled", "Settled", "Unknown"];
+    for (const status of nonBought) {
+      assert.equal(
+        resolveClaimBeneficiary(listing(status, buyer.toBase58()), taker).routedToBuyer,
+        false,
+        status,
+      );
+    }
+  });
+});
+
+describe("C-085 · PDA derivation is deterministic and distinct", () => {
+  const poster = PublicKey.unique();
+  const specA = Buffer.alloc(32, 1);
+  const specB = Buffer.alloc(32, 2);
+
+  test("deriveJobPda is a pure function of (poster, specHash)", () => {
+    const [a1] = deriveJobPda(poster, specA);
+    const [a2] = deriveJobPda(poster, specA);
+    const [b] = deriveJobPda(poster, specB);
+    assert.equal(a1.toBase58(), a2.toBase58()); // deterministic
+    assert.notEqual(a1.toBase58(), b.toBase58()); // distinct spec → distinct job
+  });
+
+  test("deriveClaimPda is deterministic per job and differs across jobs", () => {
+    const [jobA] = deriveJobPda(poster, specA);
+    const [jobB] = deriveJobPda(poster, specB);
+    const [claimA1] = deriveClaimPda(jobA);
+    const [claimA2] = deriveClaimPda(jobA);
+    const [claimB] = deriveClaimPda(jobB);
+    assert.equal(claimA1.toBase58(), claimA2.toBase58());
+    assert.notEqual(claimA1.toBase58(), claimB.toBase58());
+  });
+});

--- a/app/tests/unit/require-auth.test.ts
+++ b/app/tests/unit/require-auth.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for C-091 server-side mutating-endpoint auth (lib/require-auth).
+ *
+ * Run with:  npx tsx --test tests/unit/require-auth.test.ts
+ */
+
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { Keypair } from "@solana/web3.js";
+import nacl from "tweetnacl";
+import bs58 from "bs58";
+import {
+  requireAuth,
+  authEnforced,
+  canonicalAuthMessage,
+  sha256Hex,
+} from "../../lib/require-auth";
+
+const PATH = "/api/faucet";
+const ORIGIN = "https://covenant.run";
+
+function signedRequest(opts: {
+  kp: Keypair;
+  method?: string;
+  path?: string;
+  rawBody?: string;
+  ts?: number;
+}) {
+  const method = opts.method ?? "POST";
+  const path = opts.path ?? PATH;
+  const rawBody = opts.rawBody ?? "";
+  const ts = opts.ts ?? Date.now();
+  const message = canonicalAuthMessage({ method, path, ts, bodyHash: sha256Hex(rawBody) });
+  const signature = bs58.encode(
+    nacl.sign.detached(new TextEncoder().encode(message), opts.kp.secretKey),
+  );
+  const req = new Request(ORIGIN + path, {
+    method,
+    headers: {
+      "x-wallet": opts.kp.publicKey.toBase58(),
+      "x-signature": signature,
+      "x-timestamp": String(ts),
+    },
+  });
+  return { req, rawBody };
+}
+
+describe("canonicalAuthMessage / sha256Hex (pure)", () => {
+  test("is deterministic and binds method, path, body, ts", () => {
+    const base = { method: "POST", path: "/api/x", ts: 123, bodyHash: "ab" };
+    assert.equal(canonicalAuthMessage(base), canonicalAuthMessage(base));
+    assert.notEqual(canonicalAuthMessage(base), canonicalAuthMessage({ ...base, path: "/api/y" }));
+    assert.notEqual(canonicalAuthMessage(base), canonicalAuthMessage({ ...base, bodyHash: "cd" }));
+    assert.notEqual(canonicalAuthMessage(base), canonicalAuthMessage({ ...base, ts: 124 }));
+  });
+  test("sha256Hex is stable and differs by body", () => {
+    assert.equal(sha256Hex("a"), sha256Hex("a"));
+    assert.notEqual(sha256Hex("a"), sha256Hex("b"));
+  });
+});
+
+describe("requireAuth — disabled by default (non-breaking)", () => {
+  beforeEach(() => delete process.env.AUTH_ENFORCED);
+  test("returns ok/disabled when AUTH_ENFORCED is unset", async () => {
+    assert.equal(authEnforced(), false);
+    const r = await requireAuth(new Request(ORIGIN + PATH, { method: "POST" }));
+    assert.deepEqual(r, { ok: true, mode: "disabled" });
+  });
+});
+
+describe("requireAuth — enforced", () => {
+  beforeEach(() => {
+    process.env.AUTH_ENFORCED = "true";
+    process.env.API_KEYS = "key-one,key-two";
+  });
+  afterEach(() => {
+    delete process.env.AUTH_ENFORCED;
+    delete process.env.API_KEYS;
+  });
+
+  test("accepts a valid wallet signature bound to the request", async () => {
+    const kp = Keypair.generate();
+    const { req, rawBody } = signedRequest({ kp, rawBody: JSON.stringify({ amount: 1 }) });
+    const r = await requireAuth(req, { rawBody });
+    assert.equal(r.ok, true);
+    assert.equal(r.ok && r.mode, "signature");
+    assert.equal(r.ok && r.wallet, kp.publicKey.toBase58());
+  });
+
+  test("rejects when the body is tampered after signing (bodyHash mismatch)", async () => {
+    const kp = Keypair.generate();
+    const { req } = signedRequest({ kp, rawBody: JSON.stringify({ amount: 1 }) });
+    const r = await requireAuth(req, { rawBody: JSON.stringify({ amount: 1000000 }) });
+    assert.equal(r.ok, false);
+  });
+
+  test("rejects a signature from a different key", async () => {
+    const signer = Keypair.generate();
+    const { req, rawBody } = signedRequest({ kp: signer });
+    // Swap the advertised wallet to someone else.
+    const headers = new Headers(req.headers);
+    headers.set("x-wallet", Keypair.generate().publicKey.toBase58());
+    const forged = new Request(req.url, { method: "POST", headers });
+    const r = await requireAuth(forged, { rawBody });
+    assert.equal(r.ok, false);
+  });
+
+  test("rejects a stale timestamp (replay window)", async () => {
+    const kp = Keypair.generate();
+    const { req, rawBody } = signedRequest({ kp, ts: Date.now() - 10 * 60_000 });
+    const r = await requireAuth(req, { rawBody });
+    assert.equal(r.ok, false);
+    assert.equal(r.ok === false && r.reason, "stale request");
+  });
+
+  test("accepts a valid API key and rejects an invalid one", async () => {
+    const good = new Request(ORIGIN + PATH, { method: "POST", headers: { "x-api-key": "key-two" } });
+    assert.equal((await requireAuth(good)).ok, true);
+    const bad = new Request(ORIGIN + PATH, { method: "POST", headers: { "x-api-key": "nope" } });
+    assert.equal((await requireAuth(bad)).ok, false);
+  });
+
+  test("rejects a request with no auth headers at all", async () => {
+    const r = await requireAuth(new Request(ORIGIN + PATH, { method: "POST" }));
+    assert.equal(r.ok, false);
+    assert.equal(r.ok === false && r.status, 401);
+  });
+});


### PR DESCRIPTION
Three owner-scoped **backend gaps** found by the code-level verification sweep
(not by labels — several "open" issues turned out already implemented). All
server-side, unit-tested, **no live chain and no behaviour change** (the auth is
flag-gated off).

Refs #136, Refs #140, Refs #170

> These are **`Refs`, not `Closes`** — each advances its issue with real, tested
> code but does not fully meet the acceptance criterion yet (the remainder is
> documented per-issue below). Close them when the follow-up lands or the scope
> is accepted.

**1 commit · 8 files · +452 / −14 · `tsc --noEmit` clean · 249/249 unit tests
(+18 new) · new code eslint-clean · no new dependencies.**

---

## C-085 · Covenant Credit market unit tests — `#136` `M5`

**What:** the credit market had **zero** tests; this adds unit coverage for the
server logic that drives it, including the dispute-loss-after-buy path.

**How / where:**
- `lib/credit-server.ts` — extracted two **pure** decision functions from the
  settlement path, *behaviour-preserving* (`finalizeWithClaim` now calls them):
  - `parseClaimStatus(raw)` — decode the on-chain claim state machine
    (`{ bought: {} }` → `"Bought"`, unknown → `"Unknown"`).
  - `resolveClaimBeneficiary(listing, taker)` — who `finalize_payment` pays: the
    claim **buyer** when the receivable was sold (`Bought` + buyer), else the
    **taker**.
- `tests/unit/credit-market.test.ts` (9) — status decode, finalize routing,
  PDA determinism, and the **dispute-loss-after-buy guard**.

**⚠️ Nuance — dispute-loss-after-buy.** A job that *loses* a dispute ends
`Resolved` (escrow refunded to the poster), never `Finalized`, so it never
reaches `resolveClaimBeneficiary` — a claim buyer is **never paid on a loss** and
carries the credit risk. The test encodes that safety property: only a `Bought`
status ever routes proceeds to the buyer.

**Scope / why Refs:** this covers the *server* logic for the three credit
instructions; full on-chain instruction coverage on localnet remains **C-048**.

## C-091 · Server-side auth for mutating endpoints — `#140` `M6`

**What:** a reusable guard that requires callers of mutating routes to prove
control of a wallet (Ed25519 signature) **or** present an API key.

**How / where:**
- `lib/require-auth.ts` — `requireAuth(req, { rawBody })`. The signed **canonical
  message binds method + path + SHA-256(body) + timestamp**, so a captured
  signature cannot be replayed against a different request; the freshness window
  in `verifyWalletSignature` blocks stale replays. API-key path uses a
  constant-time compare against an allowlist.
- `tests/unit/require-auth.test.ts` (9) — real keypair sign+verify, tampered
  body, forged key, stale timestamp, API-key accept/reject, missing-auth.
- Wired to 4 sensitive money/state routes: **faucet, disputes, claims/buy,
  agents/stake**.

**⚠️ Nuance — flag-gated + non-breaking.** `requireAuth` returns
`{ ok: true, mode: "disabled" }` unless `AUTH_ENFORCED=true`, so it is a **no-op
today** — existing clients keep working. Flip the flag to enforce once the UI
signs requests.

**Scope / why Refs:** the helper + 4 representative routes are wired; enforcing
on *every* mutating route and flipping the flag (needs the frontend to sign) is
the follow-up.

## C-110 · Structured request logging + tx sigs — `#170` `M8`

**What:** make on-chain settlement actions traceable in structured logs.

**How / where:**
- **Request correlation already existed** — `middleware.ts` stamps an
  `x-request-id` on every request/response and `lib/logger.ts` `forRequest`
  reads it. (My sweep first flagged this as a gap by counting `forRequest`
  callers; the middleware is the real correlation mechanism.)
- This PR adds the missing piece: `log.forRequest(req)` **tx-sig logging** on the
  on-chain money routes — `faucet` (mint) + `claims/buy` (verified buy).

**Scope / why Refs:** "every request correlatable" is met by the middleware; the
tx-sig structured logging is added on the two highest-value money routes, with
the pattern to extend to the rest.

---

## Testing
```bash
cd app
npx tsc --noEmit                            # clean
npx tsx --test tests/unit/*.test.ts         # 249/249 (+18 new)
```
`credit-server.ts`'s 11 eslint "errors" are the pre-existing standalone-eslint
`@typescript-eslint/no-explicit-any` rule-not-found quirk (11 on `main` too,
unchanged by this PR; `next lint` / CI is unaffected).

## Coordination
- Rebased onto current `main` (now includes **#233**, merged). **Zero file
  overlap** with #233 — clean rebase.
- **C-019** (agents/hire → real bot tx) was deliberately split out: it touches
  real escrow funding + bot signing and deserves its own PR with a devnet smoke.

## Not in this PR
- C-019 (money flow), full C-091 route coverage + flag flip (frontend signing),
  on-chain credit integration tests on localnet (C-048).
