### PR TITLE
fix(program): close CovError enum — restore compilation (likely #236 root cause)

### DIFF
--- a/programs/covenant/src/errors.rs
+++ b/programs/covenant/src/errors.rs
@@ -64,3 +64,4 @@ pub enum CovError {
     NotClaimSeller,
     #[msg("Buyer may not be the same wallet as the seller")]
     BuyerIsSeller,
+}


### PR DESCRIPTION
## Özet

`programs/covenant/src/errors.rs`, `pub enum CovError`'ün **kapanış `}`'ini
kaybetmiş — bu yüzden on-chain program **#36'dan beri (commit `78af866`)
derlenmiyordu**. Derlenmeyen bir program rebuild/redeploy edilemez; bu da büyük
olasılıkla **#236'nın kök nedeni** (deployed binary stale, error 4100 /
declare_id mismatch).

## Fix

Tek satır: enum'a kapanış `}` eklendi. **İçerik kaybı yok** — program genelinde
kullanılan 25 `CovError` variant'ının hepsi tanımlı 30'un içinde; yalnızca
delimiter eksikti.

## Doğrulama

```
anchor build   → başarılı: target/deploy/covenant.so (456KB) + target/idl/covenant.json
```
Build edilen programın declare_id'si kaynakla eşleşiyor:
`5hstj5grBUL1BeSaPLYpgkD6n3ALasmbseRvKRFfCVNT`.

## Etki

- Upgrade authority artık fresh `.so`'yu **redeploy edebilir** → **#236** çözülür.
- On-chain test coverage (**C-048**) ve #236-blocked dalgası (E2E, SDK-mainnet) açılır.

## ⚠️ Dürüst sınır

"Derleniyor + declare_id eşleşiyor"u kanıtladım. "Redeploy #236'yı kapatır"ı
**kanıtlamadım** — gerçek redeploy upgrade-authority (kh0ra) gerektirir. Bu PR
kök nedeni giderir; #236'yı **redeploy** kapatır.

Refs #236
