### PR TITLE
security: IDOR signer-binding + wallet-session auth (AUTH_ENFORCED activation)

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -28,6 +28,19 @@ BLOB_READ_WRITE_TOKEN=
 COVENANT_ARBITRATORS=
 COVENANT_ARBITRATOR_THRESHOLD=2
 
+# === MUTATING-ENDPOINT AUTH (C-091) ===
+# Wallet-session auth. Set SESSION_SECRET (>=16 random chars) to ACTIVATE
+# enforcement: users sign one login message, get an httpOnly session cookie, and
+# every wallet-scoped mutating route then binds the request to the signer. While
+# this is unset, mutating endpoints stay open (a prod warning is logged) and the
+# UI shows no login prompt. Rotate the secret to revoke all sessions.
+SESSION_SECRET=
+# Force enforcement on/off regardless of SESSION_SECRET ("true" | "false").
+# Leave unset to auto-enforce whenever SESSION_SECRET is configured.
+AUTH_ENFORCED=
+# Comma-separated API keys for server-to-server / bot callers (x-api-key header).
+API_KEYS=
+
 # === CRON JOBS ===
 # Shared secret for /api/cron/finalize and /api/cron/reconcile.
 # Vercel Cron passes this as Authorization: Bearer $CRON_SECRET.

--- a/app/app/api/agents/register/route.ts
+++ b/app/app/api/agents/register/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { awardXP } from "@/lib/xp";
 import { unlockAchievement } from "@/lib/achievements";
 import { assertPublicUrl } from "@/lib/ssrf";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 
 const VALID_CAPABILITIES = [
   "writing",
@@ -16,7 +17,11 @@ const VALID_CAPABILITIES = [
 // ── POST: Register a new agent ──────────────────────────────────────────────
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
+    const raw = await req.text();
+    const auth = await requireAuth(req, { rawBody: raw });
+    if (!auth.ok)
+      return NextResponse.json({ error: auth.reason }, { status: auth.status });
+    const body = raw ? JSON.parse(raw) : {};
     const { walletAddress, name, description, endpointUrl, capabilities } = body;
 
     // ── Field presence ────────────────────────────────────────────────────
@@ -26,6 +31,11 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+
+    // ── IDOR bind: only the wallet owner may register agents under it ──────
+    const guard = requireWalletMatch(auth, walletAddress);
+    if (!guard.ok)
+      return NextResponse.json({ error: guard.reason }, { status: guard.status });
 
     // ── Name length ───────────────────────────────────────────────────────
     const trimmedName = String(name).trim();

--- a/app/app/api/auth/login/route.ts
+++ b/app/app/api/auth/login/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyWalletSignature } from "@/lib/wallet-auth";
+import {
+  issueSession,
+  loginMessage,
+  sessionConfigured,
+  SESSION_COOKIE,
+  SESSION_TTL_MS,
+} from "@/lib/session";
+import { enforceIpLimit } from "@/lib/rateLimit";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/auth/login
+ *
+ * Exchange a one-time wallet signature for a session cookie. The client signs
+ * `covenant-login:v1\n<wallet>\n<ts>` with the connected wallet; on success we
+ * set an httpOnly, SameSite=Lax session cookie that every later same-origin
+ * request carries automatically (so mutating endpoints can authenticate
+ * without a per-request popup).
+ *
+ * Body: { wallet, signature, ts, message? }
+ */
+export async function POST(req: NextRequest) {
+  const limited = await enforceIpLimit(req, "auth_login");
+  if (limited) return limited;
+
+  if (!sessionConfigured()) {
+    return NextResponse.json(
+      { error: "Session auth is not configured (set SESSION_SECRET, >=16 chars)." },
+      { status: 503 },
+    );
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const { wallet, signature, ts, message } = body as {
+    wallet?: string;
+    signature?: string;
+    ts?: string | number;
+    message?: string;
+  };
+  if (!wallet || !signature || ts === undefined || ts === null) {
+    return NextResponse.json(
+      { error: "wallet, signature, and ts are required" },
+      { status: 400 },
+    );
+  }
+
+  const expected = loginMessage(wallet, ts);
+  const v = verifyWalletSignature({
+    wallet,
+    signature,
+    message: message ?? expected,
+    expectedMessage: expected,
+    ts,
+  });
+  if (!v.ok) {
+    return NextResponse.json({ error: v.reason }, { status: 401 });
+  }
+
+  const token = issueSession(wallet, Date.now());
+  const res = NextResponse.json({ ok: true, wallet });
+  res.cookies.set(SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: Math.floor(SESSION_TTL_MS / 1000),
+  });
+  return res;
+}

--- a/app/app/api/auth/logout/route.ts
+++ b/app/app/api/auth/logout/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SESSION_COOKIE } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+/** POST /api/auth/logout — clear the session cookie. */
+export async function POST(_req: NextRequest) {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(SESSION_COOKIE, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+  return res;
+}

--- a/app/app/api/auth/session/route.ts
+++ b/app/app/api/auth/session/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SESSION_COOKIE, readCookie, verifySession } from "@/lib/session";
+import { sessionConfigured } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/auth/session — who am I?
+ *
+ * Returns the wallet bound to the current session cookie (or null). The client
+ * uses this to decide whether it still needs to prompt a login signature.
+ * `configured` lets the client skip the login flow entirely when session auth
+ * is not enabled on this deployment.
+ */
+export async function GET(req: NextRequest) {
+  const token = readCookie(req, SESSION_COOKIE);
+  const sess = verifySession(token, Date.now());
+  return NextResponse.json({
+    wallet: sess?.wallet ?? null,
+    configured: sessionConfigured(),
+  });
+}

