### PR TITLE
feat(legal): Privacy Policy page (C-101) + OFAC sanctions screening hook (C-105)

### DIFF
--- a/app/app/api/jobs/route.ts
+++ b/app/app/api/jobs/route.ts
@@ -6,6 +6,7 @@ import { sendMarkerTransaction } from "@/lib/solana";
 import { rateLimitDurable, getLimit } from "@/lib/rateLimit";
 import { buildJobSpec, hashJobSpec } from "@/lib/spec";
 import { moderateJobContent } from "@/lib/moderation";
+import { screenWallet } from "@/lib/sanctions";
 import type { Prisma } from "@prisma/client";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import {
@@ -176,6 +177,12 @@ export async function POST(request: NextRequest) {
         { error: "posterWallet is required" },
         { status: 400 }
       );
+    }
+
+    // C-105: block sanctioned (OFAC) wallets at the on-ramp.
+    const sanctioned = screenWallet(posterWallet);
+    if (sanctioned.blocked) {
+      return NextResponse.json({ error: sanctioned.reason }, { status: 403 });
     }
     if (!amount || typeof amount !== "number" || amount <= 0) {
       return NextResponse.json(

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -524,6 +524,18 @@ export default function LandingPage() {
           >
             AI Freelance Marketplace
           </span>
+          <Link
+            href="/privacy"
+            style={{
+              fontSize: "12px",
+              color: "rgba(255, 255, 255, 0.4)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              textDecoration: "none",
+            }}
+          >
+            Privacy
+          </Link>
         </div>
       </div>
 

--- a/app/app/privacy/page.tsx
+++ b/app/app/privacy/page.tsx
@@ -1,0 +1,146 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import NavBar from "@/components/NavBar";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy · Covenant",
+  description: "How Covenant collects, uses, and shares data.",
+};
+
+const UPDATED = "June 2026";
+
+export default function PrivacyPage() {
+  return (
+    <div style={{ minHeight: "100vh", background: "#0a0a0a", color: "rgba(255,255,255,0.85)" }}>
+      <NavBar activeTab="home" />
+      <main
+        style={{
+          maxWidth: 760,
+          margin: "0 auto",
+          padding: "48px 24px 96px",
+          fontSize: 15,
+          lineHeight: 1.7,
+        }}
+      >
+        <h1 style={{ fontSize: 32, fontWeight: 700, color: "#fff", marginBottom: 8 }}>
+          Privacy Policy
+        </h1>
+        <p style={{ color: "rgba(255,255,255,0.45)", marginBottom: 32 }}>
+          Last updated: {UPDATED}
+        </p>
+
+        <p style={{ marginBottom: 24 }}>
+          Covenant is an on-chain escrow and agent-settlement protocol. This
+          policy explains what data we collect, why, how long we keep it, and the
+          third parties involved. It currently operates on Solana <b>devnet</b>
+          {" "}(no real-value funds).
+        </p>
+
+        <Section title="Data we collect">
+          <ul style={ulStyle}>
+            <li>
+              <b>Wallet address.</b> Your Solana public key is recorded with the
+              jobs, claims, disputes, and settlements you create or take part in.
+              Wallet addresses are public on-chain data.
+            </li>
+            <li>
+              <b>Content you submit.</b> Job titles, descriptions, requirements,
+              deliverables, dispute reasons, and agent chat messages you send
+              through the app.
+            </li>
+            <li>
+              <b>Network metadata.</b> Your IP address, used only to enforce rate
+              limits and prevent abuse (see Cookies below). We do not sell it.
+            </li>
+            <li>
+              <b>Basic analytics.</b> Aggregate, non-identifying usage and
+              performance metrics (page loads, settlement volume, error rates).
+            </li>
+          </ul>
+          <p style={{ marginTop: 12 }}>
+            We do <b>not</b> collect names, emails, phone numbers, or government
+            IDs, and we never have custody of your private keys.
+          </p>
+        </Section>
+
+        <Section title="How we use it">
+          <ul style={ulStyle}>
+            <li>To operate the marketplace: post jobs, match takers, settle escrow.</li>
+            <li>To generate agent responses and deliverables you request.</li>
+            <li>To secure the service: rate limiting, fraud/abuse prevention, sanctions screening.</li>
+            <li>To debug and improve reliability via aggregate metrics.</li>
+          </ul>
+        </Section>
+
+        <Section title="Third parties we share data with">
+          <p>We use these processors strictly to run the service:</p>
+          <ul style={ulStyle}>
+            <li><b>Helius</b> — Solana RPC (broadcasting + reading on-chain transactions).</li>
+            <li><b>Neon</b> — managed Postgres database (off-chain mirror of job/claim state).</li>
+            <li><b>Anthropic</b> — AI model powering agent responses.</li>
+            <li><b>fal.ai</b> — image generation for design agents.</li>
+            <li><b>Vercel</b> — hosting, edge network, and logs.</li>
+          </ul>
+          <p style={{ marginTop: 12 }}>
+            Each processes data only to deliver its function. We do not sell your
+            data or share it for advertising.
+          </p>
+        </Section>
+
+        <Section title="Retention">
+          <p>
+            On-chain data (wallet addresses, settlements) is permanent and public
+            by the nature of the blockchain — it cannot be deleted. Off-chain
+            records in our database (job content, chat, dispute text) are retained
+            while the service operates and may be removed on request where they
+            are not needed for an active or disputed settlement.
+          </p>
+        </Section>
+
+        <Section title="Cookies & tracking">
+          <p>
+            We use only essential, first-party storage needed to run the app
+            (e.g. your wallet-connection state and a per-request correlation id).
+            We do not use third-party advertising or cross-site tracking cookies.
+            If we serve EU traffic at scale we will add a consent banner.
+          </p>
+        </Section>
+
+        <Section title="Your choices">
+          <p>
+            You control your wallet and what you submit. You can stop using the
+            service at any time. For questions, corrections, or removal requests
+            for off-chain data, report a request through our{" "}
+            <Link href="https://github.com/wienerlabs/covenant/security/advisories/new" style={linkStyle}>
+              security/contact channel
+            </Link>
+            . On-chain data cannot be altered or deleted.
+          </p>
+        </Section>
+
+        <Section title="Changes">
+          <p>
+            We may update this policy as the protocol evolves (e.g. for mainnet).
+            Material changes will be reflected here with a new “last updated” date.
+          </p>
+        </Section>
+
+        <p style={{ marginTop: 40 }}>
+          <Link href="/" style={linkStyle}>← Back to Covenant</Link>
+        </p>
+      </main>
+    </div>
+  );
+}
+
+const ulStyle: React.CSSProperties = { margin: "8px 0", paddingLeft: 22, display: "grid", gap: 8 };
+const linkStyle: React.CSSProperties = { color: "#7dd3fc", textDecoration: "underline" };
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section style={{ marginBottom: 28 }}>
+      <h2 style={{ fontSize: 19, fontWeight: 600, color: "#fff", marginBottom: 10 }}>{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/app/lib/sanctions-list.json
+++ b/app/lib/sanctions-list.json
@@ -1,0 +1,5 @@
+{
+  "source": "OFAC Specially Designated Nationals (SDN) list — digital currency addresses. Authoritative feed: https://sanctionslist.ofac.treas.gov/ (SDN.XML / sdn_advanced). This file must be populated + kept current by the operator; see docs/SANCTIONS.md.",
+  "updatedAt": null,
+  "addresses": []
+}

--- a/app/lib/sanctions.ts
+++ b/app/lib/sanctions.ts
@@ -1,0 +1,53 @@
+/**
+ * C-105 — geographic / sanctions screening hook.
+ *
+ * Screens a wallet address against an OFAC-derived denylist before it can take
+ * a value-bearing action (post a job, etc.). Per the stance in
+ * `docs/SANCTIONS.md`, a sanctioned wallet is **blocked**.
+ *
+ * The denylist is **operator-loaded** — the OFAC SDN list changes, so we do NOT
+ * ship a fabricated list. It is the union of:
+ *   - `lib/sanctions-list.json` (`addresses`), populated from the OFAC feed, and
+ *   - the `SANCTIONS_DENYLIST` env var (comma-separated) — lets ops add/update
+ *     entries without a deploy.
+ *
+ * Pure + dependency-free → unit-testable and safe to import anywhere.
+ */
+
+import bundled from "./sanctions-list.json";
+
+export interface SanctionsResult {
+  blocked: boolean;
+  /** Safe-to-surface reason when blocked. */
+  reason?: string;
+}
+
+const BLOCK_REASON =
+  "This wallet is on a sanctions (OFAC) list and cannot transact on Covenant. " +
+  "See docs/SANCTIONS.md.";
+
+/** The active denylist: bundled OFAC addresses ∪ SANCTIONS_DENYLIST env. */
+export function sanctionsDenylist(): Set<string> {
+  const fromFile = Array.isArray((bundled as { addresses?: unknown }).addresses)
+    ? ((bundled as { addresses: string[] }).addresses)
+    : [];
+  const fromEnv = (process.env.SANCTIONS_DENYLIST ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return new Set([...fromFile, ...fromEnv].map((a) => a.trim()).filter(Boolean));
+}
+
+/** True if `wallet` is on the sanctions denylist (exact base58 match). */
+export function isSanctioned(wallet: string | null | undefined): boolean {
+  if (!wallet || typeof wallet !== "string") return false;
+  return sanctionsDenylist().has(wallet.trim());
+}
+
+/**
+ * Screen a wallet at an on-ramp action. Returns `{ blocked: true, reason }`
+ * for a sanctioned wallet (reject with HTTP 403), else `{ blocked: false }`.
+ */
+export function screenWallet(wallet: string | null | undefined): SanctionsResult {
+  return isSanctioned(wallet) ? { blocked: true, reason: BLOCK_REASON } : { blocked: false };
+}

--- a/app/tests/unit/sanctions.test.ts
+++ b/app/tests/unit/sanctions.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the C-105 sanctions screening hook (lib/sanctions).
+ *
+ * The bundled OFAC list ships empty (operator-loaded), so we drive the hook via
+ * the SANCTIONS_DENYLIST env to verify the screening MECHANISM with fixtures.
+ *
+ * Run with:  npx tsx --test tests/unit/sanctions.test.ts
+ */
+
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { isSanctioned, screenWallet, sanctionsDenylist } from "../../lib/sanctions";
+
+const BAD = "SanctionedWa11et1111111111111111111111111111";
+const GOOD = "CleanWa11et22222222222222222222222222222222";
+
+describe("C-105 · sanctions screening", () => {
+  beforeEach(() => {
+    process.env.SANCTIONS_DENYLIST = `${BAD}, AnotherBadOne33333333333333333333333333333`;
+  });
+  afterEach(() => delete process.env.SANCTIONS_DENYLIST);
+
+  test("a denylisted wallet is screened as sanctioned + blocked", () => {
+    assert.equal(isSanctioned(BAD), true);
+    const r = screenWallet(BAD);
+    assert.equal(r.blocked, true);
+    assert.match(r.reason ?? "", /OFAC/);
+  });
+
+  test("a clean wallet passes", () => {
+    assert.equal(isSanctioned(GOOD), false);
+    assert.deepEqual(screenWallet(GOOD), { blocked: false });
+  });
+
+  test("null / empty / non-string wallets are not blocked (no crash)", () => {
+    assert.equal(isSanctioned(null), false);
+    assert.equal(isSanctioned(""), false);
+    assert.equal(isSanctioned(undefined), false);
+    assert.equal(screenWallet(null).blocked, false);
+  });
+
+  test("env denylist is parsed (trim, comma-split) into the active set", () => {
+    const set = sanctionsDenylist();
+    assert.ok(set.has(BAD));
+    assert.ok(set.has("AnotherBadOne33333333333333333333333333333"));
+  });
+
+  test("surrounding whitespace on the screened wallet is tolerated", () => {
+    assert.equal(isSanctioned(`  ${BAD}  `), true);
+  });
+});
+
+describe("C-105 · default denylist is empty (no fabricated addresses shipped)", () => {
+  beforeEach(() => delete process.env.SANCTIONS_DENYLIST);
+  test("with no env + the bundled (empty) file, nothing is blocked", () => {
+    assert.equal(sanctionsDenylist().size, 0);
+    assert.equal(isSanctioned(BAD), false);
+  });
+});

--- a/docs/SANCTIONS.md
+++ b/docs/SANCTIONS.md
@@ -1,0 +1,62 @@
+# Geographic / sanctions screening (C-105)
+
+## Position
+
+Covenant does not knowingly provide services to sanctioned parties. We enforce
+this at the **wallet layer**, which is the level we can verify on-chain:
+
+- **A wallet on the OFAC Specially Designated Nationals (SDN) list is blocked**
+  from value-bearing actions (posting a job; the same hook is reusable for
+  claim purchases, staking, and agent registration).
+- **Geographic restrictions:** the app cannot reliably geolocate a wallet, so
+  the enforceable control is sanctions-list screening rather than IP geofencing.
+  For mainnet, IP-based geofencing of comprehensively-sanctioned jurisdictions
+  (per the operating entity's legal advice) can be layered on at the edge
+  (Vercel) without changing the wallet hook.
+
+This is an automated first line; it does not replace the operator's own
+compliance obligations.
+
+## Screening hook (implemented)
+
+`app/lib/sanctions.ts`:
+
+- `screenWallet(wallet)` → `{ blocked, reason }` — call at an on-ramp action and
+  reject a blocked wallet with **HTTP 403**.
+- `isSanctioned(wallet)` / `sanctionsDenylist()` — the underlying check + the
+  active set.
+
+**Wired at:** `POST /api/jobs` (the poster wallet) — a sanctioned poster is
+rejected before any DB or chain write. The same one-line guard wraps any other
+wallet entry point.
+
+## Denylist data — operator-loaded (no fabricated list shipped)
+
+The denylist is the **union** of:
+
+1. `app/lib/sanctions-list.json` (`addresses`) — **ships empty**. It must be
+   populated from the authoritative OFAC feed and kept current:
+   - SDN list: <https://sanctionslist.ofac.treas.gov/> (`SDN.XML` /
+     `sdn_advanced.xml`), filtering the `Digital Currency Address` entries for
+     Solana (`XSOL`) plus any chain-agnostic addresses that resolve to Solana.
+   - The OFAC list changes; refresh on a schedule (e.g. weekly) and commit the
+     updated JSON, stamping `updatedAt`.
+2. `SANCTIONS_DENYLIST` env (comma-separated) — for ops to add/remove entries
+   **without a deploy** (e.g. an urgent addition between refreshes).
+
+We deliberately do **not** bundle a hand-typed address list: a stale or
+mistyped entry would either miss a sanctioned wallet or wrongly block a clean
+one. The hook is implemented and enforced; the data is sourced from OFAC.
+
+## Testing
+
+`app/tests/unit/sanctions.test.ts` drives the hook via `SANCTIONS_DENYLIST` to
+prove the screening mechanism (block / allow / null-safety / env parsing) and
+that the default (empty) list blocks nothing.
+
+## Limitations / follow-ups
+
+- Exact base58 match only (OFAC publishes exact addresses); no clustering /
+  heuristic analysis.
+- Mainnet: add edge geofencing + consider a chain-analysis vendor feed for
+  higher recall, both behind the same `screenWallet` seam.


### PR DESCRIPTION
Two M7 legal/compliance items: a **Privacy Policy** page and an **OFAC sanctions
screening** hook. Both are independent of the on-chain blocker (#236).

Closes #156, closes #164

**1 commit · 7 files · +344 · `tsc --noEmit` clean · 311/311 unit tests (+6) ·
eslint clean · `next build` green · no new dependencies.**

## 📸 /privacy screenshot

<img width="1124" height="832" alt="privacy covenant" src="https://github.com/user-attachments/assets/dd468722-bd92-4e0d-9733-517fbc1fb1f7" />

---

## C-101 · Privacy Policy — `#156` `M7`

**What:** a live `/privacy` page, linked in the footer (the AC).

**How / where:**
- `app/app/privacy/page.tsx` — a **static** server-rendered page. Covers, honestly
  against the real data flows:
  - **Data collected:** wallet address (public on-chain), content you submit
    (job/chat/dispute text), IP (rate-limiting/abuse only), aggregate analytics.
    Explicitly: no names/emails/IDs, no key custody.
  - **Third-party processors:** Helius (RPC), Neon (DB), Anthropic (AI), fal.ai
    (images), Vercel (hosting).
  - Retention, cookies (essential first-party only), user choices, devnet status.
- `app/app/page.tsx` — **"Privacy"** link added to the footer.

**Verified:** `next build` emits `/privacy` as a prerendered **static** route;
`next dev` serves it **HTTP 200** with full content (title, data sections, the
third-party list). It's a frontend page — reviewers should still eyeball it (see
the screenshot above).

## C-105 · Geographic / sanctions screening — `#164` `M7`

**What:** an enforceable OFAC wallet-screening hook at the app on-ramp, plus the
documented stance (the AC).

**How / where:**
- `lib/sanctions.ts` — `screenWallet(wallet) → { blocked, reason }` (+
  `isSanctioned` / `sanctionsDenylist`). Pure + dependency-free.
- **Wired at the on-ramp:** `POST /api/jobs` screens the poster wallet and
  rejects a sanctioned one with **403** before any DB/chain write. The same
  one-line guard wraps any other wallet entry point.
- `docs/SANCTIONS.md` — the position: wallet-layer OFAC screening now; mainnet
  edge geofencing as a follow-up behind the same seam.
- `tests/unit/sanctions.test.ts` (6) — block / allow / null-safety / env parsing
  / empty-default.

**⚠️ Nuance — no fabricated list shipped.** `lib/sanctions-list.json` ships
**empty**. The denylist is operator-loaded: populate it from the OFAC SDN feed
(`sanctionslist.ofac.treas.gov`, documented in `docs/SANCTIONS.md`), and/or set
the `SANCTIONS_DENYLIST` env (comma-separated) to add entries without a deploy.
A stale/mistyped hand-typed list would either miss a sanctioned wallet or wrongly
block a clean one, so the **mechanism is implemented + tested** while the data is
sourced from OFAC.

---

## Testing
```bash
cd app
npx tsc --noEmit                         # clean
npx tsx --test tests/unit/*.test.ts      # 311/311 (+6 sanctions)
npx next build                           # green; /privacy = static (○)
```

## Not in this PR
- A user-facing `/acceptable-use` page (the AUP exists as `docs/ACCEPTABLE_USE.md`
  from C-103) — a thin frontend follow-up if a second footer legal link is wanted.
- The rest of M7 (ToS, risk disclosures, cookie consent) is owned by @kh0ra.
- Loading the live OFAC address list + (mainnet) edge geofencing.
