### PR TITLE
security: audit wave 3 — dispute griefing, reputation self-dealing, DoS/cost guards

### DIFF
--- a/app/app/api/agents/stake/route.ts
+++ b/app/app/api/agents/stake/route.ts
@@ -36,9 +36,21 @@ export async function POST(req: NextRequest) {
     if (!__guard.ok)
       return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
 
-    if (typeof amount !== "number" || amount < 10) {
+    if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 10) {
       return NextResponse.json(
         { error: "Minimum stake is 10 USDC" },
+        { status: 400 },
+      );
+    }
+
+    // Upper sanity bound — stake is recorded off-chain and not yet verified
+    // against an on-chain transfer, so cap what can be written (matches the
+    // job-amount ceiling in lib/validate.ts). The finiteness check above also
+    // rejects Infinity / NaN, which are both typeof "number".
+    const MAX_STAKE_USDC = 1_000_000;
+    if (amount > MAX_STAKE_USDC) {
+      return NextResponse.json(
+        { error: `Maximum stake is ${MAX_STAKE_USDC} USDC` },
         { status: 400 },
       );
     }

--- a/app/app/api/generate/image/route.ts
+++ b/app/app/api/generate/image/route.ts
@@ -62,6 +62,14 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+    // Upper bound — the prompt is forwarded to the paid fal.ai API; cap it so
+    // a caller can't push a megabyte prompt through on every request.
+    if (prompt.length > 2000) {
+      return NextResponse.json(
+        { error: "prompt is too long (max 2000 chars)" },
+        { status: 400 },
+      );
+    }
 
     const dimensions = SIZE_MAP[size] ?? SIZE_MAP.square;
 

--- a/app/app/api/helius/webhook/route.ts
+++ b/app/app/api/helius/webhook/route.ts
@@ -147,6 +147,16 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
   }
 
+  // Bound the batch: each element triggers DB round-trips, so an oversized
+  // array (real Helius batches are small) is a cheap amplification vector.
+  const MAX_WEBHOOK_BATCH = 1000;
+  if (payload.length > MAX_WEBHOOK_BATCH) {
+    return NextResponse.json(
+      { error: `Webhook batch too large (${payload.length} > ${MAX_WEBHOOK_BATCH})` },
+      { status: 413 },
+    );
+  }
+
   let processed = 0;
   let skipped = 0;
   const errors: string[] = [];

--- a/app/app/api/hosted-agents/avatar/route.ts
+++ b/app/app/api/hosted-agents/avatar/route.ts
@@ -1,18 +1,73 @@
 import { NextRequest, NextResponse } from "next/server";
+import { enforceIpLimit } from "@/lib/rateLimit";
 
 export const dynamic = "force-dynamic";
 
+const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
+
+// Raster-only allowlist. SVG is intentionally excluded: it can carry inline
+// <script>, and this route returns a data: URL that may later be rendered in a
+// script-executing context — so accepting SVG would be a stored-XSS foot-gun.
+const ALLOWED_AVATAR_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
+
+/** Verify the leading magic bytes match a supported raster type. */
+function sniffRasterType(
+  buf: Buffer,
+): "image/png" | "image/jpeg" | "image/webp" | "image/gif" | null {
+  if (buf.length >= 8 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47)
+    return "image/png";
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff)
+    return "image/jpeg";
+  if (buf.length >= 12 && buf.toString("ascii", 0, 4) === "RIFF" && buf.toString("ascii", 8, 12) === "WEBP")
+    return "image/webp";
+  if (buf.length >= 6 && buf.toString("ascii", 0, 4) === "GIF8")
+    return "image/gif";
+  return null;
+}
+
 export async function POST(req: NextRequest) {
+  // Per-IP durable rate limit — the endpoint is anonymous and returns an
+  // inlined base64 data URL, so without a cap it is an unbounded storage/CPU
+  // abuse vector.
+  const limited = await enforceIpLimit(req, "avatar_upload");
+  if (limited) return limited;
+
   const formData = await req.formData();
   const file = formData.get("avatar") as File | null;
   if (!file) return NextResponse.json({ error: "No file" }, { status: 400 });
-  if (file.size > 2 * 1024 * 1024) return NextResponse.json({ error: "Max 2MB" }, { status: 400 });
-  if (!file.type.startsWith("image/")) return NextResponse.json({ error: "Images only" }, { status: 400 });
 
-  // Convert to base64 data URL — no external dependency needed
+  if (!ALLOWED_AVATAR_TYPES.has(file.type)) {
+    return NextResponse.json(
+      { error: "Only PNG, JPEG, WebP or GIF images are allowed" },
+      { status: 400 },
+    );
+  }
+
+  // Enforce the size limit on the ACTUAL decoded bytes before storing —
+  // File.size is client-supplied metadata and must not be trusted alone.
   const bytes = await file.arrayBuffer();
-  const base64 = Buffer.from(bytes).toString("base64");
-  const dataUrl = `data:${file.type};base64,${base64}`;
+  const buf = Buffer.from(bytes);
+  if (buf.byteLength > MAX_AVATAR_BYTES) {
+    return NextResponse.json({ error: "Max 2MB" }, { status: 400 });
+  }
+
+  // Verify magic bytes and build the data URL from the sniffed type, so a
+  // spoofed Content-Type cannot smuggle a different payload into the URL.
+  const sniffed = sniffRasterType(buf);
+  if (!sniffed) {
+    return NextResponse.json(
+      { error: "File content is not a valid raster image" },
+      { status: 400 },
+    );
+  }
+
+  const base64 = buf.toString("base64");
+  const dataUrl = `data:${sniffed};base64,${base64}`;
 
   return NextResponse.json({ url: dataUrl });
 }

