### PR TITLE
feat(infra+hire): RPC failover backoff + rate budget (C-064), incident runbook (C-070), real hire orchestration (C-019)

### DIFF
--- a/app/lib/hire-onchain.ts
+++ b/app/lib/hire-onchain.ts
@@ -1,0 +1,123 @@
+/**
+ * C-019 — real on-chain agent hire.
+ *
+ * Hiring a built-in/hosted agent posts a **real** job + escrow on-chain (no
+ * marker memo): a funded platform poster wallet creates the job + locks USDC,
+ * then the agent's own bot keypair accepts and delivers it. The orchestration
+ * here is pure — the three on-chain calls are injected (the real ones live in
+ * `lib/program-server.ts`), so the create → accept → deliver sequence is
+ * unit-testable without a live chain, and the route wires the real deps.
+ *
+ * Funding contract (devnet): the poster keypair must already hold the job's
+ * USDC in its ATA (the program transfers it into escrow on create_job) plus SOL
+ * for fees/rent; the agent keypair needs SOL for fees only.
+ */
+
+import type { Keypair, PublicKey } from "@solana/web3.js";
+
+/** The on-chain primitives this orchestration drives (from program-server). */
+export interface HireOnchainDeps {
+  botCreateJob: (p: {
+    botKeypair: Keypair;
+    amount: number;
+    specHash: Buffer;
+    deadline: number;
+    challengePeriod: number;
+  }) => Promise<{ sig: string; jobPda: PublicKey; escrowTokenAccount: PublicKey }>;
+  botAcceptJob: (p: {
+    takerBotKeypair: Keypair;
+    poster: PublicKey;
+    specHash: Buffer;
+  }) => Promise<string>;
+  botSubmitWork: (p: {
+    takerBotKeypair: Keypair;
+    poster: PublicKey;
+    specHash: Buffer;
+    workHash: Buffer;
+    deliveryUri: string;
+  }) => Promise<string>;
+}
+
+export interface HireOnchainParams {
+  posterKeypair: Keypair;
+  agentKeypair: Keypair;
+  /** Job amount in human-unit USDC (must be in the poster's ATA). */
+  amount: number;
+  /** sha256 of the job spec (32 bytes). */
+  specHash: Buffer;
+  /** Unix seconds. */
+  deadlineUnix: number;
+  /** Optimistic challenge window in seconds. */
+  challengePeriodSec: number;
+  /** sha256 of the delivered work (32 bytes). */
+  workHash: Buffer;
+  /** Where the deliverable lives (e.g. a blob URL). */
+  deliveryUri: string;
+  deps: HireOnchainDeps;
+}
+
+export interface HireOnchainResult {
+  jobPda: string;
+  escrowTokenAccount: string;
+  createSig: string;
+  acceptSig: string;
+  submitSig: string;
+}
+
+/**
+ * Run a full real on-chain hire: poster creates the job + escrow, then the
+ * agent accepts and delivers. Throws if any step fails (the caller decides how
+ * to surface a partially-advanced job — the reconciler heals DB state, C-021).
+ */
+export async function hireAgentOnchain(
+  params: HireOnchainParams,
+): Promise<HireOnchainResult> {
+  const {
+    posterKeypair,
+    agentKeypair,
+    amount,
+    specHash,
+    deadlineUnix,
+    challengePeriodSec,
+    workHash,
+    deliveryUri,
+    deps,
+  } = params;
+
+  if (agentKeypair.publicKey.equals(posterKeypair.publicKey)) {
+    throw new Error("hireAgentOnchain: agent and poster must be different wallets");
+  }
+
+  // 1. Poster posts the real job + locks USDC escrow.
+  const created = await deps.botCreateJob({
+    botKeypair: posterKeypair,
+    amount,
+    specHash,
+    deadline: deadlineUnix,
+    challengePeriod: challengePeriodSec,
+  });
+
+  // 2. The agent (its own wallet) accepts on-chain.
+  const acceptSig = await deps.botAcceptJob({
+    takerBotKeypair: agentKeypair,
+    poster: posterKeypair.publicKey,
+    specHash,
+  });
+
+  // 3. The agent delivers on-chain.
+  const submitSig = await deps.botSubmitWork({
+    takerBotKeypair: agentKeypair,
+    poster: posterKeypair.publicKey,
+    specHash,
+    workHash,
+    deliveryUri,
+  });
+
+  return {
+    jobPda: created.jobPda.toBase58(),
+    escrowTokenAccount: created.escrowTokenAccount.toBase58(),
+    createSig: created.sig,
+    acceptSig,
+    submitSig,
+  };
+}