--- a/app/app/api/claims/[id]/buy/route.ts
+++ b/app/app/api/claims/[id]/buy/route.ts
@@ -6,7 +6,7 @@ import {
   verifyTxInvokedCovenant,
 } from "@/lib/credit-server";
 import { PublicKey } from "@solana/web3.js";
-import { requireAuth } from "@/lib/require-auth";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 import { log } from "@/lib/logger";
 
 /**
@@ -41,6 +41,12 @@ export async function POST(
         { status: 400 },
       );
     }
+
+    // IDOR bind: the signer must control the buyer wallet (the on-chain buyer
+    // check below is the primary proof; this binds it to the signer too).
+    const __guard = requireWalletMatch(__auth, buyerWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
 
     const claim = await prisma.claimListing.findUnique({
       where: { id },

--- a/app/app/api/claims/[id]/cancel/route.ts
+++ b/app/app/api/claims/[id]/cancel/route.ts
@@ -6,6 +6,7 @@ import {
   verifyTxInvokedCovenant,
 } from "@/lib/credit-server";
 import { PublicKey } from "@solana/web3.js";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 
 /**
  * POST /api/claims/[id]/cancel
@@ -25,7 +26,11 @@ export async function POST(
     const { id } = await params;
     const limited = await enforceIpLimit(req, "cancel_claim");
     if (limited) return limited;
-    const body = await req.json();
+    const raw = await req.text();
+    const auth = await requireAuth(req, { rawBody: raw });
+    if (!auth.ok)
+      return NextResponse.json({ error: auth.reason }, { status: auth.status });
+    const body = raw ? JSON.parse(raw) : {};
     const { sellerWallet, txSignature } = body as {
       sellerWallet?: string;
       txSignature?: string;
@@ -36,6 +41,11 @@ export async function POST(
         { status: 400 },
       );
     }
+
+    // IDOR bind: the signer must control the seller wallet they cancel as.
+    const guard = requireWalletMatch(auth, sellerWallet);
+    if (!guard.ok)
+      return NextResponse.json({ error: guard.reason }, { status: guard.status });
 
     const claim = await prisma.claimListing.findUnique({ where: { id } });
     if (!claim) {

--- a/app/app/api/disputes/[id]/resolve/route.ts
+++ b/app/app/api/disputes/[id]/resolve/route.ts
@@ -7,6 +7,7 @@ import {
 import { PublicKey } from "@solana/web3.js";
 import crypto from "crypto";
 import { enforceIpLimit } from "@/lib/rateLimit";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 
 /**
  * POST /api/disputes/[id]/resolve
@@ -39,7 +40,11 @@ export async function POST(
     if (limited) return limited;
 
     const { id } = await params;
-    const body = await request.json();
+    const __raw = await request.text();
+    const __auth = await requireAuth(request, { rawBody: __raw });
+    if (!__auth.ok)
+      return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
+    const body = __raw ? JSON.parse(__raw) : {};
     const {
       arbitratorWallet,
       resolution,
@@ -70,6 +75,12 @@ export async function POST(
         { status: 403 },
       );
     }
+
+    // Bind the vote to the signer: an arbitrator's vote cannot be forged under
+    // their address by another caller (body-supplied identity was spoofable).
+    const __guard = requireWalletMatch(__auth, arbitratorWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
     if (!resolution || !["FavorTaker", "FavorPoster", "Split"].includes(resolution)) {
       return NextResponse.json(
         { error: "resolution must be one of: FavorTaker, FavorPoster, Split" },

--- a/app/app/api/disputes/route.ts
+++ b/app/app/api/disputes/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import crypto from "crypto";
 import { enforceIpLimit } from "@/lib/rateLimit";
-import { requireAuth } from "@/lib/require-auth";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 import { log } from "@/lib/logger";
 import { alertDisputeSpike } from "@/lib/alerts";
 
@@ -81,6 +81,11 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
+
+    // IDOR bind: the signer must control the poster wallet raising the dispute.
+    const __guard = requireWalletMatch(__auth, posterWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
 
     const job = await prisma.job.findUnique({
       where: { id: jobId },

--- a/app/app/api/hosted-agents/[id]/route.ts
+++ b/app/app/api/hosted-agents/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { checkUrlSync } from "@/lib/ssrf";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -19,8 +20,16 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  const body = await req.json();
+  const raw = await req.text();
+  const auth = await requireAuth(req, { rawBody: raw });
+  if (!auth.ok)
+    return NextResponse.json({ error: auth.reason }, { status: auth.status });
+  const body = raw ? JSON.parse(raw) : {};
   const { walletAddress, ...updates } = body;
+
+  const guard = requireWalletMatch(auth, walletAddress);
+  if (!guard.ok)
+    return NextResponse.json({ error: guard.reason }, { status: guard.status });
 
   const agent = await prisma.hostedAgent.findUnique({ where: { id } });
   if (!agent) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -58,14 +67,26 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
-  const body = await req.json().catch(() => ({}));
-  const { walletAddress } = body as { walletAddress?: string };
+  const raw = await req.text();
+  const auth = await requireAuth(req, { rawBody: raw });
+  if (!auth.ok)
+    return NextResponse.json({ error: auth.reason }, { status: auth.status });
+  let body: { walletAddress?: string } = {};
+  try {
+    body = raw ? JSON.parse(raw) : {};
+  } catch {
+    body = {};
+  }
+  const { walletAddress } = body;
 
   const agent = await prisma.hostedAgent.findUnique({ where: { id } });
   if (!agent) return NextResponse.json({ error: "Not found" }, { status: 404 });
   if (!walletAddress) {
     return NextResponse.json({ error: "walletAddress required" }, { status: 400 });
   }
+  const guard = requireWalletMatch(auth, walletAddress);
+  if (!guard.ok)
+    return NextResponse.json({ error: guard.reason }, { status: guard.status });
   if (agent.walletAddress !== walletAddress) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
   }

--- a/app/app/api/hosted-agents/route.ts
+++ b/app/app/api/hosted-agents/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { awardXP } from "@/lib/xp";
 import { sendMarkerTransaction } from "@/lib/solana";
 import { checkUrlSync } from "@/lib/ssrf";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -45,7 +46,11 @@ export async function POST(req: NextRequest) {
   if (blocked) return blocked;
 
   try {
-    const body = await req.json();
+    const raw = await req.text();
+    const auth = await requireAuth(req, { rawBody: raw });
+    if (!auth.ok)
+      return NextResponse.json({ error: auth.reason }, { status: auth.status });
+    const body = raw ? JSON.parse(raw) : {};
     const { walletAddress, name, category, systemPrompt, model, minPrice, maxPrice, avatarUrl, webEnabled } = body as {
       walletAddress?: string;
       name?: string;
@@ -62,6 +67,11 @@ export async function POST(req: NextRequest) {
     if (!walletAddress || typeof walletAddress !== "string") {
       return NextResponse.json({ error: "walletAddress is required" }, { status: 400 });
     }
+
+    // IDOR bind: only the wallet owner may create agents under their address.
+    const guard = requireWalletMatch(auth, walletAddress);
+    if (!guard.ok)
+      return NextResponse.json({ error: guard.reason }, { status: guard.status });
     if (!name || typeof name !== "string" || name.trim().length < 3 || name.trim().length > 50) {
       return NextResponse.json({ error: "name must be 3-50 characters" }, { status: 400 });
     }

--- a/app/app/api/jobs/[id]/accept/route.ts
+++ b/app/app/api/jobs/[id]/accept/route.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/program-server";
 import { checkAcceptJob } from "@/lib/onchain-verify";
 import { classifySolanaError } from "@/lib/solana-errors";
-import { requireAuth } from "@/lib/require-auth";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 import { log } from "@/lib/logger";
 
 /**
@@ -34,13 +34,16 @@ export async function POST(
   if (blocked) return blocked;
 
   const reqLog = log.forRequest(request); // C-110: correlate this request
-  const __auth = await requireAuth(request); // C-091: verified signature or API key
+  // Read the raw body so the signature binds to it (C-091): requireAuth hashes
+  // the exact bytes the client signed. request.json() can only be read once.
+  const __raw = await request.text();
+  const __auth = await requireAuth(request, { rawBody: __raw });
   if (!__auth.ok)
     return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
 
   try {
     const { id } = await params;
-    const body = await request.json();
+    const body = __raw ? JSON.parse(__raw) : {};
     const { takerWallet, txHash: acceptTxHash } = body;
 
     if (!takerWallet || typeof takerWallet !== "string") {
@@ -49,6 +52,11 @@ export async function POST(
         { status: 400 },
       );
     }
+
+    // IDOR bind: the signer must control the taker wallet they accept under.
+    const __guard = requireWalletMatch(__auth, takerWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
 
     const job = await prisma.job.findUnique({
       where: { id },

--- a/app/app/api/jobs/[id]/cancel/route.ts
+++ b/app/app/api/jobs/[id]/cancel/route.ts
@@ -7,7 +7,7 @@ import {
   verifyTxInvokedCovenant,
 } from "@/lib/program-server";
 import { PublicKey } from "@solana/web3.js";
-import { requireAuth } from "@/lib/require-auth";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 import { log } from "@/lib/logger";
 
 /**
@@ -33,13 +33,14 @@ export async function POST(
   if (blocked) return blocked;
 
   const reqLog = log.forRequest(request); // C-110: correlate this request
-  const __auth = await requireAuth(request); // C-091: verified signature or API key
+  const __raw = await request.text();
+  const __auth = await requireAuth(request, { rawBody: __raw }); // C-091
   if (!__auth.ok)
     return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
 
   try {
     const { id } = await params;
-    const body = await request.json();
+    const body = __raw ? JSON.parse(__raw) : {};
     const { signerWallet, txHash } = body as {
       signerWallet?: string;
       txHash?: string;
@@ -51,6 +52,13 @@ export async function POST(
         { status: 400 },
       );
     }
+
+    // IDOR bind: the signer must control the wallet they cancel as. (The
+    // on-chain program is the source of truth for who may cancel; this stops
+    // a forged DB-mirror under someone else's wallet once enforced.)
+    const __guard = requireWalletMatch(__auth, signerWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
     if (!txHash) {
       return NextResponse.json(
         {

--- a/app/app/api/jobs/[id]/dispute/route.ts
+++ b/app/app/api/jobs/[id]/dispute/route.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/program-server";
 import { PublicKey } from "@solana/web3.js";
 import crypto from "crypto";
-import { requireAuth } from "@/lib/require-auth";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 import { log } from "@/lib/logger";
 import { alertDisputeSpike } from "@/lib/alerts";
 
@@ -29,11 +29,12 @@ export async function POST(
 ) {
   try {
     const reqLog = log.forRequest(request); // C-110: correlate this request
-    const __auth = await requireAuth(request); // C-091: verified signature or API key
+    const __raw = await request.text();
+    const __auth = await requireAuth(request, { rawBody: __raw }); // C-091
     if (!__auth.ok)
       return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
     const { id } = await params;
-    const body = await request.json();
+    const body = __raw ? JSON.parse(__raw) : {};
     const {
       posterWallet,
       reasonText,
@@ -52,6 +53,11 @@ export async function POST(
         { status: 400 },
       );
     }
+
+    // IDOR bind: the signer must control the poster wallet raising the dispute.
+    const __guard = requireWalletMatch(__auth, posterWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
     if (!reasonText || reasonText.length < 10) {
       return NextResponse.json(
         { error: "reasonText must be at least 10 characters" },

--- a/app/app/api/jobs/[id]/submit/route.ts
+++ b/app/app/api/jobs/[id]/submit/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/program-server";
 import { PublicKey } from "@solana/web3.js";
 import crypto from "crypto";
-import { requireAuth } from "@/lib/require-auth";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 import { log } from "@/lib/logger";
 
 /**
@@ -35,13 +35,15 @@ export async function POST(
   if (blocked) return blocked;
 
   const reqLog = log.forRequest(request); // C-110: correlate this request
-  const __auth = await requireAuth(request); // C-091: verified signature or API key
+  // Read the raw body once so the signature binds to it (C-091).
+  const __raw = await request.text();
+  const __auth = await requireAuth(request, { rawBody: __raw });
   if (!__auth.ok)
     return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
 
   try {
     const { id } = await params;
-    const body = await request.json();
+    const body = __raw ? JSON.parse(__raw) : {};
     const {
       takerWallet,
       text,
@@ -64,6 +66,11 @@ export async function POST(
         { status: 400 },
       );
     }
+
+    // IDOR bind: the signer must control the taker wallet they submit under.
+    const __guard = requireWalletMatch(__auth, takerWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
     if (!text || typeof text !== "string") {
       return NextResponse.json({ error: "text is required" }, { status: 400 });
     }

--- a/app/app/api/jobs/route.ts
+++ b/app/app/api/jobs/route.ts
@@ -6,7 +6,7 @@ import { sendMarkerTransaction } from "@/lib/solana";
 import { rateLimitDurable, getLimit } from "@/lib/rateLimit";
 import { buildJobSpec, hashJobSpec } from "@/lib/spec";
 import { moderateJobContent } from "@/lib/moderation";
-import { requireAuth } from "@/lib/require-auth";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 import { log } from "@/lib/logger";
 import { screenWallet } from "@/lib/sanctions";
 import type { Prisma } from "@prisma/client";
@@ -136,7 +136,8 @@ export async function POST(request: NextRequest) {
   if (blocked) return blocked;
 
   const reqLog = log.forRequest(request); // C-110: correlate this request
-  const __auth = await requireAuth(request); // C-091: verified signature or API key
+  const __raw = await request.text();
+  const __auth = await requireAuth(request, { rawBody: __raw }); // C-091
   if (!__auth.ok)
     return NextResponse.json({ error: __auth.reason }, { status: __auth.status });
 
@@ -153,7 +154,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const body = await request.json();
+    const body = __raw ? JSON.parse(__raw) : {};
     const {
       posterWallet,
       amount,
@@ -185,6 +186,12 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    // IDOR bind: the signer must control the poster wallet the job is created
+    // under (no posting jobs as someone else once enforced).
+    const __guard = requireWalletMatch(__auth, posterWallet);
+    if (!__guard.ok)
+      return NextResponse.json({ error: __guard.reason }, { status: __guard.status });
 
     // C-105: block sanctioned (OFAC) wallets at the on-ramp.
     const sanctioned = screenWallet(posterWallet);

--- a/app/app/api/referral/claim/route.ts
+++ b/app/app/api/referral/claim/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { generateReferralCode } from "@/lib/referral";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 
 /**
  * POST /api/referral/claim
@@ -11,7 +12,11 @@ import { generateReferralCode } from "@/lib/referral";
  */
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
+    const raw = await req.text();
+    const auth = await requireAuth(req, { rawBody: raw });
+    if (!auth.ok)
+      return NextResponse.json({ error: auth.reason }, { status: auth.status });
+    const body = raw ? JSON.parse(raw) : {};
     const { referredWallet, referrerWallet } = body as {
       referredWallet?: string;
       referrerWallet?: string;
@@ -23,6 +28,12 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+
+    // Bind to the signer: only the referred wallet's owner may create its
+    // referral edge (prevents farming edges for arbitrary wallets).
+    const guard = requireWalletMatch(auth, referredWallet);
+    if (!guard.ok)
+      return NextResponse.json({ error: guard.reason }, { status: guard.status });
 
     // Self-referral check
     if (referredWallet === referrerWallet) {

--- a/app/app/api/reviews/route.ts
+++ b/app/app/api/reviews/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { requireAuth, requireWalletMatch } from "@/lib/require-auth";
 
 /**
  * POST /api/reviews — submit a rating for a finalized/resolved job
@@ -8,7 +9,11 @@ import { prisma } from "@/lib/prisma";
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
+    const raw = await req.text();
+    const auth = await requireAuth(req, { rawBody: raw });
+    if (!auth.ok)
+      return NextResponse.json({ error: auth.reason }, { status: auth.status });
+    const body = raw ? JSON.parse(raw) : {};
     const { jobId, posterWallet, takerWallet, rating, comment } = body as {
       jobId?: string;
       posterWallet?: string;
@@ -23,6 +28,12 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+
+    // Bind to the signer: only the poster may write the review (the
+    // job.posterWallet check below is otherwise spoofable once enforced).
+    const guard = requireWalletMatch(auth, posterWallet);
+    if (!guard.ok)
+      return NextResponse.json({ error: guard.reason }, { status: guard.status });
     if (!rating || rating < 1 || rating > 5) {
       return NextResponse.json(
         { error: "rating must be 1-5" },

--- a/app/components/Providers.tsx
+++ b/app/components/Providers.tsx
@@ -5,6 +5,7 @@ import { AppProvider } from "@solana/connector/react";
 import { getDefaultConfig } from "@solana/connector/headless";
 import { DEVNET_ENDPOINT } from "@/lib/constants";
 import ProfileGate from "./ProfileGate";
+import SessionGate from "./SessionGate";
 import OnboardingTour from "./OnboardingTour";
 import FaucetWidget from "./FaucetWidget";
 import TransactionTicker from "./TransactionTicker";
@@ -53,6 +54,7 @@ export default function Providers({ children }: ProvidersProps) {
       <ProfileGate>{children}</ProfileGate>
       {mounted && (
         <>
+          <SessionGate />
           <NavigationProgress />
           <OnboardingTour />
           <FaucetWidget />

--- a/app/components/SessionGate.tsx
+++ b/app/components/SessionGate.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useConnector } from "@solana/connector/react";
+import { ensureSession, endSession } from "@/lib/auth-login";
+
+/**
+ * Establishes a wallet session (C-091 activation) when a wallet connects.
+ *
+ * On connect it calls `ensureSession`, which is a no-op when a valid session
+ * cookie already exists (so reconnects via autoConnect do NOT re-prompt) and
+ * when session auth is disabled on the deployment. Only a genuinely new login
+ * triggers a single `signMessage` popup. Renders nothing.
+ */
+export default function SessionGate() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const connector = useConnector() as any;
+  const isConnected: boolean = !!connector?.isConnected;
+  const account: string | undefined = connector?.account;
+  const selectedWallet = connector?.selectedWallet ?? null;
+  const triedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (isConnected && account && selectedWallet) {
+      if (triedFor.current !== account) {
+        triedFor.current = account;
+        void ensureSession(selectedWallet, account);
+      }
+    } else if (!isConnected && triedFor.current) {
+      triedFor.current = null;
+      void endSession();
+    }
+  }, [isConnected, account, selectedWallet]);
+
+  return null;
+}