--- a/app/app/api/jobs/[id]/dispute/route.ts
+++ b/app/app/api/jobs/[id]/dispute/route.ts
@@ -131,9 +131,20 @@ export async function POST(
         { status: 400 },
       );
     }
+    // Disputes are only meaningful against a real on-chain escrow. A job with
+    // no PDA has no locked funds and no bond to verify, so accepting a
+    // "dispute" on it would just flip status to Disputed and permanently block
+    // finalize — a free griefing vector. Require the escrow PDA and verify the
+    // on-chain raise_dispute unconditionally (not only when job.pda is set).
+    if (!job.pda) {
+      return NextResponse.json(
+        { error: "This job has no on-chain escrow and cannot be disputed." },
+        { status: 400 },
+      );
+    }
     try {
       await verifyTxInvokedCovenant(txHash);
-      if (job.pda) {
+      {
         const onchain = await fetchJobEscrow(new PublicKey(job.pda));
         if (!onchain) {
           throw new Error(

--- a/app/app/api/jobs/[id]/finalize/route.ts
+++ b/app/app/api/jobs/[id]/finalize/route.ts
@@ -120,13 +120,26 @@ export async function POST(
       // program + the JobEscrow status is now Finalized.
       try {
         await verifyTxInvokedCovenant(callerTxSig);
-        if (job.pda) {
-          const onchain = await fetchJobEscrow(new PublicKey(job.pda));
-          if (onchain && onchain.status !== "Finalized") {
-            throw new Error(
-              `On-chain JobEscrow status is ${onchain.status}; expected Finalized after the crank tx.`,
-            );
-          }
+        // Bind the verification to THIS job. A job with no PDA has no escrow
+        // to inspect, so an arbitrary confirmed Covenant tx must not be able to
+        // satisfy finalize for it (it would book reputation/revenue/fees off an
+        // unrelated tx). Require the PDA and assert it actually reached
+        // Finalized — a null fetch or any other status is a hard failure.
+        if (!job.pda) {
+          throw new Error(
+            "Client-cranked finalize requires an on-chain escrow PDA for this job.",
+          );
+        }
+        const onchain = await fetchJobEscrow(new PublicKey(job.pda));
+        if (!onchain) {
+          throw new Error(
+            `JobEscrow PDA ${job.pda.slice(0, 8)}… not found on chain.`,
+          );
+        }
+        if (onchain.status !== "Finalized") {
+          throw new Error(
+            `On-chain JobEscrow status is ${onchain.status}; expected Finalized after the crank tx.`,
+          );
         }
         paymentTxHash = callerTxSig;
       } catch (err) {
@@ -228,19 +241,24 @@ export async function POST(
     // Update related DB records.
     const updated = await prisma.$transaction(async (tx) => {
       const j = await tx.job.findUnique({ where: { id } });
-      await tx.reputation.upsert({
-        where: { walletAddress: job.takerWallet as string },
-        create: {
-          walletAddress: job.takerWallet as string,
-          jobsCompleted: 1,
-          totalEarned: job.amount,
-          firstJobAt: new Date(),
-        },
-        update: {
-          jobsCompleted: { increment: 1 },
-          totalEarned: { increment: job.amount },
-        },
-      });
+      // Reputation self-dealing guard: a wallet that posts a job to itself
+      // must not inflate its own jobsCompleted / totalEarned by finalizing.
+      // Only credit reputation when the poster and taker are distinct wallets.
+      if (job.posterWallet !== job.takerWallet) {
+        await tx.reputation.upsert({
+          where: { walletAddress: job.takerWallet as string },
+          create: {
+            walletAddress: job.takerWallet as string,
+            jobsCompleted: 1,
+            totalEarned: job.amount,
+            firstJobAt: new Date(),
+          },
+          update: {
+            jobsCompleted: { increment: 1 },
+            totalEarned: { increment: job.amount },
+          },
+        });
+      }
       await tx.jobEvent.create({
         data: {
           jobId: id,

--- a/app/app/api/stats/dashboard/route.ts
+++ b/app/app/api/stats/dashboard/route.ts
@@ -66,22 +66,29 @@ export async function GET(req: NextRequest) {
     }));
 
     // ── 3. Category distribution ─────────────────────────────────────
-    const allUserJobs = await prisma.job.findMany({
+    // Aggregate in the DB (groupBy) rather than loading every job row for the
+    // wallet into memory — the previous unbounded findMany grew with a
+    // wallet's lifetime job count and could be used to exhaust memory.
+    const catGroups = await prisma.job.groupBy({
+      by: ["category"],
       where: {
         OR: [
           { posterWallet: wallet },
           { takerWallet: wallet },
         ],
       },
-      select: { category: true },
+      _count: { _all: true },
     });
 
     const catMap = new Map<string, number>();
-    for (const j of allUserJobs) {
-      const cat = j.category || "text_writing";
-      catMap.set(cat, (catMap.get(cat) ?? 0) + 1);
+    let totalCatJobsRaw = 0;
+    for (const g of catGroups) {
+      const cat = g.category || "text_writing";
+      const n = g._count?._all ?? 0;
+      catMap.set(cat, (catMap.get(cat) ?? 0) + n);
+      totalCatJobsRaw += n;
     }
-    const totalCatJobs = allUserJobs.length || 1;
+    const totalCatJobs = totalCatJobsRaw || 1;
     const categoryDistribution = Array.from(catMap.entries())
       .sort((a, b) => b[1] - a[1])
       .map(([category, count]) => ({

--- a/app/lib/rateLimit.ts
+++ b/app/lib/rateLimit.ts
@@ -30,6 +30,7 @@ const LIMIT_TABLE: Record<string, { limit: number; windowMs: number }> = {
   unstake:       { limit: 10, windowMs: 60_000 },
   cancel_claim:  { limit: 30, windowMs: 60_000 },
   faucet_ip:     { limit: 10, windowMs: 60 * 60_000 },
+  avatar_upload: { limit: 20, windowMs: 60_000 },
 };
 
 /** Returns the (limit, windowMs) for a named op. Falls back to a sane default. */


### PR DESCRIPTION
## Audit wave 3 — off-chain hardening (additive, non-breaking)

Follow-up to PR #248 (wave 1), #314 (wave 2), #313 (anchor). Each change is additive and preserves existing request/response contracts. The `AUTH_ENFORCED`-dependent IDOR findings remain tracked separately (deferred frontend-signing milestone).

### HIGH
- **Dispute griefing** (`jobs/[id]/dispute`): reject disputes on jobs with no on-chain escrow (`job.pda` null) and run the `raise_dispute` on-chain verification **unconditionally**. Previously a demo/no-PDA job could be flipped to `Disputed` by *any* confirmed Covenant tx, permanently blocking finalize — a free griefing vector.
- **Reputation self-dealing** (`jobs/[id]/finalize`): skip the reputation/earnings credit when `posterWallet === takerWallet`, so a wallet can't post a job to itself and farm `jobsCompleted` / `totalEarned`.

### MEDIUM
- **finalize Path B binding**: require `job.pda` and assert the JobEscrow actually reached `Finalized` (a null fetch or any other status now fails) instead of accepting any confirmed Covenant tx for a no-PDA job — which otherwise booked reputation/revenue/fees off an unrelated tx.
- **hosted-agent avatar**: per-IP durable rate limit + raster-only allowlist (reject `svg+xml`), enforce the 2 MB cap on **real decoded bytes**, and verify magic bytes — building the data URL from the sniffed type, not the spoofable `Content-Type`.
- **agents/stake**: reject non-finite amounts (`Infinity`/`NaN` are `typeof "number"`) and cap at 1,000,000 USDC (matches `lib/validate.ts`).
- **helius/webhook**: cap the batch at 1000 entries (413) — each element drives DB round-trips.
- **generate/image**: upper-bound the prompt at 2000 chars before forwarding to the paid fal.ai API.
- **stats/dashboard**: aggregate category distribution with a DB `groupBy` instead of an unbounded `findMany` over every job row for the wallet.

### Re-verified as already-addressed (intentionally not re-touched)
profile avatar (wave 1 auth + allowlist), faucet (wave 1 per-IP + per-wallet durable limits), SSRF/x402 (wave 2), escrow PDA (anchor PR #313).

## Verification
- No syntax/type regressions in any touched file (`tsc` reports only environmental `next/server` module-resolution noise from a missing local `node_modules`; CI `build` is authoritative).
- All changes are additive guards; existing callers and response shapes are unchanged.

## Test plan
- [ ] Dispute on a `job.pda === null` job is rejected (400) and does not flip status.
- [ ] Self-posted job (poster == taker) finalizes without crediting reputation.
- [ ] Path B finalize with a real-but-unrelated Covenant tx on a no-PDA job is rejected.
- [ ] hosted-agent avatar: SVG rejected, >2 MB rejected on real bytes, spoofed Content-Type ignored, rate limit trips.
- [ ] stake: `Infinity`/`NaN`/over-cap rejected.
- [ ] helius webhook batch > 1000 → 413.
- [ ] CI build green.