--- a/app/lib/rpc-failover.ts
+++ b/app/lib/rpc-failover.ts
@@ -1,16 +1,16 @@
 /**
- * Multi-RPC failover Connection wrapper.
+ * Multi-RPC failover Connection wrapper, with exponential backoff and an
+ * optional rate budget (C-064).
  *
- * Solana web3.js's `Connection` is bound to a single endpoint. When
- * that endpoint rate-limits or 5xx's mid-flow, the whole call fails.
- * For demo reliability we want automatic retry against a chain of
- * fallback RPC URLs.
+ * Solana web3.js's `Connection` is bound to a single endpoint. When that
+ * endpoint rate-limits (429) or 5xx's mid-flow, the whole call fails. This
+ * wraps `Connection` in a Proxy that, on a retryable error, **backs off** then
+ * rotates to the next URL in the chain and retries. A `429`/rate-limit error
+ * backs off harder than a transient network blip.
  *
- * `createFailoverConnection()` returns a Proxy around `Connection`
- * that intercepts every method call. On a thrown error matching
- * "rate limit" / "429" / network-level failure, it rotates to the
- * next URL in the chain and retries. The current healthy URL sticks
- * across calls until it fails.
+ * To respect a provider's plan limits, set `RPC_RATE_BUDGET_PER_SEC` — outgoing
+ * calls are then throttled through a token bucket so we proactively stay under
+ * the cap instead of waiting to be 429'd. Unset = no throttle (default).
  *
  * For server code (Anchor program calls, etc.) prefer this over
  * `new Connection(getRpcUrl())` directly.
@@ -33,20 +33,139 @@ const RETRYABLE = [
   /failed to fetch/i,
 ];
 
-function isRetryable(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
+/** Errors that specifically indicate provider rate limiting (back off harder). */
+const RATE_LIMITED = [/429/, /rate.?limit/i, /too many requests/i];
+
+function msgOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** True for transient errors worth retrying against another endpoint. */
+export function isRetryable(err: unknown): boolean {
+  const msg = msgOf(err);
   return RETRYABLE.some((re) => re.test(msg));
 }
 
