### PR TITLE
DB transfer-cost guardrails: quota alert + caching + indexes + polling (C-115)

### DIFF
--- a/app/app/api/cron/db-quota/route.ts
+++ b/app/app/api/cron/db-quota/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { constantTimeEqual } from "@/lib/secure-compare";
+import { log } from "@/lib/logger";
+import { checkDbQuota, getDbSizeBytes } from "@/lib/db-quota";
+
+// Always dynamic — talks to Prisma per request; never pre-render at build.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+/**
+ * GET /api/cron/db-quota
+ *
+ * C-115 — DB quota guardrail. Probes `pg_database_size(current_database())` and,
+ * when usage crosses the warn/critical fraction of `DB_QUOTA_LIMIT_BYTES`, fires
+ * `alertDbQuota` so the Neon quota cannot fill up silently. The size + level are
+ * always logged (structured), so it is observable even without a webhook.
+ *
+ * No-op until `DB_QUOTA_LIMIT_BYTES` is set (opt-in). The cron cadence IS the
+ * alert rate-limit: schedule it hourly → at most one alert per hour over quota.
+ *
+ * Schedule in vercel.json:
+ *   { "crons": [{ "path": "/api/cron/db-quota", "schedule": "0 * * * *" }] }
+ */
+
+const CRON_SECRET = process.env.CRON_SECRET ?? "";
+
+function authorized(req: NextRequest): boolean {
+  // Header-only, constant-time, fail-closed — same posture as the other crons.
+  if (!CRON_SECRET) return false;
+  const header = req.headers.get("authorization") ?? "";
+  return constantTimeEqual(header, `Bearer ${CRON_SECRET}`);
+}
+
+export async function GET(req: NextRequest) {
+  if (!authorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const reqLog = log.forRequest(req);
+
+  const result = await checkDbQuota({
+    getSizeBytes: () => getDbSizeBytes(prisma),
+    onResult: (r) =>
+      reqLog.info("db quota check", {
+        used_bytes: r.usedBytes,
+        limit_bytes: r.limitBytes,
+        ratio: r.ratio,
+        level: r.level,
+        alerted: r.alerted,
+      }),
+  });
+
+  if (!result.configured) {
+    reqLog.info("db quota check skipped: DB_QUOTA_LIMIT_BYTES unset");
+  }
+
+  return NextResponse.json(result, { status: 200 });
+}

--- a/app/app/api/stats/route.ts
+++ b/app/app/api/stats/route.ts
@@ -1,40 +1,53 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { memoize } from "@/lib/cache";
 
 export const dynamic = "force-dynamic";
 
+interface HomeStats {
+  totalJobs: number;
+  totalLocked: number;
+  completed: number;
+  successRate: number;
+  activeUsers: number;
+  totalTxFees: number;
+}
+
+// C-115: cache the home-page stats. The home page polls this endpoint; without a
+// cache every visitor's poll runs 5 COUNT/scan queries. A short TTL collapses all
+// concurrent polls into one query set per window, cutting DB transfer cost.
+const STATS_TTL_MS = Number(process.env.STATS_CACHE_TTL_MS ?? 30_000);
+
 export async function GET() {
   try {
-    const totalJobs = await prisma.job.count();
+    const data = await memoize<HomeStats>("stats:home", STATS_TTL_MS, async () => {
+      const totalJobs = await prisma.job.count();
 
-    const lockedJobs = await prisma.job.findMany({
-      where: {
-        status: { in: ["Open", "Accepted"] },
-      },
-      select: { amount: true },
+      const lockedJobs = await prisma.job.findMany({
+        where: { status: { in: ["Open", "Accepted"] } },
+        select: { amount: true },
+      });
+      const totalLocked = lockedJobs.reduce((sum, job) => sum + job.amount, 0);
+
+      const completed = await prisma.job.count({ where: { status: "Completed" } });
+      const successRate = totalJobs > 0 ? (completed / totalJobs) * 100 : 0;
+
+      const activeUsers = await prisma.profile.count();
+
+      const totalTransactions = await prisma.transaction.count();
+      const totalTxFees = totalTransactions * 0.000005; // Average Solana fee
+
+      return {
+        totalJobs,
+        totalLocked,
+        completed,
+        successRate: Math.round(successRate * 10) / 10,
+        activeUsers,
+        totalTxFees,
+      };
     });
 
-    const totalLocked = lockedJobs.reduce((sum, job) => sum + job.amount, 0);
-
-    const completed = await prisma.job.count({
-      where: { status: "Completed" },
-    });
-
-    const successRate = totalJobs > 0 ? (completed / totalJobs) * 100 : 0;
-
-    const activeUsers = await prisma.profile.count();
-
-    const totalTransactions = await prisma.transaction.count();
-    const totalTxFees = totalTransactions * 0.000005; // Average Solana fee
-
-    return NextResponse.json({
-      totalJobs,
-      totalLocked,
-      completed,
-      successRate: Math.round(successRate * 10) / 10,
-      activeUsers,
-      totalTxFees,
-    });
+    return NextResponse.json(data);
   } catch (error) {
     console.error("GET /api/stats error:", error);
     return NextResponse.json(

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -84,7 +84,7 @@ export default function LandingPage() {
       }
     }
     fetchStats();
-    const poll = setInterval(fetchStats, 15000);
+    const poll = setInterval(fetchStats, 30000); // C-115: >=30s to cut DB transfer cost
     return () => clearInterval(poll);
   }, []);
 

--- a/app/app/settlement/page.tsx
+++ b/app/app/settlement/page.tsx
@@ -205,7 +205,7 @@ export default function SettlementPage() {
       }
     }
     load();
-    const t = setInterval(load, 10_000);
+    const t = setInterval(load, 30_000); // C-115: >=30s to cut DB transfer cost
     return () => {
       cancelled = true;
       clearInterval(t);

--- a/app/lib/db-quota.ts
+++ b/app/lib/db-quota.ts
@@ -1,0 +1,139 @@
+/**
+ * C-115 — database quota guardrail.
+ *
+ * Probes the live Postgres database size and warns (logs + optional alert)
+ * BEFORE the Neon storage quota is hit, so the quota incident "cannot recur
+ * silently". **Opt-in**: without `DB_QUOTA_LIMIT_BYTES` the check is a no-op.
+ *
+ * The ratio/level math is pure (unit-tested); the size probe and the alert are
+ * injectable, so the decision logic is testable without a real DB or webhook.
+ *
+ * Env:
+ *   DB_QUOTA_LIMIT_BYTES   the Neon plan's storage limit in bytes (required to arm)
+ *   DB_QUOTA_WARN_RATIO    warn at this fraction of the limit (default 0.80)
+ *   DB_QUOTA_CRIT_RATIO    critical at this fraction (default 0.95)
+ */
+
+import { alertDbQuota } from "@/lib/alerts";
+
+export type QuotaLevel = "ok" | "warn" | "critical";
+
+/** used/limit, clamped to >= 0; 0 when the limit is unknown (<= 0). Pure. */
+export function quotaUsageRatio(usedBytes: number, limitBytes: number): number {
+  if (!Number.isFinite(usedBytes) || !Number.isFinite(limitBytes) || limitBytes <= 0) return 0;
+  return Math.max(0, usedBytes / limitBytes);
+}
+
+/** Map a usage ratio to a level given the warn/critical thresholds. Pure. */
+export function quotaLevel(ratio: number, warnRatio: number, critRatio: number): QuotaLevel {
+  if (ratio >= critRatio) return "critical";
+  if (ratio >= warnRatio) return "warn";
+  return "ok";
+}
+
+export interface DbQuotaConfig {
+  limitBytes: number;
+  warnRatio: number;
+  critRatio: number;
+}
+
+function clampRatio(v: number, fallback: number): number {
+  return Number.isFinite(v) && v > 0 && v <= 1 ? v : fallback;
+}
+
+/**
+ * Build config from env. Returns `null` when `DB_QUOTA_LIMIT_BYTES` is unset or
+ * invalid — that is the opt-in switch (no limit → the guardrail is a no-op).
+ */
+export function dbQuotaConfigFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): DbQuotaConfig | null {
+  const limitBytes = Number(env.DB_QUOTA_LIMIT_BYTES);
+  if (!Number.isFinite(limitBytes) || limitBytes <= 0) return null;
+  return {
+    limitBytes,
+    warnRatio: clampRatio(Number(env.DB_QUOTA_WARN_RATIO), 0.8),
+    critRatio: clampRatio(Number(env.DB_QUOTA_CRIT_RATIO), 0.95),
+  };
+}
+
+export interface DbQuotaResult {
+  configured: boolean;
+  usedBytes: number;
+  limitBytes: number;
+  ratio: number;
+  level: QuotaLevel;
+  alerted: boolean;
+}
+
+export interface CheckDbQuotaDeps {
+  /** Probe that returns the current DB size in bytes. */
+  getSizeBytes: () => Promise<number>;
+  /** Override config (else read from env). */
+  config?: DbQuotaConfig | null;
+  /** Override the alert sink (else alertDbQuota). */
+  alert?: (metric: string, value: number, threshold: number) => Promise<boolean>;
+  /** Optional observer (e.g. structured log) — always called when configured. */
+  onResult?: (result: DbQuotaResult) => void;
+}
+
+const UNCONFIGURED: DbQuotaResult = {
+  configured: false,
+  usedBytes: 0,
+  limitBytes: 0,
+  ratio: 0,
+  level: "ok",
+  alerted: false,
+};
+
+/**
+ * Probe DB size, compute the level, and fire `alertDbQuota` when at or above
+ * the warn threshold. No-op (`configured:false`) when no limit is set. Never
+ * throws — a guardrail must not itself break the cron that runs it.
+ *
+ * Alert cadence: this fires on every over-threshold run, so the caller (the
+ * cron) supplies the rate limit — schedule it e.g. hourly and you get at most
+ * one alert per hour while over quota.
+ */
+export async function checkDbQuota(deps: CheckDbQuotaDeps): Promise<DbQuotaResult> {
+  const config = deps.config ?? dbQuotaConfigFromEnv();
+  if (!config) return UNCONFIGURED;
+
+  let usedBytes = 0;
+  try {
+    usedBytes = await deps.getSizeBytes();
+  } catch {
+    usedBytes = 0; // probe failure → treat as 0 (ok); never throw
+  }
+
+  const ratio = quotaUsageRatio(usedBytes, config.limitBytes);
+  const level = quotaLevel(ratio, config.warnRatio, config.critRatio);
+
+  let alerted = false;
+  if (level !== "ok") {
+    const alert = deps.alert ?? alertDbQuota;
+    alerted = await alert("db_size_bytes", usedBytes, config.limitBytes).catch(() => false);
+  }
+
+  const result: DbQuotaResult = {
+    configured: true,
+    usedBytes,
+    limitBytes: config.limitBytes,
+    ratio: Math.round(ratio * 10000) / 10000,
+    level,
+    alerted,
+  };
+  deps.onResult?.(result);
+  return result;
+}
+
+/** `SELECT pg_database_size(current_database())` via the given Prisma client. */
+export async function getDbSizeBytes(client: {
+  $queryRaw: <T = unknown>(query: TemplateStringsArray, ...values: unknown[]) => Promise<T>;
+}): Promise<number> {
+  const rows = await client.$queryRaw<Array<{ size: bigint | number | string }>>`
+    SELECT pg_database_size(current_database()) AS size
+  `;
+  const size = rows?.[0]?.size;
+  return typeof size === "bigint" ? Number(size) : Number(size ?? 0);
+}

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -55,6 +55,7 @@ model Job {
   @@index([takerWallet])
   @@index([status])
   @@index([challengeEndAt])
+  @@index([updatedAt]) // C-115: hot "recent activity" ordering (settlement/stats, activity, notifications, …)
 }
 
 // ============================================================================

--- a/app/tests/unit/db-quota.test.ts
+++ b/app/tests/unit/db-quota.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the C-115 DB quota guardrail (lib/db-quota).
+ *
+ * Run with:  npx tsx --test tests/unit/db-quota.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  quotaUsageRatio,
+  quotaLevel,
+  dbQuotaConfigFromEnv,
+  checkDbQuota,
+} from "../../lib/db-quota";
+
+describe("C-115 · quotaUsageRatio (pure)", () => {
+  test("used/limit", () => assert.equal(quotaUsageRatio(800, 1000), 0.8));
+  test("over 100% is allowed (>1)", () => assert.equal(quotaUsageRatio(1500, 1000), 1.5));
+  test("unknown limit (<=0) → 0", () => {
+    assert.equal(quotaUsageRatio(800, 0), 0);
+    assert.equal(quotaUsageRatio(800, -5), 0);
+  });
+  test("non-finite inputs → 0", () => {
+    assert.equal(quotaUsageRatio(NaN, 1000), 0);
+    assert.equal(quotaUsageRatio(800, Infinity), 0);
+  });
+});
+
+describe("C-115 · quotaLevel (pure)", () => {
+  test("below warn → ok", () => assert.equal(quotaLevel(0.5, 0.8, 0.95), "ok"));
+  test("at warn → warn", () => assert.equal(quotaLevel(0.8, 0.8, 0.95), "warn"));
+  test("between warn and crit → warn", () => assert.equal(quotaLevel(0.9, 0.8, 0.95), "warn"));
+  test("at/over crit → critical", () => {
+    assert.equal(quotaLevel(0.95, 0.8, 0.95), "critical");
+    assert.equal(quotaLevel(1.2, 0.8, 0.95), "critical");
+  });
+});
+
+describe("C-115 · dbQuotaConfigFromEnv", () => {
+  test("no limit → null (opt-in off)", () => {
+    assert.equal(dbQuotaConfigFromEnv({}), null);
+    assert.equal(dbQuotaConfigFromEnv({ DB_QUOTA_LIMIT_BYTES: "0" }), null);
+    assert.equal(dbQuotaConfigFromEnv({ DB_QUOTA_LIMIT_BYTES: "abc" }), null);
+  });
+  test("limit set → config with default ratios", () => {
+    const c = dbQuotaConfigFromEnv({ DB_QUOTA_LIMIT_BYTES: "1000000" });
+    assert.deepEqual(c, { limitBytes: 1_000_000, warnRatio: 0.8, critRatio: 0.95 });
+  });
+  test("custom ratios parsed; out-of-range fall back", () => {
+    const c = dbQuotaConfigFromEnv({
+      DB_QUOTA_LIMIT_BYTES: "1000",
+      DB_QUOTA_WARN_RATIO: "0.7",
+      DB_QUOTA_CRIT_RATIO: "5", // invalid (>1) → default 0.95
+    });
+    assert.equal(c?.warnRatio, 0.7);
+    assert.equal(c?.critRatio, 0.95);
+  });
+});
+
+describe("C-115 · checkDbQuota", () => {
+  const config = { limitBytes: 1000, warnRatio: 0.8, critRatio: 0.95 };
+
+  test("unconfigured → no-op, no alert", async () => {
+    let alertCalls = 0;
+    const r = await checkDbQuota({
+      getSizeBytes: async () => 999,
+      config: null,
+      alert: async () => (alertCalls++, true),
+    });
+    assert.equal(r.configured, false);
+    assert.equal(r.alerted, false);
+    assert.equal(alertCalls, 0);
+  });
+
+  test("under warn → no alert, level ok", async () => {
+    let alertCalls = 0;
+    const r = await checkDbQuota({
+      getSizeBytes: async () => 500,
+      config,
+      alert: async () => (alertCalls++, true),
+    });
+    assert.equal(r.level, "ok");
+    assert.equal(r.alerted, false);
+    assert.equal(alertCalls, 0);
+  });
+
+  test("at/over warn → alerts with (used, limit)", async () => {
+    const calls: Array<{ value: number; threshold: number }> = [];
+    const r = await checkDbQuota({
+      getSizeBytes: async () => 850,
+      config,
+      alert: async (_m, value, threshold) => (calls.push({ value, threshold }), true),
+    });
+    assert.equal(r.level, "warn");
+    assert.equal(r.alerted, true);
+    assert.deepEqual(calls, [{ value: 850, threshold: 1000 }]);
+  });
+
+  test("over crit → critical + alerts", async () => {
+    let alerted = false;
+    const r = await checkDbQuota({
+      getSizeBytes: async () => 990,
+      config,
+      alert: async () => ((alerted = true), true),
+    });
+    assert.equal(r.level, "critical");
+    assert.equal(alerted, true);
+  });
+
+  test("probe failure → treated as 0, ok, never throws", async () => {
+    const r = await checkDbQuota({
+      getSizeBytes: async () => {
+        throw new Error("db down");
+      },
+      config,
+    });
+    assert.equal(r.usedBytes, 0);
+    assert.equal(r.level, "ok");
+    assert.equal(r.alerted, false);
+  });
+
+  test("onResult observer receives the result", async () => {
+    let seenLevel: string | null = null;
+    await checkDbQuota({
+      getSizeBytes: async () => 850,
+      config,
+      alert: async () => true,
+      onResult: (res) => {
+        seenLevel = res.level;
+      },
+    });
+    assert.equal(seenLevel, "warn");
+  });
+});


### PR DESCRIPTION
## Özet

**C-115 — DB transfer-cost guardrails.** Neon quota olayının **sessizce tekrar
edememesini** sağlar (alert-before-quota) ve transfer maliyetini süren polling +
sorgu yükünü kısar. Tamamı **opt-in / non-breaking**.

> ⚠️ **Stacked PR.** Bu PR #242'nin (`feat/c112-…`) üstüne kurulu — "alert before
> quota" parçası #242'deki `lib/alerts.ts`'in `alertDbQuota` helper'ını kullanıyor.
> **Base bilerek `feat/c112-alerting-c091-auth-c110-logging`** seçildi ki diff
> sadece C-115'i göstersin. #242 main'e merge olunca bu PR otomatik main'e
> retarget olur; **önce #242, sonra bu**.

**1 commit · 7 dosya (4 değişen + 3 yeni) · prisma schema valid · `tsc` temiz ·
333/333 unit test (+17) · eslint temiz · cron canlı smoke'lu.**

Closes #180

---

## Alert before quota — çekirdek (AC: "quota sessizce dolamaz")

**Ne:** Canlı Postgres boyutunu ölçüp, Neon storage limitine yaklaşınca
**loglar + (opsiyonel) alert atar**. Limit env'i set değilse **no-op**.

**Nasıl / nerede:**
- **`lib/db-quota.ts`** (yeni):
  - Saf: `quotaUsageRatio(used, limit)` + `quotaLevel(ratio, warn, crit)` +
    `dbQuotaConfigFromEnv` (env parse + ratio clamp).
  - `checkDbQuota(deps)` — boyut-probe + alert sink **inject edilebilir**, **asla
    throw etmez** (guardrail, onu çalıştıran cron'u kırmamalı). `warn+` seviyede
    `alertDbQuota` ateşler.
  - `getDbSizeBytes(client)` — `SELECT pg_database_size(current_database())`.
  - Opt-in: `DB_QUOTA_LIMIT_BYTES` (limit). Eşikler `DB_QUOTA_WARN_RATIO` /
    `DB_QUOTA_CRIT_RATIO` (default **0.80 / 0.95**).
- **`app/api/cron/db-quota/route.ts`** (yeni): `CRON_SECRET` + `constantTimeEqual`
  ile korumalı GET (mevcut crontlar — reconcile/finalize/keep-alive — ile **aynı
  posture**). Boyutu ölçer, **seviyeyi her zaman loglar** (webhook olmasa da
  görünür), `warn+` ise alert atar.
- **`tests/unit/db-quota.test.ts`** (yeni, **17 test**): ratio/level/config + her
  `checkDbQuota` yolu (no-op, eşik altı/üstü, probe-failure→0, observer).

**⚠️ Nüanslar:**
- **Cron cadence = alert rate-limit.** In-memory dedup yok (serverless'te güvenilmez);
  cron'u saatlik kurarsan quota üstündeyken saatte en fazla 1 alert. Cron, mevcut
  crontlarla **aynı şekilde** tetiklenir (`vercel.json`'da `crons` yok → operatörün
  scheduler'ı `CRON_SECRET` ile endpoint'i çağırır). `vercel.json`'a tek başına
  `db-quota` eklemedim — mevcut desenle tutarlılık için.
- **Probe çökerse** (DB down) → `usedBytes=0`, `level=ok`, alert yok — guardrail
  asla patlamaz.

---

## Transfer maliyetini kısma

**Polling ≥30s** (AC: "Settlement/home polling ≥30s"):
- `app/page.tsx` (home): `fetchStats` poll **15s → 30s**.
- `app/settlement/page.tsx`: data `load` **10s → 30s**.
- *1 saniyelik UI sayaçları* (countdown / saat tick) **dokunulmadı** — DB'ye
  gitmiyorlar, sadece re-render; AC "polling"i veri-poll'ü kastediyor.

**Caching:**
- `app/api/stats/route.ts` (home) → `memoize` (30s TTL, `STATS_CACHE_TTL_MS` ile
  ayarlanır). Cache'siz her ziyaretçinin poll'ü **5 COUNT/scan** sorgusu
  çalıştırıyordu; kısa TTL eşzamanlı poll'leri pencere başına **tek sorgu setine**
  indiriyor.
- `app/api/settlement/stats` **zaten `memoize`'lıydı** — dokunmadım.

**Index:**
- `prisma/schema.prisma` → Job'a `@@index([updatedAt])`. `orderBy: { updatedAt }`
  **10 hot "recent activity" sorgusunda** kullanılıyordu ve index'siz ti.
- **Nüans:** Diğer hot kolonlar (`status`, `challengeEndAt`, `posterWallet`,
  `Dispute.resolution`, …) **zaten index'liydi** (şemada 45 index var) — uydurma
  index eklemedim; `updatedAt` gerçek tek boşluktu.

---

## Doğrulama

```bash
cd app
DATABASE_URL=… DIRECT_URL=… npx prisma validate   # "schema is valid 🚀"
npx tsc --noEmit                                   # temiz
npx tsx --test tests/unit/*.test.ts                # 333/333 (+17 db-quota)
npx eslint <değişen dosyalar>                      # temiz
```
**Canlı cron smoke** (`CRON_SECRET=testsecret`, `DB_QUOTA_LIMIT_BYTES=1000000`,
DB kasıtlı down):
```
GET /api/cron/db-quota                       → HTTP 401  (auth yok)
GET … -H "Authorization: Bearer wrong"       → HTTP 401  (yanlış secret)
GET … -H "Authorization: Bearer testsecret"  → HTTP 200
  { "configured": true, "usedBytes": 0, "limitBytes": 1000000,
    "ratio": 0, "level": "ok", "alerted": false }   ← probe-fail dürüstçe ok'a düşüyor
```

## Bu PR'da olmayanlar (dürüst sınır)
- **Polling**: AC sadece settlement/home dedi → onları yaptım. Diğer 10s poll'lü
  sayfalar (taker/admin/events/onchain + bazı component'ler) **kapsam dışı**;
  istenirse ayrı bir geçişte ≥30s'e çekilebilir.
- **Alert arming operatöre bağlı**: `DB_QUOTA_LIMIT_BYTES` set + cron schedule
  edilmeli (mevcut crontlar gibi). Mekanizma + testler hazır.
- `covenant_db_size_bytes` metric'i (#242'nin metrics route'una eklenebilir) —
  conflict'i önlemek için bu PR'a koymadım; #242 merge olunca küçük bir follow-up.
