### PR TITLE
SDK resilience + security regression suite + docs completeness (C-122 / C-139 / C-142)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ const { jobPda } = await covenant.createJob({
 
 ---
 
+## Documentation
+
+Full docs live in **[`docs/`](docs/README.md)** — start there. Quick links:
+
+- **[Architecture](docs/ARCHITECTURE.md)** · **[Job state machine](docs/STATE_MACHINE.md)**
+- **[SDK reference](sdk/README.md)** (`covenant-sdk`) · **[MCP server](mcp/README.md)** (`covenant-mcp`)
+- **[HTTP API guide](docs/API.md)** — live spec at `/api/openapi`, rendered at `/api-docs`
+- **[Runbook](docs/RUNBOOK.md)** · **[SLO](docs/SLO.md)** · **[Secrets](docs/SECRETS.md)**
+
+---
+
 ## How It Works
 
 ```

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,8 @@
     "postinstall": "prisma generate",
     "start": "next start",
     "lint": "next lint",
-    "test": "npx --yes tsx --test tests/unit/*.test.ts",
+    "test": "npx --yes tsx --test tests/unit/*.test.ts tests/security/*.test.ts",
+    "test:security": "npx --yes tsx --test tests/security/*.test.ts",
     "test:x402": "npx --yes tsx --test tests/unit/x402-server.test.ts tests/unit/x402-payments.test.ts tests/unit/x402-flow.test.ts",
     "license:check": "npx --yes tsx scripts/license-inventory.ts --check"
   },

--- a/app/tests/security/regression.test.ts
+++ b/app/tests/security/regression.test.ts
@@ -1,0 +1,196 @@
+/**
+ * C-139 — security regression suite.
+ *
+ * Each test reproduces a class of exploit that was closed in M2 (x402 payment
+ * bypasses) or M6 (auth gaps), and asserts it stays closed. If someone reopens
+ * a hole — accepts an unverified payment, drops the admin fail-closed default,
+ * un-blocks an SSRF target — the corresponding test goes red.
+ *
+ * Pure library-level assertions (no DB / no network), so they run fast and
+ * deterministically alongside the unit suite.
+ *
+ * Run with:  npx --yes tsx --test tests/security/*.test.ts
+ */
+
+import { test, describe, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { constantTimeEqual } from "../../lib/secure-compare";
+import { requireAdmin } from "../../lib/admin-auth";
+import { verifyWalletSignature } from "../../lib/wallet-auth";
+import { validatePaymentSchema, verifyTransfer } from "../../lib/x402-server";
+import { isBlockedIp, checkUrlSync } from "../../lib/ssrf";
+import { requireAuth } from "../../lib/require-auth";
+
+/* ============================================================ *
+ *  M2 — x402 payment bypasses (C-030 / C-031 / C-033)
+ * ============================================================ */
+
+describe("M2 · x402 — payment cannot be spoofed", () => {
+  // Minimal accept descriptor; validatePaymentSchema only reads these fields.
+  const accept = { scheme: "exact", network: "solana-devnet", asset: "MintAAA" } as unknown as Parameters<
+    typeof validatePaymentSchema
+  >[1];
+  const parsed = (scheme: string, network: string, asset: string) =>
+    ({ txSignature: "Sig1111", scheme, network, asset }) as unknown as Parameters<typeof validatePaymentSchema>[0];
+
+  test("EXPLOIT C-033: wrong scheme/network/asset is rejected", () => {
+    assert.ok(
+      validatePaymentSchema(parsed("bogus", "solana-devnet", "MintAAA"), accept).some(
+        (i) => i.field === "scheme",
+      ),
+    );
+    assert.ok(
+      validatePaymentSchema(parsed("exact", "ethereum", "MintAAA"), accept).some(
+        (i) => i.field === "network",
+      ),
+    );
+    assert.ok(
+      validatePaymentSchema(parsed("exact", "solana-devnet", "WrongMint"), accept).some(
+        (i) => i.field === "asset",
+      ),
+    );
+  });
+
+  test("a fully-matching schema has zero issues (no false positive)", () => {
+    assert.equal(
+      validatePaymentSchema(parsed("exact", "solana-devnet", "MintAAA"), accept).length,
+      0,
+    );
+  });
+
+  // ---- C-031: the recipient must actually receive the right mint + amount ----
+  const RECIP = "RecipientWalletAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const OTHER = "AttackerWalletBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const PAYER = "PayerWalletCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+  const MINT_A = "MintAAA";
+  const MINT_B = "MintBBB";
+
+  /** A transaction that moves `amount` atomic of `mint` from PAYER to RECIP. */
+  function transferMeta(mint: string, amount: number) {
+    return {
+      preTokenBalances: [
+        { accountIndex: 0, mint, owner: RECIP, uiTokenAmount: { amount: "0" } },
+        { accountIndex: 1, mint, owner: PAYER, uiTokenAmount: { amount: String(amount) } },
+      ],
+      postTokenBalances: [
+        { accountIndex: 0, mint, owner: RECIP, uiTokenAmount: { amount: String(amount) } },
+        { accountIndex: 1, mint, owner: PAYER, uiTokenAmount: { amount: "0" } },
+      ],
+    };
+  }
+
+  test("a correct transfer verifies", () => {
+    const r = verifyTransfer(transferMeta(MINT_A, 1000), { mint: MINT_A, payTo: RECIP, minAmountAtomic: 1000n });
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.amountAtomic, 1000n);
+  });
+
+  test("EXPLOIT C-031: wrong recipient is rejected", () => {
+    const r = verifyTransfer(transferMeta(MINT_A, 1000), { mint: MINT_A, payTo: OTHER, minAmountAtomic: 1000n });
+    assert.equal(r.ok, false);
+  });
+
+  test("EXPLOIT C-031: wrong mint is rejected", () => {
+    const r = verifyTransfer(transferMeta(MINT_A, 1000), { mint: MINT_B, payTo: RECIP, minAmountAtomic: 1000n });
+    assert.equal(r.ok, false);
+  });
+
+  test("EXPLOIT C-031: underpayment is rejected", () => {
+    const r = verifyTransfer(transferMeta(MINT_A, 1000), { mint: MINT_A, payTo: RECIP, minAmountAtomic: 2000n });
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.reason, /underpay/i);
+  });
+});
+
+/* ============================================================ *
+ *  M6 — auth gaps (C-091 / C-093 / C-094 / C-095)
+ * ============================================================ */
+
+describe("M6 · admin endpoints are fail-closed (C-095)", () => {
+  afterEach(() => {
+    delete process.env.ADMIN_SECRET;
+    delete process.env.CRON_SECRET;
+  });
+
+  test("EXPLOIT: no admin secret configured → denied (never open)", () => {
+    delete process.env.ADMIN_SECRET;
+    delete process.env.CRON_SECRET;
+    const r = requireAdmin(new Request("http://x/api/admin", { headers: { authorization: "Bearer anything" } }));
+    assert.equal(r.ok, false);
+  });
+
+  test("EXPLOIT: wrong bearer token → denied", () => {
+    process.env.ADMIN_SECRET = "s3cret";
+    const r = requireAdmin(new Request("http://x/api/admin", { headers: { authorization: "Bearer wrong" } }));
+    assert.equal(r.ok, false);
+  });
+
+  test("correct bearer token → allowed", () => {
+    process.env.ADMIN_SECRET = "s3cret";
+    const r = requireAdmin(new Request("http://x/api/admin", { headers: { authorization: "Bearer s3cret" } }));
+    assert.equal(r.ok, true);
+  });
+});
+
+describe("M6 · wallet signature cannot be forged (wallet-auth)", () => {
+  const base = { wallet: "Wallet1111", message: "covenant-auth", expectedMessage: "covenant-auth", ts: Date.now() };
+
+  test("EXPLOIT: garbage signature is rejected", () => {
+    const r = verifyWalletSignature({ ...base, signature: "not-a-real-signature" });
+    assert.equal(r.ok, false);
+  });
+
+  test("missing fields are rejected", () => {
+    assert.equal(verifyWalletSignature({ ...base, signature: "" }).ok, false);
+    assert.equal(
+      verifyWalletSignature({ wallet: "", signature: "x", message: "m", expectedMessage: "m", ts: Date.now() }).ok,
+      false,
+    );
+    assert.equal(
+      verifyWalletSignature({ wallet: "w", signature: "x", message: "m", expectedMessage: "m", ts: "" }).ok,
+      false,
+    );
+  });
+});
+
+describe("M6 · constant-time secret comparison (C-094)", () => {
+  test("equal strings compare equal", () => assert.equal(constantTimeEqual("abc123", "abc123"), true));
+  test("EXPLOIT: a near-miss does not compare equal", () =>
+    assert.equal(constantTimeEqual("abc123", "abc124"), false));
+  test("length mismatch returns false without throwing", () => {
+    assert.equal(constantTimeEqual("short", "muchlongersecret"), false);
+    assert.equal(constantTimeEqual("", "x"), false);
+  });
+  test("empty vs empty is equal", () => assert.equal(constantTimeEqual("", ""), true));
+});
+
+describe("M6 · SSRF targets stay blocked (C-093)", () => {
+  test("EXPLOIT: loopback / private / link-local IPs are blocked", () => {
+    for (const ip of ["127.0.0.1", "10.0.0.5", "192.168.1.1", "172.16.0.1", "169.254.169.254", "::1"]) {
+      assert.equal(isBlockedIp(ip), true, `${ip} must be blocked`);
+    }
+  });
+  test("a public IP is allowed", () => assert.equal(isBlockedIp("8.8.8.8"), false));
+  test("EXPLOIT: internal URLs are rejected by checkUrlSync", () => {
+    assert.equal(checkUrlSync("http://localhost/admin").ok, false);
+    assert.equal(checkUrlSync("http://127.0.0.1:8899").ok, false);
+    assert.equal(checkUrlSync("http://169.254.169.254/latest/meta-data").ok, false);
+  });
+});
+
+describe("M6 · mutating routes require auth when enforced (C-091)", () => {
+  afterEach(() => delete process.env.AUTH_ENFORCED);
+
+  test("EXPLOIT: AUTH_ENFORCED + no credentials → rejected", async () => {
+    process.env.AUTH_ENFORCED = "true";
+    const res = await requireAuth(new Request("http://x/api/jobs", { method: "POST" }));
+    assert.equal(res.ok, false);
+  });
+
+  test("AUTH_ENFORCED unset → no-op (does not break existing callers)", async () => {
+    delete process.env.AUTH_ENFORCED;
+    const res = await requireAuth(new Request("http://x/api/jobs", { method: "POST" }));
+    assert.equal(res.ok, true);
+  });
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,7 +47,7 @@ Some endpoints (e.g. paid agent chat) require an on-chain micropayment using the
 
 The server verifies the **mint, recipient, amount, and confirmation depth**, and
 rejects **replayed** signatures (a signature is consumed once). See
-[x402 conformance](../docs/AUDIT.md) and the `lib/x402-server` module.
+[the audit notes](AUDIT.md) and the `lib/x402-server` module.
 
 ## Rate limits
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,93 @@
+# HTTP API guide
+
+Covenant exposes a REST API for the full job lifecycle, dispute handling, and
+Covenant Credit trading. This guide covers the cross-cutting concerns — base
+URL, auth, payments, rate limits, and the call sequence. For the exact request
+/response schema of each endpoint, use the machine-readable spec:
+
+- **OpenAPI 3.1 spec:** `GET /api/openapi` (feed it to `openapi-typescript`, Postman, etc.)
+- **Rendered docs:** `/api-docs`
+- **Typed client:** the **[SDK](../sdk/README.md)** wraps all of this — prefer it over raw HTTP.
+
+The network is **devnet** (see [SIMULATION_INVENTORY.md](SIMULATION_INVENTORY.md) for what is real on-chain vs. simulated).
+
+## Base URL
+
+```
+https://<your-deployment>        # production
+http://localhost:3000            # next dev
+```
+
+## Authentication
+
+Read endpoints are public. Mutating endpoints are **flag-gated**: until
+`AUTH_ENFORCED=true` they accept unauthenticated calls (so existing demos keep
+working); once enforced, every mutating request must present **either**:
+
+- an API key: `x-api-key: <key>`, **or**
+- a wallet signature over a canonical message:
+  - `x-wallet: <base58 pubkey>`
+  - `x-timestamp: <unix-ms>` (must be within the allowed skew — replay-protected)
+  - `x-signature: <base58 ed25519 signature>` of `"{METHOD} {path}\n{timestamp}\n{sha256(body)}"`
+
+A rejected request returns `401` with `{ "error": "..." }`. The
+[SDK](../sdk/README.md) and the signing helper handle the canonical message for
+you.
+
+## Paid endpoints (x402)
+
+Some endpoints (e.g. paid agent chat) require an on-chain micropayment using the
+**x402** flow:
+
+1. Call the endpoint with no payment → `402 Payment Required` with an `accepts`
+   descriptor (scheme, network, asset/mint, amount, pay-to).
+2. Send the SPL-token transfer on Solana.
+3. Retry with the `X-PAYMENT` header carrying the confirmed transaction
+   signature.
+
+The server verifies the **mint, recipient, amount, and confirmation depth**, and
+rejects **replayed** signatures (a signature is consumed once). See
+[x402 conformance](../docs/AUDIT.md) and the `lib/x402-server` module.
+
+## Rate limits
+
+Mutating endpoints are rate-limited per IP. Over the limit returns `429` with a
+`Retry-After` header (seconds). Budget your polling accordingly — the UI polls
+read endpoints at ≥30s.
+
+## Job lifecycle call sequence
+
+The happy path (each step has both an on-chain instruction and its mirroring API
+route — see [STATE_MACHINE.md](STATE_MACHINE.md) for the full transition table):
+
+```
+POST /api/jobs                  # poster creates a job, locks USDC escrow   → Open
+POST /api/jobs/{id}/accept      # a taker accepts                            → Accepted
+POST /api/jobs/{id}/submit      # taker submits a delivery commitment        → Delivered
+                                #   …challenge window runs…
+POST /api/jobs/{id}/finalize    # permissionless settle after the window     → Finalized
+```
+
+Off the happy path:
+
+```
+POST /api/jobs/{id}/dispute     # poster disputes within the window          → Disputed
+POST /api/disputes              # (and the arbitration endpoints)            → Resolved
+POST /api/jobs/{id}/cancel      # cancel per the on-chain rules              → Cancelled
+```
+
+Covenant Credit (factoring a pending claim) is `POST /api/claims` to list,
+`/api/claims/{id}/buy` to purchase; see the
+[SDK Covenant Credit section](../sdk/README.md).
+
+## Health & metrics
+
+- `GET /api/health` — subsystem status (DB, RPC, program reachable, crank liveness).
+- `GET /api/metrics` — Prometheus exposition (settlement volume, dispute rate, fee accrual, RPC health).
+
+## Errors
+
+All errors return a JSON body `{ "error": "<message>" }` with an appropriate
+status (`400` validation, `401` auth, `402` payment required, `404` not found,
+`409` conflict, `429` rate limited, `5xx` server). The SDK surfaces these as
+typed errors (`CovenantRpcError`, `CovenantProgramError`, `CovenantValidationError`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,51 @@
+# Covenant documentation
+
+Everything you need to integrate with, operate, or audit Covenant — the open
+optimistic-settlement payment rail for AI agents on Solana.
+
+New here? Start with **[Architecture](ARCHITECTURE.md)** for the mental model,
+then pick the integration path that matches you:
+
+| You want to… | Read |
+| --- | --- |
+| Call the protocol from TypeScript | **[SDK reference](../sdk/README.md)** |
+| Drive it from an AI agent / Claude | **[MCP server](../mcp/README.md)** |
+| Hit the HTTP API directly | **[API guide](API.md)** · live spec at `/api/openapi`, rendered at `/api-docs` |
+
+## Protocol
+
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — components, data flow, on-chain ↔ DB mirror.
+- **[STATE_MACHINE.md](STATE_MACHINE.md)** — the job lifecycle (Open → Accepted → Delivered → Finalized / Disputed / Resolved / Cancelled) and every transition.
+- **[SIMULATION_INVENTORY.md](SIMULATION_INVENTORY.md)** — what is real on-chain vs. simulated, and the flags that gate it.
+
+## Integration
+
+- **[SDK reference](../sdk/README.md)** — `covenant-sdk`: install, quick start, dispute flow, reading chain state, PDA derivation, event parsing, Covenant Credit, and error handling / retries.
+- **[MCP server](../mcp/README.md)** — `covenant-mcp`: tools, install, and use with Claude Desktop / Claude Code / Cursor.
+- **[API guide](API.md)** — base URL, authentication, the x402 payment flow, rate limits, and the lifecycle call sequence. Machine-readable spec: `GET /api/openapi`.
+
+## Operations
+
+- **[RUNBOOK.md](RUNBOOK.md)** — on-call procedures: crank, RPC failover, DB, alerts.
+- **[SLO.md](SLO.md)** — service-level objectives and the metrics that back them (`/api/metrics`).
+- **[SECRETS.md](SECRETS.md)** — environment variables and secret handling.
+- **[VERIFIABLE_BUILD.md](VERIFIABLE_BUILD.md)** — reproducing the on-chain program build.
+
+## Security & compliance
+
+- **[AUDIT.md](AUDIT.md)** — security review notes and findings.
+- **[ACCOUNT_CONSTRAINTS_AUDIT.md](ACCOUNT_CONSTRAINTS_AUDIT.md)** — on-chain account-constraint audit.
+- **[SANCTIONS.md](SANCTIONS.md)** — OFAC / sanctions screening posture.
+- **[ACCEPTABLE_USE.md](ACCEPTABLE_USE.md)** — acceptable-use policy.
+- **[THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md)** — dependency licenses.
+
+## Project
+
+- **[MAINNET_ROADMAP.md](MAINNET_ROADMAP.md)** — the path to mainnet (the C-XXX issues).
+- **[PITCH.md](PITCH.md)** — what Covenant is and why.
+
+---
+
+Link hygiene in this folder is enforced by `scripts/check-doc-links.mjs`
+(`node scripts/check-doc-links.mjs` from the repo root) — every relative link
+above is verified to resolve.

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * C-142 — verify every relative Markdown link in the docs resolves.
+ *
+ * Scans the top-level README, every docs/*.md, and the SDK + MCP READMEs for
+ * `[text](target)` links. Relative file links must point at an existing file or
+ * directory. Skipped: absolute URLs (http/https/mailto), runtime routes (links
+ * starting with "/", e.g. /api/openapi), and pure "#anchor" links.
+ *
+ * Exit code 0 = all links resolve; 1 = at least one is broken.
+ *
+ *   node scripts/check-doc-links.mjs
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const docFiles = readdirSync(resolve(ROOT, "docs"))
+  .filter((f) => f.endsWith(".md"))
+  .map((f) => `docs/${f}`);
+const FILES = ["README.md", "sdk/README.md", "mcp/README.md", ...docFiles];
+
+const LINK_RE = /\[[^\]]*\]\(([^)]+)\)/g;
+
+function isExternalOrRuntime(target) {
+  return (
+    target.startsWith("http://") ||
+    target.startsWith("https://") ||
+    target.startsWith("mailto:") ||
+    target.startsWith("#") ||
+    target.startsWith("/") || // runtime route (e.g. /api/openapi), not a repo file
+    target.includes("://")
+  );
+}
+
+let checked = 0;
+const broken = [];
+
+for (const rel of FILES) {
+  const abs = resolve(ROOT, rel);
+  if (!existsSync(abs)) {
+    broken.push(`${rel} — listed file does not exist`);
+    continue;
+  }
+  const src = readFileSync(abs, "utf8");
+  const baseDir = dirname(abs);
+  let m;
+  while ((m = LINK_RE.exec(src)) !== null) {
+    let target = m[1].trim();
+    if (!target || isExternalOrRuntime(target)) continue;
+    // Drop a trailing #anchor and any title: [x](path "title")
+    target = target.split("#")[0].split(/\s+/)[0];
+    if (!target) continue;
+    checked++;
+    if (!existsSync(resolve(baseDir, target))) {
+      broken.push(`${rel} → ${target}`);
+    }
+  }
+}
+
+if (broken.length > 0) {
+  console.error(`✖ ${broken.length} broken doc link(s):`);
+  for (const b of broken) console.error(`  ${b}`);
+  process.exit(1);
+}
+console.log(`✓ all ${checked} relative doc links resolve (${FILES.length} files)`);

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -245,6 +245,42 @@ At Ethereum mainnet gas prices, factoring a $10 claim over a 24-hour
 window would cost more in gas than the yield. Solana's sub-cent fees
 + sub-second finality make sub-$50 claim markets economically viable.
 
+## Error handling & retries
+
+Every failure the client surfaces is a typed `CovenantError`, so you can branch
+on the kind instead of string-matching messages:
+
+| Error | Meaning | Retriable? |
+| --- | --- | --- |
+| `CovenantRpcError` | Transient RPC / network blip (timeout, 429, stale blockhash) | yes (auto) |
+| `CovenantProgramError` | The on-chain program rejected the instruction (carries `code` + `logs`) | no |
+| `CovenantValidationError` | Bad input or an account that failed to decode | no |
+
+Flaky RPC is retried automatically with exponential backoff — every lifecycle
+instruction (`createJob`, `acceptJob`, `submitWork`, `finalizePayment`,
+`raiseDispute`, …) is wrapped. Tune it per client:
+
+```ts
+const client = CovenantClient.fromProvider(provider, idl, programId, {
+  maxRetries: 5,      // extra attempts after the first (default 3)
+  baseDelayMs: 250,   // first backoff step (default 250)
+  maxDelayMs: 4000,   // cap per step (default 4000)
+});
+
+try {
+  await client.finalizePayment({ /* … */ });
+} catch (err) {
+  if (err instanceof CovenantProgramError) {
+    console.error("rejected on-chain", err.code, err.logs);
+  } else if (err instanceof CovenantRpcError) {
+    console.error("RPC still failing after retries", err.message);
+  }
+}
+```
+
+`withRetry`, `backoffDelayMs`, `classifyError`, and `isRetriableError` are also
+exported if you need to wrap your own RPC calls with the same policy.
+
 ## Examples
 
 See [`examples/`](./examples) for integrations with:

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/bn.js": "^5.2.0",
         "@types/node": "^20",
+        "tsx": "^4.7.0",
         "typescript": "^5.3.0"
       }
     },
@@ -78,6 +79,448 @@
       },
       "peerDependencies": {
         "@solana/web3.js": "^1.68.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@noble/curves": {
@@ -664,6 +1107,48 @@
         "es6-promise": "^4.0.3"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -684,18 +1169,26 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
@@ -1002,10 +1495,30 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1020,21 +1533,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rm -rf dist",
+    "test": "tsx --test test/*.test.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [
@@ -33,6 +35,7 @@
   "devDependencies": {
     "@types/bn.js": "^5.2.0",
     "@types/node": "^20",
+    "tsx": "^4.7.0",
     "typescript": "^5.3.0"
   },
   "publishConfig": {

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -36,6 +36,8 @@ import type {
   ClaimListingAccount,
   ClaimStatus,
 } from "./types";
+import { withRetry, type RetryOptions } from "./retry";
+import { classifyError, CovenantValidationError } from "./errors";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyProgram = Program<any>;
@@ -50,7 +52,7 @@ function parseStatus(raw: RawAccount): JobStatus {
   if ("finalized" in raw) return "Finalized";
   if ("resolved" in raw) return "Resolved";
   if ("cancelled" in raw) return "Cancelled";
-  throw new Error(`Unknown job status: ${JSON.stringify(raw)}`);
+  throw new CovenantValidationError(`Unknown job status: ${JSON.stringify(raw)}`);
 }
 
 function parseResolution(raw: RawAccount): DisputeResolutionKind {
@@ -101,7 +103,7 @@ function parseClaimStatus(raw: RawAccount): ClaimStatus {
   if ("bought" in raw) return "Bought";
   if ("cancelled" in raw) return "Cancelled";
   if ("settled" in raw) return "Settled";
-  throw new Error(`Unknown claim status: ${JSON.stringify(raw)}`);
+  throw new CovenantValidationError(`Unknown claim status: ${JSON.stringify(raw)}`);
 }
 
 /**
@@ -114,7 +116,22 @@ export class CovenantClient {
   constructor(
     private readonly program: AnyProgram,
     public readonly connection: Connection,
+    private readonly retryOptions: Partial<RetryOptions> = {},
   ) {}
+
+  /**
+   * Send an Anchor instruction with C-122 resilience: flaky RPC is retried with
+   * exponential backoff, and any failure is rethrown as a typed CovenantError
+   * (CovenantRpcError for transient RPC, CovenantProgramError for an on-chain
+   * rejection). Configure retries via the constructor's `retryOptions`.
+   */
+  private async send(builder: { rpc: () => Promise<TransactionSignature> }): Promise<TransactionSignature> {
+    try {
+      return await withRetry(() => builder.rpc(), this.retryOptions);
+    } catch (err) {
+      throw classifyError(err);
+    }
+  }
 
   /**
    * Convenience: build a CovenantClient from a provider and IDL.
@@ -128,6 +145,7 @@ export class CovenantClient {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     idl: any,
     programId: PublicKey = COVENANT_PROGRAM_ID,
+    retryOptions: Partial<RetryOptions> = {},
   ): CovenantClient {
     // Anchor 0.30 reads the address from the IDL; mirror our default in
     // case the caller passed an IDL that's missing it.
@@ -135,7 +153,7 @@ export class CovenantClient {
       ? idl
       : { ...idl, address: programId.toBase58() };
     const program = new Program(idlWithAddress, provider) as AnyProgram;
-    return new CovenantClient(program, provider.connection);
+    return new CovenantClient(program, provider.connection, retryOptions);
   }
 
   get programId(): PublicKey {
@@ -178,7 +196,7 @@ export class CovenantClient {
     minBondAbsolute?: BN | number;
   }): Promise<TransactionSignature> {
     const [configPda] = deriveConfigPda(this.programId);
-    return (this.program.methods as any)
+    return this.send((this.program.methods as any)
       .initConfig(
         params.arbitrators,
         params.threshold ?? 2,
@@ -193,7 +211,7 @@ export class CovenantClient {
         systemProgram: SystemProgram.programId,
       })
       .signers([params.admin])
-      .rpc();
+      );
   }
 
   /**
@@ -205,14 +223,14 @@ export class CovenantClient {
     threshold?: number;
   }): Promise<TransactionSignature> {
     const [configPda] = deriveConfigPda(this.programId);
-    return (this.program.methods as any)
+    return this.send((this.program.methods as any)
       .updateArbitrators(params.arbitrators, params.threshold ?? 2)
       .accounts({
         admin: params.admin.publicKey,
         config: configPda,
       })
       .signers([params.admin])
-      .rpc();
+      );
   }
 
   // ---- Job lifecycle ----
@@ -242,7 +260,7 @@ export class CovenantClient {
       params.challengePeriodSeconds ?? DEFAULT_CHALLENGE_PERIOD_SECONDS,
     );
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .createJob(amount, Array.from(specHash), deadline, challengePeriod)
       .accounts({
         poster: params.poster.publicKey,
@@ -256,7 +274,7 @@ export class CovenantClient {
         rent: SYSVAR_RENT_PUBKEY,
       })
       .signers([params.poster, escrowTokenAccount])
-      .rpc();
+      );
 
     return { txSig, jobPda, specHash };
   }
@@ -272,7 +290,7 @@ export class CovenantClient {
     const { bytes: specHash } = hashSpec(params.spec);
     const job = await this.fetchJob(params.jobPda);
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .acceptJob(Array.from(specHash))
       .accounts({
         taker: params.taker.publicKey,
@@ -280,7 +298,7 @@ export class CovenantClient {
         poster: job.poster,
       })
       .signers([params.taker])
-      .rpc();
+      );
 
     return { txSig };
   }
@@ -298,7 +316,7 @@ export class CovenantClient {
     validateDeliveryUri(params.deliveryUri);
     const job = await this.fetchJob(params.jobPda);
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .submitWork(Array.from(params.workHash), params.deliveryUri)
       .accounts({
         taker: params.taker.publicKey,
@@ -306,7 +324,7 @@ export class CovenantClient {
         poster: job.poster,
       })
       .signers([params.taker])
-      .rpc();
+      );
 
     return { txSig };
   }
@@ -324,7 +342,7 @@ export class CovenantClient {
     const job = await this.fetchJob(params.jobPda);
     const reputationPda = this.reputationPda(job.taker);
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .finalizePayment()
       .accounts({
         crank: params.crank.publicKey,
@@ -338,7 +356,7 @@ export class CovenantClient {
         systemProgram: SystemProgram.programId,
       })
       .signers([params.crank])
-      .rpc();
+      );
 
     return { txSig };
   }
@@ -359,7 +377,7 @@ export class CovenantClient {
     const [bondPda] = deriveBondPda(params.jobPda, this.programId);
     const bond = new BN(params.bond);
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .raiseDispute(Array.from(params.reasonHash), bond)
       .accounts({
         poster: params.poster.publicKey,
@@ -373,7 +391,7 @@ export class CovenantClient {
         rent: SYSVAR_RENT_PUBKEY,
       })
       .signers([params.poster])
-      .rpc();
+      );
 
     return { txSig, bondPda };
   }
@@ -395,7 +413,7 @@ export class CovenantClient {
     const job = await this.fetchJob(params.jobPda);
     const reputationPda = this.reputationPda(job.taker);
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .resolveDispute(encodeResolution(params.resolution))
       .accounts({
         arbitrator: params.arbitrator.publicKey,
@@ -412,7 +430,7 @@ export class CovenantClient {
         systemProgram: SystemProgram.programId,
       })
       .signers([params.arbitrator])
-      .rpc();
+      );
 
     return { txSig };
   }
@@ -429,7 +447,7 @@ export class CovenantClient {
       job.taker.equals(PublicKey.default) ? params.signer.publicKey : job.taker,
     );
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .cancelJob()
       .accounts({
         signer: params.signer.publicKey,
@@ -442,7 +460,7 @@ export class CovenantClient {
         systemProgram: SystemProgram.programId,
       })
       .signers([params.signer])
-      .rpc();
+      );
 
     return { txSig };
   }
@@ -470,7 +488,7 @@ export class CovenantClient {
     const job = await this.fetchJob(params.jobPda);
     const claimPda = this.claimPda(params.jobPda);
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .listClaim(params.price)
       .accounts({
         seller: params.seller.publicKey,
@@ -480,7 +498,7 @@ export class CovenantClient {
         systemProgram: SystemProgram.programId,
       })
       .signers([params.seller])
-      .rpc();
+      );
 
     return { txSig, claimPda };
   }
@@ -499,7 +517,7 @@ export class CovenantClient {
     const job = await this.fetchJob(params.jobPda);
     const claimPda = this.claimPda(params.jobPda);
 
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .buyClaim()
       .accounts({
         buyer: params.buyer.publicKey,
@@ -511,7 +529,7 @@ export class CovenantClient {
         tokenProgram: TOKEN_PROGRAM_ID,
       })
       .signers([params.buyer])
-      .rpc();
+      );
 
     return { txSig };
   }
@@ -524,14 +542,14 @@ export class CovenantClient {
     jobPda: PublicKey;
   }): Promise<{ txSig: TransactionSignature }> {
     const claimPda = this.claimPda(params.jobPda);
-    const txSig = await (this.program.methods as any)
+    const txSig = await this.send((this.program.methods as any)
       .cancelClaim()
       .accounts({
         seller: params.seller.publicKey,
         claimListing: claimPda,
       })
       .signers([params.seller])
-      .rpc();
+      );
     return { txSig };
   }
 

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -134,6 +134,19 @@ export class CovenantClient {
   }
 
   /**
+   * Run a read (account fetch) with the same retry policy. Reads are idempotent,
+   * so retrying a transient RPC failure is always safe; an account-not-found
+   * error is non-retriable and surfaces (callers that tolerate it catch it).
+   */
+  private async query<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await withRetry(fn, this.retryOptions);
+    } catch (err) {
+      throw classifyError(err);
+    }
+  }
+
+  /**
    * Convenience: build a CovenantClient from a provider and IDL.
    *
    * Anchor 0.30+ takes `(idl, provider)` — the program ID lives inside the
@@ -560,8 +573,8 @@ export class CovenantClient {
   async fetchClaim(jobPda: PublicKey): Promise<ClaimListingAccount | null> {
     const claimPda = this.claimPda(jobPda);
     try {
-      const raw = (await (this.program.account as any)["claimListing"].fetch(
-        claimPda,
+      const raw = (await this.query(() =>
+        (this.program.account as any)["claimListing"].fetch(claimPda),
       )) as RawAccount;
       return {
         job: raw.job,
@@ -582,8 +595,8 @@ export class CovenantClient {
   // ---- Account fetchers ----
 
   async fetchJob(jobPda: PublicKey): Promise<JobEscrowAccount> {
-    const raw = (await (this.program.account as any)["jobEscrow"].fetch(
-      jobPda,
+    const raw = (await this.query(() =>
+      (this.program.account as any)["jobEscrow"].fetch(jobPda),
     )) as RawAccount;
     return {
       poster: raw.poster,
@@ -606,8 +619,8 @@ export class CovenantClient {
     wallet: PublicKey,
   ): Promise<AgentReputationAccount | null> {
     try {
-      const raw = (await (this.program.account as any)["agentReputation"].fetch(
-        this.reputationPda(wallet),
+      const raw = (await this.query(() =>
+        (this.program.account as any)["agentReputation"].fetch(this.reputationPda(wallet)),
       )) as RawAccount;
       return {
         address: raw.address,
@@ -624,8 +637,8 @@ export class CovenantClient {
 
   async fetchConfig(): Promise<ProtocolConfigAccount | null> {
     try {
-      const raw = (await (this.program.account as any)["protocolConfig"].fetch(
-        this.configPda(),
+      const raw = (await this.query(() =>
+        (this.program.account as any)["protocolConfig"].fetch(this.configPda()),
       )) as RawAccount;
       return {
         admin: raw.admin,

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -58,9 +58,13 @@ const RETRIABLE_PATTERNS: RegExp[] = [
   /enotfound/i,
   /socket hang ?up/i,
   /network (request )?failed/i,
-  /was not confirmed/i,
   /failed to query long-term storage/i,
 ];
+// NOTE: "Transaction was not confirmed" is deliberately NOT retriable. It means
+// the tx was sent and confirmation polling timed out — the tx has very likely
+// landed, so auto-resending it would be a double-send. The caller should
+// reconcile against on-chain state instead. (Reads, which are idempotent, are
+// always safe to retry; sends rely on on-chain idempotency as the backstop.)
 
 function messageOf(err: unknown): string {
   if (err instanceof Error) return err.message;

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,0 +1,118 @@
+/**
+ * C-122 — typed SDK errors.
+ *
+ * Every failure surfaced by the client is one of these, so callers can branch
+ * on the kind (retriable RPC blip vs. on-chain program rejection vs. bad input)
+ * instead of string-matching `Error.message`.
+ */
+
+export class CovenantError extends Error {
+  /** The original thrown value, preserved for debugging. */
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "CovenantError";
+    this.cause = cause;
+  }
+}
+
+/** Transient RPC / network failure (timeout, 429, stale blockhash). Safe to retry. */
+export class CovenantRpcError extends CovenantError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "CovenantRpcError";
+  }
+}
+
+/** The on-chain program rejected the instruction. A logic failure — NOT retriable. */
+export class CovenantProgramError extends CovenantError {
+  readonly code?: number | string;
+  readonly logs?: string[];
+  constructor(message: string, opts?: { code?: number | string; logs?: string[]; cause?: unknown }) {
+    super(message, opts?.cause);
+    this.name = "CovenantProgramError";
+    this.code = opts?.code;
+    this.logs = opts?.logs;
+  }
+}
+
+/** Client-side validation failure (bad params, account decode mismatch). NOT retriable. */
+export class CovenantValidationError extends CovenantError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "CovenantValidationError";
+  }
+}
+
+const RETRIABLE_PATTERNS: RegExp[] = [
+  /blockhash not found/i,
+  /node is behind/i,
+  /too many requests/i,
+  /\b429\b/,
+  /\b50[234]\b/, // 502 / 503 / 504
+  /timed?\s*out/i,
+  /timeout/i,
+  /fetch failed/i,
+  /econnreset/i,
+  /etimedout/i,
+  /enotfound/i,
+  /socket hang ?up/i,
+  /network (request )?failed/i,
+  /was not confirmed/i,
+  /failed to query long-term storage/i,
+];
+
+function messageOf(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function extractAnchorCode(err: unknown): number | string | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const e = err as any;
+  if (e.error?.errorCode?.code !== undefined) return e.error.errorCode.code;
+  if (e.error?.errorCode?.number !== undefined) return e.error.errorCode.number;
+  if (typeof e.code === "number") return e.code;
+  const custom = e.transactionError?.InstructionError?.[1]?.Custom;
+  if (typeof custom === "number") return custom;
+  return undefined;
+}
+
+function extractLogs(err: unknown): string[] | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const e = err as any;
+  if (Array.isArray(e.logs)) return e.logs;
+  if (Array.isArray(e.transactionLogs)) return e.transactionLogs;
+  return undefined;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** True for transient RPC/network errors that are safe to retry. */
+export function isRetriableError(err: unknown): boolean {
+  if (err instanceof CovenantRpcError) return true;
+  if (err instanceof CovenantProgramError || err instanceof CovenantValidationError) return false;
+  // A classified program error embedded as a cause is never retriable.
+  if (extractAnchorCode(err) !== undefined) return false;
+  return RETRIABLE_PATTERNS.some((re) => re.test(messageOf(err)));
+}
+
+/** Map a raw thrown value into a typed CovenantError. Idempotent. */
+export function classifyError(err: unknown): CovenantError {
+  if (err instanceof CovenantError) return err;
+  const msg = messageOf(err);
+
+  const code = extractAnchorCode(err);
+  if (code !== undefined) {
+    return new CovenantProgramError(msg, { code, logs: extractLogs(err), cause: err });
+  }
+  if (isRetriableError(err)) {
+    return new CovenantRpcError(msg, err);
+  }
+  return new CovenantError(msg, err);
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -52,3 +52,15 @@ export type {
   ClaimListingAccount,
   ClaimStatus,
 } from "./types";
+
+// C-122 — typed errors + RPC retry/backoff
+export {
+  CovenantError,
+  CovenantRpcError,
+  CovenantProgramError,
+  CovenantValidationError,
+  classifyError,
+  isRetriableError,
+} from "./errors";
+export { withRetry, backoffDelayMs, DEFAULT_RETRY_OPTIONS } from "./retry";
+export type { RetryOptions } from "./retry";

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,0 +1,66 @@
+/**
+ * C-122 — retry with exponential backoff for flaky RPC.
+ *
+ * Pure + injectable (sleep, jitter source) so the backoff schedule and the
+ * retry/give-up behaviour are unit-testable without real timers or a network.
+ */
+
+import { isRetriableError } from "./errors";
+
+export interface RetryOptions {
+  /** Extra attempts after the first try (default 3 → up to 4 total). */
+  maxRetries: number;
+  /** First backoff step in ms (default 250). */
+  baseDelayMs: number;
+  /** Upper bound on a single backoff step in ms (default 4000). */
+  maxDelayMs: number;
+  /** Apply full jitter to each delay (default true). */
+  jitter: boolean;
+  /** Decide whether a given error is retriable (default isRetriableError). */
+  shouldRetry?: (err: unknown) => boolean;
+  /** Injectable sleep (tests). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable jitter source in [0,1) (tests). */
+  random?: () => number;
+}
+
+export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+  maxRetries: 3,
+  baseDelayMs: 250,
+  maxDelayMs: 4000,
+  jitter: true,
+};
+
+/** Exponential backoff (base * 2^attempt) capped at maxDelayMs, with optional full jitter. */
+export function backoffDelayMs(attempt: number, opts?: Partial<RetryOptions>): number {
+  const base = opts?.baseDelayMs ?? DEFAULT_RETRY_OPTIONS.baseDelayMs;
+  const max = opts?.maxDelayMs ?? DEFAULT_RETRY_OPTIONS.maxDelayMs;
+  const jitter = opts?.jitter ?? DEFAULT_RETRY_OPTIONS.jitter;
+  const random = opts?.random ?? Math.random;
+  const capped = Math.min(max, base * 2 ** attempt);
+  return jitter ? Math.floor(random() * capped) : capped;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn`, retrying retriable errors with exponential backoff. Rethrows the
+ * last (raw) error once retries are exhausted or on a non-retriable error.
+ */
+export async function withRetry<T>(fn: () => Promise<T>, opts?: Partial<RetryOptions>): Promise<T> {
+  const maxRetries = opts?.maxRetries ?? DEFAULT_RETRY_OPTIONS.maxRetries;
+  const shouldRetry = opts?.shouldRetry ?? isRetriableError;
+  const sleep = opts?.sleep ?? defaultSleep;
+
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt >= maxRetries || !shouldRetry(err)) break;
+      await sleep(backoffDelayMs(attempt, opts));
+    }
+  }
+  throw lastErr;
+}