+/** True when the error is a 429 / rate-limit (vs a generic transient failure). */
+export function isRateLimited(err: unknown): boolean {
+  const msg = msgOf(err);
+  return RATE_LIMITED.some((re) => re.test(msg));
+}
+
+/**
+ * Exponential backoff with full jitter. `attempt` is 0-based. Rate-limited
+ * errors start from a higher base so we genuinely yield the provider's window.
+ * Pure (inject `rand` for deterministic tests).
+ */
+export function backoffDelayMs(
+  attempt: number,
+  opts?: {
+    baseMs?: number;
+    maxMs?: number;
+    rateLimited?: boolean;
+    rand?: () => number;
+  },
+): number {
+  const baseMs = opts?.baseMs ?? 250;
+  const maxMs = opts?.maxMs ?? 8000;
+  const base = opts?.rateLimited ? baseMs * 4 : baseMs;
+  const uncapped = base * 2 ** Math.max(0, attempt);
+  const ceil = Math.min(maxMs, uncapped);
+  const rand = opts?.rand ?? Math.random;
+  // Full jitter in [50%, 100%] of the ceiling — avoids thundering-herd retries.
+  return Math.floor(ceil * (0.5 + 0.5 * rand()));
+}
+
+/**
+ * Token-bucket rate budget — proactively keep RPC calls under a provider's
+ * per-second plan limit. Pure + injectable clock for tests.
+ */
+export class RpcRateBudget {
+  private tokens: number;
+  private readonly capacity: number;
+  private readonly refillPerMs: number;
+  private last: number;
+  private readonly now: () => number;
+
+  constructor(opts: { ratePerSec: number; burst?: number; now?: () => number }) {
+    this.capacity = Math.max(1, opts.burst ?? opts.ratePerSec);
+    this.tokens = this.capacity;
+    this.refillPerMs = opts.ratePerSec / 1000;
+    this.now = opts.now ?? Date.now;
+    this.last = this.now();
+  }
+
+  private refill(): void {
+    const t = this.now();
+    this.tokens = Math.min(this.capacity, this.tokens + (t - this.last) * this.refillPerMs);
+    this.last = t;
+  }
+
+  /** Take a token if available without waiting. */
+  tryTake(): boolean {
+    this.refill();
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return true;
+    }
+    return false;
+  }
+
+  /** Ms until the next token is available (0 if one is available now). */
+  msUntilToken(): number {
+    this.refill();
+    if (this.tokens >= 1) return 0;
+    return Math.ceil((1 - this.tokens) / this.refillPerMs);
+  }
+}
+
+/**
+ * Run `invoke` with retry-on-rotate + backoff. Pure: all side effects (rotating
+ * the endpoint, sleeping) are injected, so the loop is unit-testable.
+ */
+export async function callWithFailover<T>(
+  invoke: () => Promise<T>,
+  deps: {
+    maxAttempts: number;
+    isRetryable: (e: unknown) => boolean;
+    delayFor: (attempt: number, err: unknown) => number;
+    sleep: (ms: number) => Promise<void>;
+    onRetry: (attempt: number, err: unknown) => void;
+  },
+): Promise<T> {
+  let lastErr: unknown = null;
+  for (let attempt = 0; attempt < deps.maxAttempts; attempt++) {
+    try {
+      return await invoke();
+    } catch (err) {
+      lastErr = err;
+      if (!deps.isRetryable(err)) throw err;
+      if (attempt < deps.maxAttempts - 1) {
+        await deps.sleep(deps.delayFor(attempt, err));
+        deps.onRetry(attempt, err);
+      }
+    }
+  }
+  throw lastErr;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  ms > 0 ? new Promise((r) => setTimeout(r, ms)) : Promise.resolve();
+
 interface FailoverState {
-  /** Index of the URL currently in use. */
   cursor: number;
-  /** Cached Connection for the current URL. */
   conn: Connection;
   chain: string[];
+  budget: RpcRateBudget | null;
 }
 
 let _state: FailoverState | null = null;
+
+function makeBudget(): RpcRateBudget | null {
+  const perSec = Number(process.env.RPC_RATE_BUDGET_PER_SEC);
+  if (!Number.isFinite(perSec) || perSec <= 0) return null;
+  return new RpcRateBudget({ ratePerSec: perSec });
+}
 
 function getState(commitment: Commitment): FailoverState {
   if (!_state) {
@@ -55,6 +174,7 @@ function getState(commitment: Commitment): FailoverState {
       cursor: 0,
       chain,
       conn: new Connection(chain[0], commitment),
+      budget: makeBudget(),
     };
   }
   return _state;
@@ -71,10 +191,9 @@ function rotate(commitment: Commitment): void {
 }
 
 /**
- * Returns a `Connection`-shaped proxy that auto-fails over across
- * the configured RPC chain.
+ * Returns a `Connection`-shaped proxy that throttles to the rate budget (if
+ * configured) and auto-fails over with backoff across the RPC chain.
  *
- * Usage:
  *   const conn = createFailoverConnection("confirmed");
  *   await conn.getLatestBlockhash();
  */
@@ -86,33 +205,36 @@ export function createFailoverConnection(commitment: Commitment = "confirmed"): 
       const orig = Reflect.get(state.conn, prop);
       if (typeof orig !== "function") return orig;
 
-      // Wrap method call with retry-on-rotate semantics.
-      return async (...args: unknown[]) => {
-        const maxAttempts = state.chain.length;
-        let lastErr: unknown = null;
-        for (let attempt = 0; attempt < maxAttempts; attempt++) {
-          try {
+      return (...args: unknown[]) =>
+        callWithFailover(
+          async () => {
+            // Respect the provider's plan limit before each call.
+            if (state.budget) {
+              const wait = state.budget.msUntilToken();
+              if (wait > 0) await sleep(wait);
+              state.budget.tryTake();
+            }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const fn = (state.conn as any)[prop] as (...a: unknown[]) => unknown;
-            const result = fn.apply(state.conn, args);
-            // If it returns a promise, await + catch
-            if (result && typeof (result as Promise<unknown>).then === "function") {
-              return await (result as Promise<unknown>);
-            }
-            return result;
-          } catch (err) {
-            lastErr = err;
-            if (!isRetryable(err)) throw err;
-            // eslint-disable-next-line no-console
-            console.warn(
-              `[rpc-failover] ${String(prop)} failed on ${state.chain[state.cursor]}, rotating:`,
-              err instanceof Error ? err.message : String(err),
-            );
-            rotate(commitment);
-          }
-        }
-        throw lastErr;
-      };
+            return await Promise.resolve(fn.apply(state.conn, args));
+          },
+          {
+            maxAttempts: state.chain.length,
+            isRetryable,
+            delayFor: (attempt, err) =>
+              backoffDelayMs(attempt, { rateLimited: isRateLimited(err) }),
+            sleep,
+            onRetry: (attempt, err) => {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `[rpc-failover] ${String(prop)} failed on ${state.chain[state.cursor]} ` +
+                  `(attempt ${attempt + 1}), backing off + rotating:`,
+                msgOf(err),
+              );
+              rotate(commitment);
+            },
+          },
+        );
     },
   });
 }

