### PR TITLE
security: audit wave 2 — x402 underpayment guard, SSRF DNS-rebinding pin

### DIFF
--- a/app/app/api/agents/register/route.ts
+++ b/app/app/api/agents/register/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { awardXP } from "@/lib/xp";
 import { unlockAchievement } from "@/lib/achievements";
-import { assertPublicUrl } from "@/lib/ssrf";
+import { assertPublicUrl, safeFetch } from "@/lib/ssrf";
 
 const VALID_CAPABILITIES = [
   "writing",
@@ -44,6 +44,9 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+    // Pin the validated addresses for the test fetch below so DNS can't be
+    // rebound to a private IP between this check and the request (TOCTOU).
+    const validatedAddresses = urlGuard.addresses;
 
     // ── Capabilities ──────────────────────────────────────────────────────
     if (!Array.isArray(capabilities) || capabilities.length === 0) {
@@ -79,15 +82,19 @@ export async function POST(req: NextRequest) {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 10_000);
 
-      const testRes = await fetch(endpointUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          prompt: "Hello, please respond with 'OK' to confirm you are operational.",
-          test: true,
-        }),
-        signal: controller.signal,
-      });
+      const testRes = await safeFetch(
+        endpointUrl,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            prompt: "Hello, please respond with 'OK' to confirm you are operational.",
+            test: true,
+          }),
+          signal: controller.signal,
+        },
+        validatedAddresses,
+      );
 
       clearTimeout(timeout);
 

--- a/app/lib/ssrf.ts
+++ b/app/lib/ssrf.ts
@@ -22,6 +22,8 @@ import { lookup } from "node:dns/promises";
 export interface UrlCheck {
   ok: boolean;
   reason?: string;
+  /** On success for a hostname target, the validated resolved addresses. */
+  addresses?: string[];
 }
 
 /* ------------------------------------------------------------------ */
@@ -211,7 +213,9 @@ export async function assertPublicUrl(
   const host = hostnameOf(url);
 
   // Already an IP literal or numeric IPv4: the sync screen verified it.
-  if (isIP(host) || parseLooseIPv4(host)) return { ok: true };
+  if (isIP(host)) return { ok: true, addresses: [host] };
+  const loose = parseLooseIPv4(host);
+  if (loose) return { ok: true, addresses: [loose] };
 
   let addresses: string[];
   try {
@@ -227,5 +231,54 @@ export async function assertPublicUrl(
       return { ok: false, reason: `host resolves to blocked address ${addr}` };
     }
   }
-  return { ok: true };
+  return { ok: true, addresses };
+}
+
+/**
+ * Fetch a user-supplied URL while DEFEATING DNS-rebinding / TOCTOU.
+ *
+ * `assertPublicUrl` validates the addresses a hostname resolves to, but a
+ * plain `fetch(url)` re-resolves DNS at connect time — an attacker who controls
+ * the authoritative DNS can return a public IP during validation and a private
+ * one (127.0.0.1, 169.254.169.254, ...) for the real request. This pins the
+ * connection to the already-validated address via an undici dispatcher whose
+ * lookup ignores the network and returns the vetted IP, so the bytes go exactly
+ * where we screened.
+ *
+ *   const guard = await assertPublicUrl(url);
+ *   if (!guard.ok) return reject;
+ *   const res = await safeFetch(url, init, guard.addresses);
+ */
+export async function safeFetch(
+  rawUrl: string,
+  init: RequestInit,
+  addresses?: string[],
+): Promise<Response> {
+  // No validated addresses (IP-literal path handled by sync screen, or caller
+  // omitted them): re-screen and fall back to a plain fetch.
+  if (!addresses || addresses.length === 0) {
+    const guard = await assertPublicUrl(rawUrl);
+    if (!guard.ok) throw new Error(`SSRF screen failed: ${guard.reason}`);
+    addresses = guard.addresses;
+  }
+  const pinned = addresses && addresses[0];
+  if (!pinned) {
+    return fetch(rawUrl, init);
+  }
+  const { Agent } = await import("undici");
+  const family = isIP(pinned);
+  const dispatcher = new Agent({
+    connect: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      lookup: (_hostname: string, _opts: unknown, cb: any) => {
+        cb(null, [{ address: pinned, family: family === 6 ? 6 : 4 }]);
+      },
+    },
+  });
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return await fetch(rawUrl, { ...init, dispatcher } as any);
+  } finally {
+    void dispatcher.close().catch(() => {});
+  }
 }

--- a/app/lib/x402-server.ts
+++ b/app/lib/x402-server.ts
@@ -531,6 +531,32 @@ export async function verifyPayment(
         reason: fres.invalidReason ?? "facilitator rejected the payment",
       };
     }
+    // Defense-in-depth: even though the facilitator asserts validity, if it
+    // echoes the paid amount we re-check it covers the requirement here, so a
+    // misconfigured/compromised facilitator cannot approve an underpayment.
+    if (fres.amountAtomic !== undefined && fres.amountAtomic !== null) {
+      let paid: bigint;
+      let need: bigint;
+      try {
+        paid = BigInt(fres.amountAtomic);
+        need = BigInt(accept.amount);
+      } catch {
+        return {
+          valid: false,
+          txHash: parsed.txSignature,
+          payer: "",
+          reason: "facilitator returned an unparseable amount",
+        };
+      }
+      if (paid < need) {
+        return {
+          valid: false,
+          txHash: parsed.txSignature,
+          payer: "",
+          reason: `underpaid: facilitator reports ${paid} < required ${need}`,
+        };
+      }
+    }
     return {
       valid: true,
       txHash: parsed.txSignature,


### PR DESCRIPTION
## Audit wave 2 — two contained, high-value off-chain fixes

### x402 facilitator underpayment guard (`app/lib/x402-server.ts`)
On the optional facilitator verification path, when the facilitator echoes the paid amount we now re-check server-side that it covers the required amount. A misconfigured/compromised facilitator can no longer approve an underpayment. The default (no-facilitator) path already does full on-chain parsing (amount/mint/recipient/confirmed).

### SSRF DNS-rebinding / TOCTOU pin (`app/lib/ssrf.ts`, `app/app/api/agents/register/route.ts`)
`assertPublicUrl` now returns the validated resolved addresses, and a new `safeFetch()` pins the connection to a vetted IP via an undici dispatcher whose `lookup` ignores DNS. This closes the gap where a hostname validated as public could rebind to `127.0.0.1` / `169.254.169.254` between the check and the fetch. Agent registration's endpoint health-check now uses `safeFetch`, so it can't be used as an SSRF probe into internal services.

### Deferred (tracked in `docs/SECURITY_AUDIT.md` / SEC issues)
- Wallet-signature replay nonce cache
- Off-chain dispute griefing guard
- Reputation self-dealing mitigation

Both become meaningful once `AUTH_ENFORCED=true`; they need a durable store / redesign and are scoped to the frontend-signing milestone.

## Test plan
- [ ] Facilitator path: a response reporting `amountAtomic < required` is rejected with `underpaid: …`.
- [ ] `safeFetch` to a hostname that resolves public but rebinds to a private IP connects only to the pinned public address.
- [ ] Agent register with an endpoint that DNS-rebinds to internal is blocked.