--- a/sdk/test/resilience.test.ts
+++ b/sdk/test/resilience.test.ts
@@ -1,0 +1,143 @@
+/**
+ * C-122 — unit tests for typed errors + RPC retry/backoff.
+ *
+ * Run with:  npx tsx --test test/resilience.test.ts
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CovenantError,
+  CovenantRpcError,
+  CovenantProgramError,
+  CovenantValidationError,
+  classifyError,
+  isRetriableError,
+} from "../src/errors";
+import { backoffDelayMs, withRetry } from "../src/retry";
+
+describe("C-122 · error classes", () => {
+  test("instanceof chain + names", () => {
+    const rpc = new CovenantRpcError("x");
+    assert.ok(rpc instanceof CovenantError);
+    assert.equal(rpc.name, "CovenantRpcError");
+    const prog = new CovenantProgramError("y", { code: 6000, logs: ["a"] });
+    assert.equal(prog.code, 6000);
+    assert.deepEqual(prog.logs, ["a"]);
+    assert.ok(prog instanceof CovenantError);
+  });
+});
+
+describe("C-122 · isRetriableError", () => {
+  for (const msg of [
+    "blockhash not found",
+    "Node is behind by 42 slots",
+    "429 Too Many Requests",
+    "503 Service Unavailable",
+    "request timed out",
+    "fetch failed",
+    "Transaction was not confirmed in 30s",
+  ]) {
+    test(`retriable: "${msg}"`, () => assert.equal(isRetriableError(new Error(msg)), true));
+  }
+  test("CovenantRpcError is retriable", () => assert.equal(isRetriableError(new CovenantRpcError("x")), true));
+  test("program error is NOT retriable", () =>
+    assert.equal(isRetriableError(new CovenantProgramError("x", { code: 6000 })), false));
+  test("validation error is NOT retriable", () =>
+    assert.equal(isRetriableError(new CovenantValidationError("x")), false));
+  test("anchor-shaped program error is NOT retriable", () =>
+    assert.equal(isRetriableError({ error: { errorCode: { code: "ConstraintSeeds", number: 2006 } } }), false));
+  test("plain logic error is NOT retriable", () =>
+    assert.equal(isRetriableError(new Error("invalid argument: amount must be > 0")), false));
+});
+
+describe("C-122 · classifyError", () => {
+  test("anchor program error → CovenantProgramError with code + logs", () => {
+    const raw = { error: { errorCode: { code: "Unauthorized", number: 6001 } }, logs: ["log a", "log b"] };
+    const out = classifyError(raw);
+    assert.ok(out instanceof CovenantProgramError);
+    assert.equal((out as CovenantProgramError).code, "Unauthorized");
+    assert.deepEqual((out as CovenantProgramError).logs, ["log a", "log b"]);
+  });
+  test("SendTransactionError custom instruction error → program error", () => {
+    const raw = { transactionError: { InstructionError: [0, { Custom: 6002 }] } };
+    const out = classifyError(raw);
+    assert.ok(out instanceof CovenantProgramError);
+    assert.equal((out as CovenantProgramError).code, 6002);
+  });
+  test("transient RPC message → CovenantRpcError", () => {
+    assert.ok(classifyError(new Error("blockhash not found")) instanceof CovenantRpcError);
+  });
+  test("unknown error → CovenantError (base)", () => {
+    const out = classifyError(new Error("something weird"));
+    assert.ok(out instanceof CovenantError);
+    assert.equal(out instanceof CovenantRpcError, false);
+    assert.equal(out instanceof CovenantProgramError, false);
+  });
+  test("already typed → returned as-is (idempotent)", () => {
+    const e = new CovenantValidationError("bad");
+    assert.equal(classifyError(e), e);
+  });
+});
+
+describe("C-122 · backoffDelayMs", () => {
+  test("exponential, no jitter", () => {
+    const o = { baseDelayMs: 100, maxDelayMs: 10000, jitter: false };
+    assert.equal(backoffDelayMs(0, o), 100);
+    assert.equal(backoffDelayMs(1, o), 200);
+    assert.equal(backoffDelayMs(2, o), 400);
+    assert.equal(backoffDelayMs(3, o), 800);
+  });
+  test("capped at maxDelayMs", () => {
+    assert.equal(backoffDelayMs(20, { baseDelayMs: 100, maxDelayMs: 1000, jitter: false }), 1000);
+  });
+  test("jitter scales the capped delay by random()", () => {
+    assert.equal(backoffDelayMs(1, { baseDelayMs: 100, maxDelayMs: 10000, jitter: true, random: () => 0.5 }), 100);
+  });
+});
+
+describe("C-122 · withRetry", () => {
+  const noSleep = { sleep: async () => {}, jitter: false };
+
+  test("succeeds on first try → one call, no retry", async () => {
+    let calls = 0;
+    const r = await withRetry(async () => (calls++, "ok"), noSleep);
+    assert.equal(r, "ok");
+    assert.equal(calls, 1);
+  });
+
+  test("retries a retriable error then succeeds", async () => {
+    let calls = 0;
+    const r = await withRetry(async () => {
+      calls++;
+      if (calls < 3) throw new Error("blockhash not found");
+      return "ok";
+    }, { ...noSleep, maxRetries: 5 });
+    assert.equal(r, "ok");
+    assert.equal(calls, 3);
+  });
+
+  test("gives up after maxRetries and throws the last error", async () => {
+    let calls = 0;
+    await assert.rejects(
+      withRetry(async () => {
+        calls++;
+        throw new Error("429 Too Many Requests");
+      }, { ...noSleep, maxRetries: 2 }),
+      /429/,
+    );
+    assert.equal(calls, 3); // first try + 2 retries
+  });
+
+  test("does NOT retry a non-retriable error → one call", async () => {
+    let calls = 0;
+    await assert.rejects(
+      withRetry(async () => {
+        calls++;
+        throw new CovenantProgramError("rejected", { code: 6000 });
+      }, { ...noSleep, maxRetries: 5 }),
+      CovenantProgramError,
+    );
+    assert.equal(calls, 1);
+  });
+});

--- a/sdk/test/resilience.test.ts
+++ b/sdk/test/resilience.test.ts
@@ -36,10 +36,11 @@ describe("C-122 · isRetriableError", () => {
     "503 Service Unavailable",
     "request timed out",
     "fetch failed",
-    "Transaction was not confirmed in 30s",
   ]) {
     test(`retriable: "${msg}"`, () => assert.equal(isRetriableError(new Error(msg)), true));
   }
+  test("SAFETY: 'was not confirmed' is NOT retriable (avoid double-send)", () =>
+    assert.equal(isRetriableError(new Error("Transaction was not confirmed in 30.00 seconds")), false));
   test("CovenantRpcError is retriable", () => assert.equal(isRetriableError(new CovenantRpcError("x")), true));
   test("program error is NOT retriable", () =>
     assert.equal(isRetriableError(new CovenantProgramError("x", { code: 6000 })), false));


### PR DESCRIPTION
## Özet

M9/M10'dan, on-chain blocker'a (#236) bağlı **olmayan** üç backend issue'yu tek bir
tutarlı kalite dilimi olarak getirir: **SDK dayanıklılığı**, **güvenlik regresyon
suite'i**, ve **docs completeness**. Üçü de bağımsız ve **non-breaking** — çalışan
uygulama davranışı değişmez; SDK'ya yeni (geriye-uyumlu) API eklenir, yeni testler
ve dokümanlar eklenir.

**4 commit · 14 dosya · +1391 / −58 · `tsc`/typecheck temiz · SDK 25/25 + app 331/331 (20 güvenlik) test · 42/42 doc-link · eslint temiz.**

Closes #186
Closes #214
Closes #220

---

## C-122 · SDK: typed errors + RPC retry/backoff — `#186` `M9`

**Ne:** `covenant-sdk` artık flaky RPC'yi otomatik retry eder ve her hatayı,
çağıranın `instanceof` ile branch'leyebileceği **tipli** bir hata olarak yüzeye çıkarır.

**Nasıl / nerede:**
- **`sdk/src/errors.ts`** (yeni) — `CovenantError` hiyerarşisi:
  - `CovenantRpcError` — geçici RPC/network (timeout, 429, stale blockhash) → **retriable**
  - `CovenantProgramError` — on-chain reddi; `code` + `logs` taşır → retriable **değil**
  - `CovenantValidationError` — kötü input / account decode hatası → retriable değil
  - `classifyError()` ham Anchor/Solana/RPC throwable'larını maplar (idempotent);
    `isRetriableError()` retry'ı kapıda tutar.
- **`sdk/src/retry.ts`** (yeni) — `backoffDelayMs` (exponential + full jitter, capped)
  + `withRetry` (sleep/jitter **inject edilebilir** → gerçek timer'sız unit-testlenir).
  Default: 3 retry, 250ms base, 4s cap.
- **`sdk/src/client.ts`**:
  - private `send()` → **12 lifecycle `.rpc()`** çağrısının hepsini `withRetry` +
    `classifyError` ile sarar.
  - private `query()` → **4 account read** (`fetchJob`/`fetchClaim`/`fetchReputation`/
    `fetchConfig`) aynı retry policy ile sarılır.
  - constructor + `fromProvider` opsiyonel `retryOptions` alır.
  - Account-decode hataları artık `CovenantValidationError` fırlatır.
- **`sdk/src/index.ts`** — yeni hata tipleri + retry API (`withRetry`, `backoffDelayMs`,
  `classifyError`, `isRetriableError`, `RetryOptions`) export edilir.
- **`sdk/test/resilience.test.ts`** (yeni, **25 test**) — hata sınıflandırma, retriable
  pattern'ler, backoff schedule, withRetry retry/give-up/no-retry-on-logic-error.
- **`sdk/package.json`** — `test` (tsx --test) + `typecheck` script'leri (+ tsx devDep).

**⚠️ Nüanslar (settlement güvenliği):**
- **Bir program-error (on-chain logic reddi) ASLA retry'lanmaz** — para tekrar gönderilmez.
- **`"Transaction was not confirmed"` bilerek retriable DEĞİL:** confirmation timeout, tx'in
  zincire çok büyük olasılıkla **indiği** anlamına gelir; otomatik yeniden gönderim
  double-send olurdu. Send'ler için backstop on-chain idempotency'dir (aynı op'un 2.
  inişi program-error'la reddedilir); read'ler idempotent olduğu için retry her zaman güvenli.

## C-139 · Security regression suite — `#214` `M10`

**Ne:** M2 (x402 bypass'leri) + M6 (auth açıkları) exploit'lerinin **kapalı kaldığını**
kanıtlayan, biri yeniden açılırsa **kırmızıya dönen** testler.

**Nasıl / nerede** (`app/tests/security/regression.test.ts`, yeni, **20 test**):
- **M2 · x402** — `validatePaymentSchema` yanlış scheme/network/asset'i reddeder (C-033);
  `verifyTransfer` (sentetik pre/post token-balance üzerinden) yanlış recipient / yanlış
  mint / underpayment'ı reddeder (C-031).
- **M6 · auth** — admin endpoint'leri secret yokken **fail-closed** + yanlış token'ı
  reddeder (C-095); wallet imzası forge edilemez (garbage/eksik alan reddedilir);
  constant-time compare doğru + length-safe (C-094); SSRF hedefleri (loopback / private /
  link-local / 169.254.169.254 metadata) blokeli kalır (C-093); `AUTH_ENFORCED` iken
  imzasız mutating istek reddedilir, flag kapalıyken no-op (C-091).
- **`app/package.json`** — `test:security` script'i + `tests/security/*.test.ts` ana `test`
  glob'una eklendi (CI'da çalışır).

**⚠️ Nüans:** Lib-seviyesinde, DB/network'süz, deterministik assertion'lar. Mevcut unit
testleri kopyalamaz; **adversarial "exploit → closed"** çerçevesinde + daha önce test'siz
olan primitive'leri (`secure-compare`, `wallet-auth`) kapsar.

## C-142 · Docs completeness — `#220` `M10`

**Ne:** Bir geliştirici yalnızca dokümanlardan entegre edebilsin; linkler doğrulansın.

**Nasıl / nerede:**
- **`docs/README.md`** (yeni) — dokümantasyon **index'i**: protocol / integration (SDK,
  MCP, API) / operations / security dokümanlarını haritalar. "Start here" girişi.
- **`docs/API.md`** (yeni) — HTTP API entegrasyon kılavuzu: base URL, auth (api-key veya
  wallet imzası + canonical mesaj), x402 ödeme akışı, rate limit, lifecycle çağrı sırası.
  OpenAPI spec'i **duplike etmez**; canlı `/api/openapi` + render `/api-docs`'a işaret eder.
- **`sdk/README.md`** — C-122 typed errors + retry/backoff bölümü (tablo + örnek).
- **`README.md`** — `docs/`, SDK, MCP, API'yi linkleyen "Documentation" bölümü.
- **`scripts/check-doc-links.mjs`** (yeni) — her relative Markdown linkinin çözüldüğünü
  doğrular (README + docs/*.md + SDK/MCP README). Şu an **42/42** (19 dosya).

**⚠️ Nüans:** Mevcut SDK/MCP README'leri zaten kapsamlıydı; bu PR yalnızca **eksikleri**
kapatır (index yoktu, API.md yoktu, README docs'a link vermiyordu, C-122 dokümansızdı) +
**link doğrulamasını otomatikleştirir** (AC: "links verified").

---

## Öz-denetim (PR öncesi review pass — son commit `cc0655b`)

İlk implementasyon kusursuz değildi; üç gerçek sorunu bulup düzelttim:
1. **C-122 double-send:** `"was not confirmed"` retriable'dı → artık değil (yukarıdaki nüans).
2. **C-122 read'ler retry'lanmıyordu** → `query()` helper'ı ile 4 read sarıldı (`fetchJob`
   artık tek bir geçici blip'te throw etmiyor).
3. **C-142 doc-link** → intra-docs link düzeltildi (`../docs/AUDIT.md` → `AUDIT.md`).

## Doğrulama
```bash
# SDK
cd sdk && npm run typecheck && npm test        # clean · 25/25
# App
cd app && npx tsc --noEmit && npm test         # clean · 331/331 (20 security)
# Docs
node scripts/check-doc-links.mjs               # 42/42 links across 19 files
```

## Bu PR'da olmayanlar (dürüst sınır)
- **C-139 lib-seviyesinde:** route/E2E exploit testleri (canlı x402 replay, gerçek tx
  fetch) #236 redeploy'a bağlı.
- **C-142 API.md** spec'i duplike etmez — endpoint başına şema canlı `/api/openapi`'de.
- Komşu issue'lar ayrı/blokeli: C-120/121 (SDK mainnet/e2e — devnet-lock + #236),
  C-123–126 (MCP write surface/publish — execution #236-blocked / release), C-130–140
  (E2E/load/mainnet — #236-blocked), C-048 (Anchor localnet — Rust, ayrı domain).