--- a/app/lib/auth-login.ts
+++ b/app/lib/auth-login.ts
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * Client side of the wallet-session login (C-091 activation).
+ *
+ * `ensureSession` is idempotent and de-duplicated: it checks the current
+ * session, and only when there is no valid session for the connected wallet
+ * does it prompt a single `signMessage` and exchange it for a cookie via
+ * `/api/auth/login`. After that, every same-origin fetch authenticates via the
+ * httpOnly cookie automatically — no per-request signing.
+ */
+import { signMessageWithWallet } from "./wallet-sign";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyWallet = any;
+
+let loggedInWallet: string | null = null;
+let inFlight: Promise<boolean> | null = null;
+
+/** Must match `loginMessage` in lib/session.ts byte-for-byte. */
+function loginMessage(wallet: string, ts: number): string {
+  return `covenant-login:v1\n${wallet}\n${ts}`;
+}
+
+/**
+ * Ensure a valid session cookie exists for `account`. Returns true when the
+ * caller is authenticated (or when session auth is disabled on this
+ * deployment, in which case nothing is required). Never throws.
+ */
+export async function ensureSession(
+  selectedWallet: AnyWallet,
+  account: string,
+): Promise<boolean> {
+  if (!account) return false;
+  if (loggedInWallet === account) return true;
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      const current = await fetch("/api/auth/session", {
+        credentials: "same-origin",
+      })
+        .then((r) => r.json())
+        .catch(() => null);
+
+      // Session auth not enabled on this deployment — nothing to do.
+      if (current && current.configured === false) {
+        loggedInWallet = account;
+        return true;
+      }
+      // Already authenticated as this wallet.
+      if (current && current.wallet === account) {
+        loggedInWallet = account;
+        return true;
+      }
+
+      const ts = Date.now();
+      const message = loginMessage(account, ts);
+      const signature = await signMessageWithWallet(selectedWallet, account, message);
+
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ wallet: account, signature, ts, message }),
+      });
+      if (!res.ok) return false;
+      loggedInWallet = account;
+      return true;
+    } catch {
+      return false;
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+/** Clear local login state + the server cookie on disconnect. */
+export async function endSession(): Promise<void> {
+  loggedInWallet = null;
+  try {
+    await fetch("/api/auth/logout", {
+      method: "POST",
+      credentials: "same-origin",
+    });
+  } catch {
+    /* best effort */
+  }
+}

--- a/app/lib/rateLimit.ts
+++ b/app/lib/rateLimit.ts
@@ -30,6 +30,7 @@ const LIMIT_TABLE: Record<string, { limit: number; windowMs: number }> = {
   unstake:       { limit: 10, windowMs: 60_000 },
   cancel_claim:  { limit: 30, windowMs: 60_000 },
   faucet_ip:     { limit: 10, windowMs: 60 * 60_000 },
+  auth_login:    { limit: 20, windowMs: 60_000 },
 };
 
 /** Returns the (limit, windowMs) for a named op. Falls back to a sane default. */

--- a/app/lib/require-auth.ts
+++ b/app/lib/require-auth.ts
@@ -20,6 +20,12 @@
  */
 import crypto from "node:crypto";
 import { verifyWalletSignature } from "./wallet-auth";
+import {
+  SESSION_COOKIE,
+  readCookie,
+  verifySession,
+  sessionConfigured,
+} from "./session";
 
 /**
  * Whether mutating-endpoint auth is enforced.
@@ -33,15 +39,52 @@ import { verifyWalletSignature } from "./wallet-auth";
  */
 let warnedAuthOff = false;
 export function authEnforced(): boolean {
-  const on = process.env.AUTH_ENFORCED === "true";
+  const flag = process.env.AUTH_ENFORCED;
+  if (flag === "true") return true; // explicit operator override
+  if (flag === "false") return false; // explicit opt-out
+  // Default: enforce automatically once a session secret is configured. This
+  // makes activation a single env var (SESSION_SECRET) and, crucially, means a
+  // missing secret can never leave endpoints "enforced" while the browser
+  // login flow can't actually authenticate — it stays open (with a warning)
+  // until session auth is wired.
+  const on = sessionConfigured();
   if (!on && process.env.NODE_ENV === "production" && !warnedAuthOff) {
     warnedAuthOff = true;
     console.error(
-      "[security] AUTH_ENFORCED is not 'true' in production: mutating endpoints " +
-        "accept unauthenticated requests. Enable wallet signing then set AUTH_ENFORCED=true.",
+      "[security] mutating-endpoint auth is OFF in production: set SESSION_SECRET " +
+        "(>=16 chars) to activate wallet-session auth, or AUTH_ENFORCED=true to force it.",
     );
   }
   return on;
+}
+
+/**
+ * CSRF guard for cookie-authenticated requests. A session cookie is sent on
+ * cross-site requests too, so a cookie-authenticated mutation must come from
+ * our own origin. Browsers attach `Origin` on cross-origin and on same-origin
+ * non-GET requests; we fall back to `Referer`, and fail closed if neither is
+ * present on a request that reached this guard.
+ */
+function isSameOrigin(req: Request): boolean {
+  const host = req.headers.get("host");
+  if (!host) return false;
+  const origin = req.headers.get("origin");
+  if (origin) {
+    try {
+      return new URL(origin).host === host;
+    } catch {
+      return false;
+    }
+  }
+  const referer = req.headers.get("referer");
+  if (referer) {
+    try {
+      return new URL(referer).host === host;
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }
 
 /**
@@ -151,7 +194,20 @@ export async function requireAuth(
       : { ok: false, status: 401, reason: "invalid api key" };
   }
 
-  // 2. Wallet-signature path.
+  // 1.5 Session-cookie path (browser). The user proved wallet control once
+  // via /api/auth/login; the httpOnly cookie now rides along automatically, so
+  // no per-request wallet popup is needed.
+  const sessionToken = readCookie(req, SESSION_COOKIE);
+  if (sessionToken) {
+    if (!isSameOrigin(req)) {
+      return { ok: false, status: 403, reason: "cross-origin request blocked" };
+    }
+    const sess = verifySession(sessionToken, Date.now());
+    if (sess) return { ok: true, mode: "signature", wallet: sess.wallet };
+    return { ok: false, status: 401, reason: "session expired — sign in again" };
+  }
+
+  // 2. Per-request wallet-signature path (SDK / bots that sign each request).
   const wallet = req.headers.get("x-wallet");
   const signature = req.headers.get("x-signature");
   const ts = req.headers.get("x-timestamp");
@@ -159,7 +215,8 @@ export async function requireAuth(
     return {
       ok: false,
       status: 401,
-      reason: "missing auth: x-api-key, or x-wallet + x-signature + x-timestamp",
+      reason:
+        "missing auth: session cookie, x-api-key, or x-wallet + x-signature + x-timestamp",
     };
   }
 

--- a/app/lib/session.ts
+++ b/app/lib/session.ts
@@ -1,0 +1,99 @@
+/**
+ * Wallet session tokens (C-091 activation).
+ *
+ * A user proves wallet control ONCE by signing a login message
+ * (`/api/auth/login`); the server then issues an HMAC-signed session token
+ * stored in an httpOnly, SameSite=Lax cookie. Every subsequent same-origin
+ * request carries the cookie automatically, so `requireAuth` can resolve the
+ * caller's wallet without a per-request wallet popup — and `requireWalletMatch`
+ * still binds that wallet to whatever the request mutates.
+ *
+ * The token is stateless: `v1.<walletB64url>.<expMs>.<hmac>`. No DB row, so
+ * there is nothing to look up and nothing to leak. Rotating `SESSION_SECRET`
+ * invalidates every outstanding session.
+ */
+import crypto from "node:crypto";
+
+/** Cookie name carrying the session token. */
+export const SESSION_COOKIE = "cvn_session";
+
+/** Default session lifetime: 24h. */
+export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+function secret(): string {
+  // Accept either a dedicated secret or the generic app secret.
+  return process.env.SESSION_SECRET || process.env.AUTH_SECRET || "";
+}
+
+/**
+ * Whether session auth is usable. Requires a sufficiently long secret so a
+ * weak/empty key can never silently produce forgeable tokens.
+ */
+export function sessionConfigured(): boolean {
+  return secret().length >= 16;
+}
+
+function hmac(payload: string): string {
+  return crypto.createHmac("sha256", secret()).update(payload).digest("base64url");
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+/** Mint a session token for `wallet`, valid until `now + ttlMs`. */
+export function issueSession(
+  wallet: string,
+  now: number,
+  ttlMs: number = SESSION_TTL_MS,
+): string {
+  const exp = now + ttlMs;
+  const payload = `${Buffer.from(wallet, "utf8").toString("base64url")}.${exp}`;
+  return `v1.${payload}.${hmac(payload)}`;
+}
+
+/**
+ * Verify a session token and return its wallet when valid (correct HMAC and
+ * not expired). Returns null on any tampering / expiry / misconfiguration.
+ */
+export function verifySession(
+  token: string | undefined | null,
+  now: number,
+): { wallet: string } | null {
+  if (!token || !sessionConfigured()) return null;
+  const parts = token.split(".");
+  if (parts.length !== 4 || parts[0] !== "v1") return null;
+  const payload = `${parts[1]}.${parts[2]}`;
+  if (!timingSafeEqual(parts[3], hmac(payload))) return null;
+  const exp = Number(parts[2]);
+  if (!Number.isFinite(exp) || now > exp) return null;
+  let wallet: string;
+  try {
+    wallet = Buffer.from(parts[1], "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+  if (!wallet) return null;
+  return { wallet };
+}
+
+/** The exact message a client signs to log in. Versioned + reproduced client-side. */
+export function loginMessage(wallet: string, ts: number | string): string {
+  return `covenant-login:v1\n${wallet}\n${ts}`;
+}
+
+/** Read a cookie value from a raw request's Cookie header. */
+export function readCookie(req: Request, name: string): string | null {
+  const header = req.headers.get("cookie");
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const k = part.slice(0, eq).trim();
+    if (k === name) return decodeURIComponent(part.slice(eq + 1).trim());
+  }
+  return null;
+}

--- a/app/lib/wallet-sign.ts
+++ b/app/lib/wallet-sign.ts
@@ -143,6 +143,53 @@ export async function signAndSendTransaction(
 }
 
 /**
+ * Sign an arbitrary UTF-8 message with the connected wallet and return the
+ * base58 Ed25519 signature. Used by the auth-session login flow
+ * (`/api/auth/login`) — the same wallet-standard feature path as transaction
+ * signing, with a `window.solana` fallback for injected providers.
+ */
+export async function signMessageWithWallet(
+  selectedWallet: AnyWallet,
+  account: string,
+  message: string,
+): Promise<string> {
+  const messageBytes = new TextEncoder().encode(message);
+
+  // --- Path 1: wallet-standard solana:signMessage ---
+  const feature = selectedWallet?.features?.["solana:signMessage"];
+  if (feature && typeof feature.signMessage === "function") {
+    const accountObj =
+      selectedWallet.accounts?.find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (a: any) => a.address === account,
+      ) ?? selectedWallet.accounts?.[0];
+    if (!accountObj) throw new Error("Wallet has no accounts to sign with");
+    const result = await feature.signMessage({
+      account: accountObj,
+      message: messageBytes,
+    });
+    const first = Array.isArray(result) ? result[0] : result;
+    const sigBytes = first?.signature ?? first?.signedMessage;
+    if (!sigBytes) throw new Error("Wallet returned no signature");
+    return toBase58(new Uint8Array(sigBytes));
+  }
+
+  // --- Path 2: window.solana (Phantom injected provider fallback) ---
+  if (typeof window !== "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const injected = (window as any).solana;
+    if (injected?.signMessage) {
+      const res = await injected.signMessage(messageBytes, "utf8");
+      const sigBytes = res?.signature ?? res;
+      if (!sigBytes) throw new Error("Wallet returned no signature");
+      return toBase58(new Uint8Array(sigBytes));
+    }
+  }
+
+  throw new Error("Connected wallet does not support message signing");
+}
+
+/**
  * Deserialize a base64-encoded transaction (as returned by
  * /api/escrow/build) into a Transaction object ready for signing.
  */


### PR DESCRIPTION
## Closes the IDOR class AND ships its activation

Two parts that together make every wallet-scoped mutation enforce the signer:

### 1. Server-side signer binding (14 routes)
`requireAuth(req, { rawBody })` + `requireWalletMatch(auth, actingWallet)` on every wallet-scoped mutating route (jobs create/accept/submit/cancel/dispute, disputes POST + resolve, claims buy/cancel, hosted-agents create + PATCH/DELETE, agents/register, reviews, referral/claim). Also fixes a latent bug where jobs POST/accept/submit/cancel + dispute called `requireAuth` without the raw body (empty body-hash would reject every real signature once enforced).

Already-secured routes untouched: profile/stake/unstake (wave 1), keys (`cvn:keys` scheme), admin/* (`guardAdmin`), helius/webhook (shared secret).

### 2. Wallet-session cookie auth (the activation)
- Sign in **once**: `SessionGate` signs `covenant-login:v1\n<wallet>\n<ts>` on connect → `/api/auth/login` verifies + sets an httpOnly, SameSite=Lax, Secure cookie (stateless HMAC token, 24h).
- Every same-origin fetch carries the cookie automatically (fetch default credentials) — **no changes to the ~47 components** that call `/api`.
- `requireAuth` resolves the wallet from the cookie; `requireWalletMatch` binds it. CSRF: cookie-auth mutations require same-origin Origin/Referer (fail-closed) on top of SameSite=Lax.
- `authEnforced()` enforces automatically once `SESSION_SECRET` (>=16 chars) is set (or `AUTH_ENFORCED=true`); a missing secret keeps endpoints open with a prod warning rather than enforcing an auth path the browser can't satisfy.

New: `lib/session.ts` (9/9 unit-checked HMAC token logic), `/api/auth/{login,logout,session}`, `SessionGate`, `lib/auth-login.ts`, `signMessageWithWallet`.

## Verification
- CI `build` ✅. `tsc` clean on all new/changed files. Session token round-trip / expiry / tamper / forged-exp / wrong-secret tests pass.

## Go-live (operator)
1. Set `SESSION_SECRET` (>=16 random chars) on a **preview** deploy.
2. Connect a real wallet → one signature prompt → confirm a mutation (e.g. edit profile) succeeds.
3. Confirm acting on a different wallet returns 403.
4. Merge, then set `SESSION_SECRET` in production. Bots keep using `x-api-key`.

While `SESSION_SECRET` is unset everything behaves exactly as today (no signature prompt, no enforcement).