--- a/app/scripts/hire-smoke.ts
+++ b/app/scripts/hire-smoke.ts
@@ -1,0 +1,80 @@
+/**
+ * C-019 devnet smoke — run a REAL on-chain agent hire end to end.
+ *
+ * Loads a funded poster keypair (SOL + USDC), creates a throwaway agent
+ * keypair, funds it with a little SOL for fees, then runs the real
+ * create_job -> accept_job -> submit_work lifecycle via the same
+ * `hireAgentOnchain` orchestration the /api/agents/hire route uses. Prints the
+ * Explorer links proving real transactions (not marker memos).
+ *
+ *   HIRE_POSTER_KEYFILE=/tmp/poster.json npx tsx scripts/hire-smoke.ts
+ */
+import { readFileSync } from "node:fs";
+import crypto from "node:crypto";
+import {
+  Keypair,
+  Connection,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import { botCreateJob, botAcceptJob, botSubmitWork } from "../lib/program-server";
+import { hireAgentOnchain } from "../lib/hire-onchain";
+
+const RPC = process.env.SMOKE_RPC ?? "https://api.devnet.solana.com";
+const KEYFILE = process.env.HIRE_POSTER_KEYFILE ?? "/tmp/poster.json";
+const AMOUNT = Number(process.env.SMOKE_AMOUNT ?? 10);
+
+const exp = (sig: string) => `https://explorer.solana.com/tx/${sig}?cluster=devnet`;
+
+async function main(): Promise<void> {
+  const poster = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(KEYFILE, "utf8"))),
+  );
+  const agent = Keypair.generate();
+  const conn = new Connection(RPC, "confirmed");
+
+  console.log("poster:", poster.publicKey.toBase58());
+  console.log("agent :", agent.publicKey.toBase58());
+
+  // Fund the throwaway agent with a little SOL for fees (from the poster).
+  const fund = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: poster.publicKey,
+      toPubkey: agent.publicKey,
+      lamports: Math.floor(0.05 * LAMPORTS_PER_SOL),
+    }),
+  );
+  const fundSig = await sendAndConfirmTransaction(conn, fund, [poster]);
+  console.log("funded agent SOL:", exp(fundSig));
+
+  const spec = { title: "Smoke hire", agent: "smoke", amount: AMOUNT, ts: Date.now() };
+  const specHash = crypto.createHash("sha256").update(JSON.stringify(spec)).digest();
+  const workHash = crypto.createHash("sha256").update("delivered work " + Date.now()).digest();
+  const deadlineUnix = Math.floor(Date.now() / 1000) + 24 * 3600;
+
+  const res = await hireAgentOnchain({
+    posterKeypair: poster,
+    agentKeypair: agent,
+    amount: AMOUNT,
+    specHash,
+    deadlineUnix,
+    challengePeriodSec: 60,
+    workHash,
+    deliveryUri: "https://example.invalid/work.json",
+    deps: { botCreateJob, botAcceptJob, botSubmitWork },
+  });
+
+  console.log("\nREAL ON-CHAIN HIRE:");
+  console.log("  jobPda :", res.jobPda);
+  console.log("  escrow :", res.escrowTokenAccount);
+  console.log("  create :", exp(res.createSig));
+  console.log("  accept :", exp(res.acceptSig));
+  console.log("  deliver:", exp(res.submitSig));
+}
+
+main().catch((e) => {
+  console.error("smoke failed:", e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/app/tests/unit/hire-onchain.test.ts
+++ b/app/tests/unit/hire-onchain.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for C-019 on-chain hire orchestration (lib/hire-onchain).
+ *
+ * The three on-chain primitives are injected and recorded, so we assert the
+ * create → accept → deliver sequence, the wallet each step signs with, and the
+ * aggregated result — without touching a chain.
+ *
+ * Run with:  npx tsx --test tests/unit/hire-onchain.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { hireAgentOnchain, type HireOnchainDeps } from "../../lib/hire-onchain";
+
+const poster = Keypair.generate();
+const agent = Keypair.generate();
+const jobPda = Keypair.generate().publicKey;
+const escrow = Keypair.generate().publicKey;
+
+function recordingDeps() {
+  const calls: { fn: string; args: Record<string, unknown> }[] = [];
+  const deps: HireOnchainDeps = {
+    botCreateJob: async (p) => {
+      calls.push({ fn: "create", args: { signer: p.botKeypair.publicKey.toBase58(), amount: p.amount, deadline: p.deadline, challengePeriod: p.challengePeriod } });
+      return { sig: "CREATE_SIG", jobPda, escrowTokenAccount: escrow };
+    },
+    botAcceptJob: async (p) => {
+      calls.push({ fn: "accept", args: { signer: p.takerBotKeypair.publicKey.toBase58(), poster: p.poster.toBase58() } });
+      return "ACCEPT_SIG";
+    },
+    botSubmitWork: async (p) => {
+      calls.push({ fn: "submit", args: { signer: p.takerBotKeypair.publicKey.toBase58(), poster: p.poster.toBase58(), deliveryUri: p.deliveryUri } });
+      return "SUBMIT_SIG";
+    },
+  };
+  return { deps, calls };
+}
+
+const baseParams = {
+  posterKeypair: poster,
+  agentKeypair: agent,
+  amount: 15,
+  specHash: Buffer.alloc(32, 7),
+  deadlineUnix: 1_900_000_000,
+  challengePeriodSec: 60,
+  workHash: Buffer.alloc(32, 9),
+  deliveryUri: "https://blob.example/work.json",
+};
+
+describe("C-019 · hireAgentOnchain", () => {
+  test("runs create → accept → deliver in order, each with the right signer", async () => {
+    const { deps, calls } = recordingDeps();
+    const res = await hireAgentOnchain({ ...baseParams, deps });
+
+    assert.deepEqual(
+      calls.map((c) => c.fn),
+      ["create", "accept", "submit"],
+    );
+    // poster signs create; agent signs accept + deliver
+    assert.equal(calls[0].args.signer, poster.publicKey.toBase58());
+    assert.equal(calls[0].args.amount, 15);
+    assert.equal(calls[1].args.signer, agent.publicKey.toBase58());
+    assert.equal(calls[1].args.poster, poster.publicKey.toBase58());
+    assert.equal(calls[2].args.signer, agent.publicKey.toBase58());
+    assert.equal(calls[2].args.deliveryUri, baseParams.deliveryUri);
+
+    assert.deepEqual(res, {
+      jobPda: jobPda.toBase58(),
+      escrowTokenAccount: escrow.toBase58(),
+      createSig: "CREATE_SIG",
+      acceptSig: "ACCEPT_SIG",
+      submitSig: "SUBMIT_SIG",
+    });
+  });
+
+  test("rejects when the agent and poster are the same wallet", async () => {
+    const { deps, calls } = recordingDeps();
+    await assert.rejects(
+      hireAgentOnchain({ ...baseParams, agentKeypair: poster, deps }),
+      /different wallets/,
+    );
+    assert.equal(calls.length, 0); // never touches the chain
+  });
+
+  test("fails fast: if create throws, accept/deliver never run", async () => {
+    const calls: string[] = [];
+    const deps: HireOnchainDeps = {
+      botCreateJob: async () => {
+        throw new Error("escrow underfunded");
+      },
+      botAcceptJob: async () => {
+        calls.push("accept");
+        return "x";
+      },
+      botSubmitWork: async () => {
+        calls.push("submit");
+        return "y";
+      },
+    };
+    await assert.rejects(hireAgentOnchain({ ...baseParams, deps }), /underfunded/);
+    assert.deepEqual(calls, []);
+  });
+
+  test("passes the 32-byte spec + work hashes through unchanged", async () => {
+    let seenSpec: Buffer | null = null;
+    let seenWork: Buffer | null = null;
+    const deps: HireOnchainDeps = {
+      botCreateJob: async (p) => {
+        seenSpec = p.specHash;
+        return { sig: "s", jobPda, escrowTokenAccount: escrow };
+      },
+      botAcceptJob: async () => "a",
+      botSubmitWork: async (p) => {
+        seenWork = p.workHash;
+        return "b";
+      },
+    };
+    await hireAgentOnchain({ ...baseParams, deps });
+    assert.equal(seenSpec && (seenSpec as Buffer).length, 32);
+    assert.equal(seenWork && (seenWork as Buffer).length, 32);
+  });
+});

--- a/app/tests/unit/rpc-failover.test.ts
+++ b/app/tests/unit/rpc-failover.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for C-064 RPC failover backoff + rate budget (lib/rpc-failover).
+ *
+ * Run with:  npx tsx --test tests/unit/rpc-failover.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isRetryable,
+  isRateLimited,
+  backoffDelayMs,
+  RpcRateBudget,
+  callWithFailover,
+} from "../../lib/rpc-failover";
+
+describe("C-064 · error classification", () => {
+  test("retryable: 429, rate limit, 5xx, network blips", () => {
+    for (const m of [
+      "Server responded 429",
+      "rate limit exceeded",
+      "503 Service Unavailable",
+      "ETIMEDOUT",
+      "ECONNRESET",
+      "failed to fetch",
+    ]) {
+      assert.equal(isRetryable(new Error(m)), true, m);
+    }
+  });
+
+  test("not retryable: deterministic program/logic errors", () => {
+    for (const m of ["custom program error: 0x1", "invalid account", "Blockhash not found"]) {
+      assert.equal(isRetryable(new Error(m)), false, m);
+    }
+  });
+
+  test("isRateLimited isolates 429/rate-limit from other transient errors", () => {
+    assert.equal(isRateLimited(new Error("429 too many requests")), true);
+    assert.equal(isRateLimited(new Error("rate-limit")), true);
+    assert.equal(isRateLimited(new Error("ETIMEDOUT")), false);
+    assert.equal(isRateLimited(new Error("503")), false);
+  });
+});
+
+describe("C-064 · backoffDelayMs (exponential + jitter)", () => {
+  const noJitter = () => 1; // rand()=1 → 100% of the ceiling
+
+  test("grows exponentially with the attempt", () => {
+    assert.equal(backoffDelayMs(0, { baseMs: 100, rand: noJitter }), 100);
+    assert.equal(backoffDelayMs(1, { baseMs: 100, rand: noJitter }), 200);
+    assert.equal(backoffDelayMs(2, { baseMs: 100, rand: noJitter }), 400);
+  });
+
+  test("is capped at maxMs", () => {
+    assert.equal(backoffDelayMs(20, { baseMs: 100, maxMs: 1000, rand: noJitter }), 1000);
+  });
+
+  test("rate-limited errors back off harder (4x base)", () => {
+    const normal = backoffDelayMs(0, { baseMs: 100, rand: noJitter });
+    const limited = backoffDelayMs(0, { baseMs: 100, rateLimited: true, rand: noJitter });
+    assert.equal(limited, normal * 4);
+  });
+
+  test("jitter keeps the delay within [50%, 100%] of the ceiling", () => {
+    const lo = backoffDelayMs(1, { baseMs: 100, rand: () => 0 }); // 50%
+    const hi = backoffDelayMs(1, { baseMs: 100, rand: () => 1 }); // 100%
+    assert.equal(lo, 100);
+    assert.equal(hi, 200);
+  });
+});
+
+describe("C-064 · RpcRateBudget (token bucket)", () => {
+  test("allows up to the burst, then blocks until refill", () => {
+    let t = 0;
+    const b = new RpcRateBudget({ ratePerSec: 10, burst: 3, now: () => t });
+    assert.equal(b.tryTake(), true);
+    assert.equal(b.tryTake(), true);
+    assert.equal(b.tryTake(), true);
+    assert.equal(b.tryTake(), false); // burst exhausted
+    assert.ok(b.msUntilToken() > 0);
+  });
+
+  test("refills over time at ratePerSec", () => {
+    let t = 0;
+    const b = new RpcRateBudget({ ratePerSec: 10, burst: 1, now: () => t });
+    assert.equal(b.tryTake(), true);
+    assert.equal(b.tryTake(), false);
+    assert.equal(b.msUntilToken(), 100); // 1 token / 10ps = 100ms
+    t = 100; // advance 100ms → 1 token back
+    assert.equal(b.tryTake(), true);
+  });
+});
+
+describe("C-064 · callWithFailover (retry loop)", () => {
+  const passthroughDelay = (attempt: number) => attempt; // deterministic
+
+  test("retries a retryable failure, backing off + rotating, then succeeds", async () => {
+    const sleeps: number[] = [];
+    const rotations: number[] = [];
+    let calls = 0;
+    const result = await callWithFailover(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error("429");
+        return "ok";
+      },
+      {
+        maxAttempts: 5,
+        isRetryable,
+        delayFor: passthroughDelay,
+        sleep: async (ms) => void sleeps.push(ms),
+        onRetry: (attempt) => void rotations.push(attempt),
+      },
+    );
+    assert.equal(result, "ok");
+    assert.equal(calls, 3); // two failures + success
+    assert.deepEqual(sleeps, [0, 1]); // backed off before each of the 2 retries
+    assert.deepEqual(rotations, [0, 1]); // rotated twice
+  });
+
+  test("throws immediately on a non-retryable error (no backoff, no rotate)", async () => {
+    const sleeps: number[] = [];
+    await assert.rejects(
+      callWithFailover(
+        async () => {
+          throw new Error("custom program error");
+        },
+        {
+          maxAttempts: 5,
+          isRetryable,
+          delayFor: passthroughDelay,
+          sleep: async (ms) => void sleeps.push(ms),
+          onRetry: () => {},
+        },
+      ),
+      /custom program error/,
+    );
+    assert.equal(sleeps.length, 0);
+  });
+
+  test("gives up after maxAttempts and throws the last error", async () => {
+    let calls = 0;
+    await assert.rejects(
+      callWithFailover(
+        async () => {
+          calls++;
+          throw new Error("503");
+        },
+        {
+          maxAttempts: 3,
+          isRetryable,
+          delayFor: () => 0,
+          sleep: async () => {},
+          onRetry: () => {},
+        },
+      ),
+      /503/,
+    );
+    assert.equal(calls, 3);
+  });
+});

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,123 @@
+# Incident runbook (C-070)
+
+Operational playbook for Covenant. Each scenario below has concrete, ordered
+steps grounded in the actual system. Keep this current as infrastructure
+changes.
+
+> **Status:** the program is deployed on **devnet** today
+> (`5hstj5grBUL1BeSaPLYpgkD6n3ALasmbseRvKRFfCVNT`). These procedures are the
+> standing process we carry into mainnet.
+
+## System at a glance
+
+| Component | Where | Notes |
+|-----------|-------|-------|
+| Anchor program | devnet `5hstj5gr…` | upgrade authority = deployer key (multisig planned, C-046/C-092) |
+| Web app + API | Vercel | Next.js; env vars in Vercel project settings |
+| Database | Neon Postgres | `DATABASE_URL` / `DIRECT_URL`; runtime schema sync in `lib/prisma.ts` |
+| Auto-release crank | `GET /api/cron/finalize` | every ~5 min; signs with `CRANK_KEYPAIR`, fees only |
+| Reconciler | `GET /api/cron/reconcile` | every ~10 min; heals DB↔chain drift (C-021) |
+| RPC | `RPC_CHAIN` (failover) | backoff + rotate on 429/5xx (`lib/rpc-failover.ts`, C-064) |
+| Health / metrics | `GET /api/health`, `/api/metrics` | DB/schema/env status; Prometheus series |
+
+**Key env flags (the fastest levers):**
+- `SETTLEMENT_MODE` — `onchain` (real) vs `simulated` (fakes return/no-op).
+- `COVENANT_ENV` — declared cluster (`devnet`/`mainnet`).
+- `AUTH_ENFORCED` — require signed/keyed auth on mutating routes (C-091).
+- `CRON_SECRET` — gates the crank/reconcile endpoints.
+
+**Keys / signers:** `DEPLOYER_KEYPAIR` (program upgrade + admin), `CRANK_KEYPAIR`
+(finalize crank — fee-payer only, cannot redirect funds), `AGENT_ALPHA_KEYPAIR`
+/ `AGENT_OMEGA_KEYPAIR` (bot wallets), arbitrator keys (2-of-3 multisig for
+`resolve_dispute`).
+
+---
+
+## Scenario 1 — Pause the protocol
+
+Use when a bug or exploit is suspected and you must stop state changes fast.
+
+1. **Stop the crank.** Disable the scheduled jobs so no new `finalize_payment`
+   fires: pause the Vercel Cron (or the GitHub Actions schedule in
+   `.github/workflows/covenant-crons.yml`), or rotate `CRON_SECRET` so the
+   endpoints 401. Verify: `GET /api/cron/finalize` returns 401.
+2. **Freeze mutating routes.** Set `AUTH_ENFORCED=true` with no issued
+   credentials to reject unauthenticated mutations (C-091), and/or set
+   `SETTLEMENT_MODE=simulated` so still-simulated paths no-op and real-settlement
+   routes refuse (`blockSimulatedRouteIfOnchain` 501, C-002/C-003).
+3. **Redeploy** the env change on Vercel (env edits require a redeploy to take
+   effect).
+4. **Confirm** `GET /api/health` is green and `GET /api/metrics`
+   `covenant_jobs_by_status` shows no further transitions.
+5. **Communicate** status; open an incident note.
+
+> The program itself has no global pause instruction today — pausing is done at
+> the app/crank/env layer. (A program-level pause is a future hardening item.)
+
+## Scenario 2 — Roll back a bad deploy
+
+1. **App rollback (fastest):** in Vercel → Deployments, **Promote** the last
+   known-good deployment to Production. This reverts code + the env snapshot
+   bound to that build instantly.
+2. **Env-only rollback:** if a single env var caused it, revert that var and
+   redeploy; no code change needed.
+3. **Database:** schema changes are additive + idempotent (`MIGRATION_SQL` /
+   `ensureSchema` in `lib/prisma.ts`) so a code rollback does **not** require a
+   DB rollback. If data was corrupted, restore from a Neon branch/point-in-time
+   snapshot (see Scenario 5) — never hand-edit money rows.
+4. **Program rollback:** the on-chain program is upgradeable by the upgrade
+   authority. To revert, rebuild the previous verified artifact
+   (`docs/VERIFIABLE_BUILD.md`) and `anchor upgrade` / `solana program deploy`
+   with the prior `.so`. Confirm the on-chain hash matches via the
+   `Verifiable build` workflow.
+5. **Reconcile:** run `GET /api/cron/reconcile` to heal any DB↔chain drift the
+   rollback introduced (C-021), then verify `/api/health`.
+
+## Scenario 3 — Key compromise
+
+Identify which key leaked; the blast radius differs.
+
+- **`CRANK_KEYPAIR` (crank):** lowest risk — it only pays SOL fees and **cannot
+  redirect funds** (the program enforces payout to the registered taker).
+  Mitigate: generate a new keypair, fund it, set `CRANK_KEYPAIR`, redeploy; drain
+  the old key's SOL.
+- **`AGENT_*_KEYPAIR` (bot wallets):** at-risk = those bots' own USDC + any open
+  jobs they're party to. Mitigate: rotate the env keypair, move funds to a fresh
+  wallet, re-register the agent.
+- **Arbitrator key:** dispute resolution is **2-of-3 multisig**, so one leaked
+  arbitrator cannot resolve alone. Rotate it via `update_arbitrators`
+  (init-config authority) and review recent `resolve_dispute` txs.
+- **`DEPLOYER_KEYPAIR` (upgrade + admin authority): CRITICAL.** An attacker could
+  upgrade the program. Mitigate immediately: transfer the program's upgrade
+  authority to a new key (`solana program set-upgrade-authority`), rotate
+  `ADMIN_SECRET`, and audit recent admin actions in the `AdminAuditLog` table
+  (C-095). Move to the planned multisig upgrade authority (C-046) as the durable
+  fix. Never store this key in `/tmp` in production (C-063).
+
+In all cases: rotate the secret in Vercel, redeploy, and document the timeline.
+
+## Scenario 4 — RPC outage
+
+1. **Expected automatic behavior:** `lib/rpc-failover.ts` (C-064) already backs
+   off on 429/5xx and rotates across `RPC_CHAIN`; a single provider outage should
+   self-heal. Watch `covenant_db_up` + error logs to confirm rotation
+   (`[rpc-failover] rotated to …`).
+2. **All providers degraded:** add/promote a healthy endpoint by editing
+   `RPC_CHAIN` (Helius primary + a second provider) and redeploy. If you are
+   being rate-limited, set/lower `RPC_RATE_BUDGET_PER_SEC` to stay under plan
+   limits.
+3. **Effect on settlement:** the crank will retry on the next tick; no funds are
+   lost — escrow stays on-chain until a `finalize_payment` lands. Once RPC
+   recovers, the crank catches up and the reconciler heals any DB lag.
+4. **Verify recovery:** `GET /api/health` green; crank logs show real tx
+   signatures again.
+
+---
+
+## After any incident
+
+1. Confirm `/api/health` green and `/api/cron/reconcile` reports zero unhealed
+   drift.
+2. Write a short postmortem (timeline, root cause, fix, prevention).
+3. If a security issue, follow `SECURITY.md` disclosure + add a regression test
+   so it cannot silently reopen.


### PR DESCRIPTION
Three M1/M4 backend issues: RPC resilience, an incident runbook, and the real
on-chain hire orchestration. The first two are complete + tested; the third is
code-complete + unit-tested but its on-chain execution is blocked by a deployed-
program bug surfaced here (see **#236**).

Closes #110, closes #122
Refs #60 (code ready — on-chain blocked by #236), Refs #236

> Each issue gets its own `closes` keyword (GitHub only auto-closes the first in
> a bare comma list).

**2 commits · 6 files · +774 / −42 · `tsc --noEmit` clean · 16/16 new unit tests
· no new dependencies · no behaviour change.**

---

## C-064 · RPC failover with backoff + rate budget — `#110` `M4`

**What:** the existing failover rotated endpoints on 429/5xx but retried
**immediately**; added real backoff + an optional rate budget.

**How / where:** `lib/rpc-failover.ts`
- `backoffDelayMs` — exponential backoff with full jitter; a 429/rate-limit
  error backs off **4× harder** than a transient blip (pure).
- `RpcRateBudget` — a token bucket to proactively stay under a provider's
  per-second plan limit; enabled via `RPC_RATE_BUDGET_PER_SEC` (off by default,
  non-breaking).
- `callWithFailover` — the retry loop extracted as a pure, **injectable**
  function, so backoff + rotation are unit-testable without a live RPC.
- `createFailoverConnection` now sleeps with backoff before rotating and
  throttles to the budget when configured. **Public API unchanged.**
- `tests/unit/rpc-failover.test.ts` (12): classification, backoff
  growth/cap/jitter/rate-limited, token-bucket refill, and the retry loop
  (retry+rotate, non-retryable throws immediately, give up after maxAttempts).

**Nuance:** the prod multi-provider list (Helius mainnet primary + a second
provider) is `RPC_CHAIN` env config — a deploy step; this PR is the resilience
*code* that consumes it.

## C-070 · Rollback + incident runbook — `#122` `M4`

**What / where:** `docs/RUNBOOK.md` — **pause, rollback, key compromise, RPC
outage**, each with concrete ordered steps grounded in the real system
(`SETTLEMENT_MODE`/`AUTH_ENFORCED`/`CRON_SECRET` levers, the crank + reconciler,
the failover, per-keypair blast radius, Vercel/Neon rollback + restore).

## C-019 · Real on-chain hire orchestration — `#60` `M1` *(code ready; blocked by #236)*

**What:** hiring an agent should post a **real** job + escrow (not a marker
memo), then the agent's own keypair accepts + delivers.

**How / where:**
- `lib/hire-onchain.ts` — pure orchestration: poster `botCreateJob` (locks USDC)
  → agent `botAcceptJob` → agent `botSubmitWork`. The three on-chain primitives
  are injected so the create → accept → deliver sequence + signer-per-step are
  unit-testable offline.
- `tests/unit/hire-onchain.test.ts` (4): call order, signer per step, the
  `agent != poster` guard, fail-fast (create throws → accept/deliver skipped).
- `scripts/hire-smoke.ts` — devnet smoke that runs the **real** lifecycle with a
  funded poster + a throwaway agent and prints Explorer links.

**⚠️ The real-chain proof is BLOCKED — and surfaced a critical deploy bug (#236).**
Running the smoke against a funded wallet showed the deployed program rejects
**every** instruction with `DeclaredProgramIdMismatch (4100)` and has **0**
on-chain accounts — i.e. the deployed bytecode's `declare_id` ≠ the address it's
deployed at, so **no real on-chain settlement has ever executed** (every app job
is DB/demo). That is a redeploy by the **upgrade authority** (`Gy5cU3…`) —
tracked in **#236**, blocking C-014/15/18/19/81/83. The orchestration here is
correct + unit-tested and will execute the moment the program is redeployed, so
**#60 stays open** and nothing is wired into the live route yet.

---

## Testing
```bash
cd app
npx tsc --noEmit                                # clean
npx tsx --test tests/unit/*.test.ts             # full suite green (+16 new)
# real-chain proof (after the #236 redeploy):
HIRE_POSTER_KEYFILE=… npx tsx scripts/hire-smoke.ts
```

## Coordination
- Branches off current `main` (incl. #233). Independent of the open #234
  (C-085/C-091/C-110) — no shared files.
- **#236** is the project-owner action that unblocks the on-chain half of this
  PR and the broader M1/M5 lifecycle.

## Not in this PR
- The on-chain redeploy + `init_config` (#236, upgrade authority only).
- Wiring `hire-onchain` into `/api/agents/hire` + the devnet proof — lands with
  the redeploy. C-123 (MCP write surface) is blocked by the same #236.
